### PR TITLE
[CRT-383] Disable duplicate block option for students

### DIFF
--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -78,6 +78,7 @@ import {
   mapScratchEventTypeToStudentActionType,
 } from "../../utilities/scratch-student-activities/student-activity-tracking";
 import { handleBlockLifecycle } from "../../utilities/scratch-student-activities/scratch-block";
+import { overrideBlockDuplicateOption } from "../../utils/scratch-blocks-overrides";
 import ExtensionLibrary from "./ExtensionLibrary";
 import type { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import type { CrtContextValue } from "../../contexts/CrtContext";
@@ -285,6 +286,10 @@ class Blocks extends React.Component<Props, State> {
 
     this.workspace = this.ScratchBlocks.inject(this.blocks, workspaceConfig);
 
+    overrideBlockDuplicateOption({
+      canEditTask: this.props.canEditTask ?? true,
+    });
+
     // Register buttons under new callback keys for creating variables,
     // lists, and procedures from extensions.
     const toolboxWorkspace = this.getWorkspaceFlyout().getWorkspace();
@@ -408,6 +413,12 @@ class Blocks extends React.Component<Props, State> {
     // If any modals are open, call hideChaff to close z-indexed field editors
     if (this.props.anyModalVisible && !prevProps.anyModalVisible) {
       this.ScratchBlocks.hideChaff();
+    }
+
+    if (this.props.canEditTask !== prevProps.canEditTask) {
+      overrideBlockDuplicateOption({
+        canEditTask: this.props.canEditTask ?? true,
+      });
     }
 
     // Only rerender the toolbox when the blocks are visible and the xml is

--- a/apps/scratch/src/utils/scratch-blocks-overrides.ts
+++ b/apps/scratch/src/utils/scratch-blocks-overrides.ts
@@ -1,0 +1,35 @@
+import ScratchBlocks from "scratch-blocks";
+
+interface OverrideOptions {
+  canEditTask: boolean;
+}
+
+export const overrideBlockDuplicateOption = (options: OverrideOptions) => {
+  const { canEditTask } = options;
+
+  const originalDuplicateOption =
+    ScratchBlocks.ContextMenu.blockDuplicateOption;
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  ScratchBlocks.ContextMenu.blockDuplicateOption = function (
+    block: ScratchBlocks.Block,
+    event: Event,
+  ) {
+    const option = originalDuplicateOption.call(
+      ScratchBlocks.ContextMenu,
+      block,
+      event,
+    );
+
+    if (!canEditTask) {
+      option.enabled = false;
+    }
+
+    return option;
+  };
+
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+  return () => {
+    ScratchBlocks.ContextMenu.blockDuplicateOption = originalDuplicateOption;
+  };
+};

--- a/apps/scratch/src/utils/scratch-blocks-overrides.ts
+++ b/apps/scratch/src/utils/scratch-blocks-overrides.ts
@@ -32,9 +32,4 @@ export const overrideBlockDuplicateOption = (
 
     return option;
   };
-
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-  return () => {
-    ScratchBlocks.ContextMenu.blockDuplicateOption = originalDuplicateOption;
-  };
 };

--- a/apps/scratch/src/utils/scratch-blocks-overrides.ts
+++ b/apps/scratch/src/utils/scratch-blocks-overrides.ts
@@ -4,18 +4,23 @@ interface OverrideOptions {
   canEditTask: boolean;
 }
 
-export const overrideBlockDuplicateOption = (options: OverrideOptions) => {
+type OriginalDuplicateOptionType = ReturnType<
+  typeof ScratchBlocks.ContextMenu.blockDuplicateOption
+>;
+
+export const overrideBlockDuplicateOption = (
+  options: OverrideOptions,
+): void => {
   const { canEditTask } = options;
 
   const originalDuplicateOption =
     ScratchBlocks.ContextMenu.blockDuplicateOption;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
   ScratchBlocks.ContextMenu.blockDuplicateOption = function (
     block: ScratchBlocks.Block,
     event: Event,
-  ) {
-    const option = originalDuplicateOption.call(
+  ): OriginalDuplicateOptionType {
+    const option: OriginalDuplicateOptionType = originalDuplicateOption.call(
       ScratchBlocks.ContextMenu,
       block,
       event,

--- a/apps/scratch/types/scratch-blocks.d.ts
+++ b/apps/scratch/types/scratch-blocks.d.ts
@@ -37,6 +37,18 @@ declare namespace ScratchBlocksExtended {
     type: string;
   }
 
+  interface ContextMenuOption {
+    text: string;
+    enabled: boolean;
+    callback: () => void;
+  }
+
+  interface ContextMenuStatic {
+    blockDuplicateOption: (block: Block, event: Event) => ContextMenuOption;
+  }
+
+  const ContextMenu: ContextMenuStatic;
+
   class Flyout extends ScratchBlocks.Flyout {
     getWorkspace(): Workspace;
     setRecyclingEnabled(enabled: boolean);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents students from bypassing block usage limits by disabling the “Duplicate” option in the Scratch context menu when they can’t edit the task. Safely overrides `scratch-blocks` to meet CRT-383.

- **Bug Fixes**
  - Added `overrideBlockDuplicateOption` to patch `ScratchBlocks.ContextMenu.blockDuplicateOption` and disable it when `canEditTask` is false.
  - Applied the override on workspace init and when `canEditTask` changes; removed an unused cleanup path.
  - Strengthened local `scratch-blocks` typings for context menu and override types.

<sup>Written for commit 318afdc8377dffd9e412b0a8754d59b3d2791c79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

