### PR TITLE
[CRT-116] invalidate task file cache when changing file

### DIFF
--- a/frontend/src/api/collimator/hooks/tasks/useDeleteTask.ts
+++ b/frontend/src/api/collimator/hooks/tasks/useDeleteTask.ts
@@ -4,19 +4,19 @@ import { tasksControllerRemoveV0 } from "../../generated/endpoints/tasks/tasks";
 import { useRevalidateTaskList } from "./useRevalidateTaskList";
 import { useAuthenticationOptions } from "../authentication/useAuthenticationOptions";
 
-type DeleteUserType = (id: number) => Promise<DeletedTask>;
+type DeleteTaskType = (id: number) => Promise<DeletedTask>;
 
 const fetchAndTransform = (
   options: RequestInit,
   id: number,
-): ReturnType<DeleteUserType> =>
+): ReturnType<DeleteTaskType> =>
   tasksControllerRemoveV0(id, options).then(DeletedTask.fromDto);
 
-export const useDeleteTask = (): DeleteUserType => {
+export const useDeleteTask = (): DeleteTaskType => {
   const revalidateTaskList = useRevalidateTaskList();
   const authOptions = useAuthenticationOptions();
 
-  return useCallback<DeleteUserType>(
+  return useCallback<DeleteTaskType>(
     (id) =>
       fetchAndTransform(authOptions, id).then((result) => {
         // Invalidate the cache for the task list

--- a/frontend/src/api/collimator/hooks/tasks/useRevalidateTask.ts
+++ b/frontend/src/api/collimator/hooks/tasks/useRevalidateTask.ts
@@ -4,8 +4,8 @@ import { GetTaskReturnType } from "./useTask";
 import { getTasksControllerFindOneV0Url } from "../../generated/endpoints/tasks/tasks";
 
 export const useRevalidateTask = (): ((
-  userId: number,
-  newUser?: GetTaskReturnType,
+  taskId: number,
+  newTask?: GetTaskReturnType,
 ) => void) => {
   const { mutate } = useSWRConfig();
 

--- a/frontend/src/api/collimator/hooks/tasks/useRevalidateTaskFile.ts
+++ b/frontend/src/api/collimator/hooks/tasks/useRevalidateTaskFile.ts
@@ -1,0 +1,17 @@
+import { useSWRConfig } from "swr";
+import { useCallback } from "react";
+import { getTasksControllerDownloadOneV0Url } from "../../generated/endpoints/tasks/tasks";
+
+export const useRevalidateTaskFile = (): ((
+  taskId: number,
+  newFile?: Blob,
+) => void) => {
+  const { mutate } = useSWRConfig();
+
+  return useCallback(
+    (taskId: number, newFile?: Blob) => {
+      mutate(getTasksControllerDownloadOneV0Url(taskId), newFile);
+    },
+    [mutate],
+  );
+};

--- a/frontend/src/api/collimator/hooks/tasks/useUpdateTask.ts
+++ b/frontend/src/api/collimator/hooks/tasks/useUpdateTask.ts
@@ -3,11 +3,12 @@ import {
   tasksControllerUpdateFileV0,
   tasksControllerUpdateV0,
 } from "../../generated/endpoints/tasks/tasks";
+import { UpdateTaskDto, UpdateTaskFileDto } from "../../generated/models";
 import { ExistingTask } from "../../models/tasks/existing-task";
+import { useAuthenticationOptions } from "../authentication/useAuthenticationOptions";
 import { useRevalidateTaskList } from "./useRevalidateTaskList";
 import { useRevalidateTask } from "./useRevalidateTask";
-import { useAuthenticationOptions } from "../authentication/useAuthenticationOptions";
-import { UpdateTaskDto, UpdateTaskFileDto } from "../../generated/models";
+import { useRevalidateTaskFile } from "./useRevalidateTaskFile";
 
 type UpdateTaskType = (
   id: number,
@@ -56,10 +57,17 @@ const fetchAndTransformFile = (
 
 export const useUpdateTaskFile = (): UpdateTaskFileType => {
   const authOptions = useAuthenticationOptions();
+  const revalidateTaskFile = useRevalidateTaskFile();
 
   return useCallback(
     (id, updateTaskFileDto) =>
-      fetchAndTransformFile(authOptions, id, updateTaskFileDto),
-    [authOptions],
+      fetchAndTransformFile(authOptions, id, updateTaskFileDto).then(
+        (result) => {
+          revalidateTaskFile(id, updateTaskFileDto.file);
+
+          return result;
+        },
+      ),
+    [authOptions, revalidateTaskFile],
   );
 };


### PR DESCRIPTION
`useSWR` was keeping an old file in its cache, even when a new file was posted to the server.
This PR mutates that cache to ensure that the new file is used.