### PR TITLE
[CRT-392] Task blocks should not be deletable

### DIFF
--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -229,11 +229,9 @@ test.describe("/solve", () => {
     );
     await expect(moveSteps).toHaveText((moveStepsAllowedCount - 1).toString());
 
-    await page.removeAllNonFrozenBlocks();
+    const addedBlock = page.blocksOfCurrentTarget.last();
+    await page.removeBlock(addedBlock);
 
-    await expect(page.blocksOfCurrentTarget).toHaveCount(
-      task.blocksOfMainTarget - task.frozenBlocksOfMainTarget,
-    );
     await expect(moveSteps).toHaveText(
       getExpectedBlockConfigButtonLabel(task.crtConfig, "motion_movesteps"),
     );
@@ -419,26 +417,6 @@ test.describe("/solve", () => {
     );
 
     await expect(taskPage.blocksOfCurrentTarget).toHaveCount(0);
-  });
-
-  test("removing initial blocks does not increase the limit", async ({
-    page: pwPage,
-  }) => {
-    const { page, task } = await TestTaskPage.load(pwPage);
-
-    const { moveSteps, turnRight } = page.enabledBlockConfigButtons;
-
-    await expect(page.taskBlocks.catActor.editableBlock).toHaveCount(1);
-
-    await page.removeBlock(page.taskBlocks.catActor.editableBlock);
-
-    await expect(page.taskBlocks.catActor.editableBlock).toHaveCount(0);
-    await expect(moveSteps).toHaveText(
-      getExpectedBlockConfigButtonLabel(task.crtConfig, "motion_movesteps"),
-    );
-    await expect(turnRight).toHaveText(
-      getExpectedBlockConfigButtonLabel(task.crtConfig, "motion_turnright"),
-    );
   });
 
   test("loads assertions extension if task contains assertion blocks", async ({

--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -206,7 +206,7 @@ test.describe("/solve", () => {
     );
   });
 
-  test.only("removing student-added blocks increases the limit", async ({
+  test("removing student-added blocks increases the limit", async ({
     page: pwPage,
   }) => {
     const { page, task } = await TestTaskPage.load(pwPage);
@@ -233,7 +233,7 @@ test.describe("/solve", () => {
     await page.removeBlock(addedBlock);
 
     await expect(page.blocksOfCurrentTarget).toHaveCount(
-      task.blocksOfMainTarget + 1,
+      task.blocksOfMainTarget,
     );
 
     await expect(moveSteps).toHaveText(

--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -206,7 +206,7 @@ test.describe("/solve", () => {
     );
   });
 
-  test("removing student-added blocks increases the limit", async ({
+  test.only("removing student-added blocks increases the limit", async ({
     page: pwPage,
   }) => {
     const { page, task } = await TestTaskPage.load(pwPage);
@@ -231,6 +231,10 @@ test.describe("/solve", () => {
 
     const addedBlock = page.blocksOfCurrentTarget.last();
     await page.removeBlock(addedBlock);
+
+    await expect(page.blocksOfCurrentTarget).toHaveCount(
+      task.blocksOfMainTarget + 1,
+    );
 
     await expect(moveSteps).toHaveText(
       getExpectedBlockConfigButtonLabel(task.crtConfig, "motion_movesteps"),

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -58,7 +58,6 @@ const findBlockInRuntime = (
 const shouldPreventBlockDeletion = (
   event: WorkspaceChangeEvent,
   vm: VMExtended,
-  workspace: ScratchBlocksExtended.Workspace,
   blockId: string,
 ): boolean => {
   if (event.type !== "delete") {
@@ -71,19 +70,18 @@ const shouldPreventBlockDeletion = (
   }
 
   if (block.isTaskBlock) {
-    workspace.undo(false);
     return true;
   }
 
   return false;
 };
 
-export const preventBlockActions = (
+export const shouldPreventBlocksActions = (
   event: WorkspaceChangeEvent,
   props: {
     canEditTask: boolean | undefined;
     vm: VMExtended;
-    workspace: ScratchBlocksExtended.Workspace;
+    workspace: ScratchBlocksExtended.Workspace | null;
     blockId: string | undefined;
   },
 ): boolean => {
@@ -93,11 +91,20 @@ export const preventBlockActions = (
     return false;
   }
 
+  if (!workspace) {
+    return false;
+  }
+
   if (shouldPreventBlockCreation(event, vm, workspace)) {
     return true;
   }
 
-  if (blockId && shouldPreventBlockDeletion(event, vm, workspace, blockId)) {
+  if (!blockId) {
+    return false;
+  }
+
+  if (shouldPreventBlockDeletion(event, vm, blockId)) {
+    workspace.undo(false);
     return true;
   }
 

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -8,20 +8,11 @@ export const ignoreEvent = (event: MouseEvent): void => {
   event.preventDefault();
 };
 
-export const shouldPreventBlockCreation = (
+const shouldPreventBlockCreation = (
   event: WorkspaceChangeEvent,
-  props: {
-    canEditTask: boolean | undefined;
-    vm: VMExtended;
-    workspace: ScratchBlocksExtended.Workspace;
-  },
+  vm: VMExtended,
+  workspace: ScratchBlocksExtended.Workspace,
 ): boolean => {
-  const { canEditTask, vm, workspace } = props;
-
-  if (canEditTask) {
-    return false;
-  }
-
   // when a block is dragged outside the workspace onto a sprite thumbnail, scratch-blocks fires an endDrag event with the serialized block XML
   // the vm uses this event to copy the blocks to the target sprite's workspace
   const isBlockDraggedToSprite =
@@ -48,6 +39,69 @@ export const shouldPreventBlockCreation = (
   }
 
   return true;
+};
+
+const findBlockInRuntime = (
+  vm: VMExtended,
+  blockId: string,
+): VMExtended.BlockExtended | undefined => {
+  for (const target of vm.runtime.targets) {
+    const block = target.blocks._blocks[blockId];
+    if (block) {
+      return block;
+    }
+  }
+
+  return undefined;
+};
+
+const shouldPreventBlockDeletion = (
+  event: WorkspaceChangeEvent,
+  vm: VMExtended,
+  workspace: ScratchBlocksExtended.Workspace,
+  blockId: string,
+): boolean => {
+  if (event.type !== "delete") {
+    return false;
+  }
+
+  const block = findBlockInRuntime(vm, blockId);
+  if (!block) {
+    return false;
+  }
+
+  if (block.isTaskBlock) {
+    workspace.undo(false);
+    return true;
+  }
+
+  return false;
+};
+
+export const preventBlockActions = (
+  event: WorkspaceChangeEvent,
+  props: {
+    canEditTask: boolean | undefined;
+    vm: VMExtended;
+    workspace: ScratchBlocksExtended.Workspace;
+    blockId: string | undefined;
+  },
+): boolean => {
+  const { canEditTask, vm, workspace, blockId } = props;
+
+  if (canEditTask) {
+    return false;
+  }
+
+  if (shouldPreventBlockCreation(event, vm, workspace)) {
+    return true;
+  }
+
+  if (blockId && shouldPreventBlockDeletion(event, vm, workspace, blockId)) {
+    return true;
+  }
+
+  return false;
 };
 
 /**

--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -79,7 +79,7 @@ import {
 } from "../../utilities/scratch-student-activities/student-activity-tracking";
 import { handleBlockLifecycle } from "../../utilities/scratch-student-activities/scratch-block";
 import { overrideBlockDuplicateOption } from "../../utils/scratch-blocks-overrides";
-import { shouldPreventBlockCreation } from "../../blocks/helpers";
+import { preventBlockActions } from "../../blocks/helpers";
 import ExtensionLibrary from "./ExtensionLibrary";
 import type { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import type { CrtContextValue } from "../../contexts/CrtContext";
@@ -1111,10 +1111,11 @@ class Blocks extends React.Component<Props, State> {
     }
 
     if (
-      shouldPreventBlockCreation(event, {
+      preventBlockActions(event, {
         canEditTask: this.props.canEditTask,
         vm: this.props.vm,
         workspace: this.getWorkspace(),
+        blockId: event.blockId,
       })
     ) {
       return;

--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -79,7 +79,7 @@ import {
 } from "../../utilities/scratch-student-activities/student-activity-tracking";
 import { handleBlockLifecycle } from "../../utilities/scratch-student-activities/scratch-block";
 import { overrideBlockDuplicateOption } from "../../utils/scratch-blocks-overrides";
-import { preventBlockActions } from "../../blocks/helpers";
+import { shouldPreventBlocksActions } from "../../blocks/helpers";
 import ExtensionLibrary from "./ExtensionLibrary";
 import type { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import type { CrtContextValue } from "../../contexts/CrtContext";
@@ -240,7 +240,6 @@ class Blocks extends React.Component<Props, State> {
       "setLocale",
       "requestToolboxUpdate",
       "onWorkspaceChange",
-      "blockListener",
       "reAttachWorkspaceListeners",
       "removeWorkspaceListeners",
       "onBlocksChange",
@@ -608,9 +607,6 @@ class Blocks extends React.Component<Props, State> {
 
     // Blockly does not provide a way to check if a listener is already attached.
     // We remove and reattach to avoid duplicates without having to track attachment state
-    workspace.removeChangeListener(this.blockListener);
-    workspace.addChangeListener(this.blockListener);
-
     workspace.removeChangeListener(this.onWorkspaceChange);
     workspace.addChangeListener(this.onWorkspaceChange);
   }
@@ -618,7 +614,6 @@ class Blocks extends React.Component<Props, State> {
   removeWorkspaceListeners() {
     const workspace = this.getWorkspace();
 
-    workspace.removeChangeListener(this.blockListener);
     workspace.removeChangeListener(this.onWorkspaceChange);
   }
 
@@ -1100,7 +1095,7 @@ class Blocks extends React.Component<Props, State> {
     return flyout;
   }
 
-  blockListener(event: WorkspaceChangeEvent) {
+  onWorkspaceChange(event: WorkspaceChangeEvent) {
     if (
       "element" in event &&
       (event.element === "stackclick" || event.element === "click")
@@ -1110,21 +1105,17 @@ class Blocks extends React.Component<Props, State> {
       return;
     }
 
-    if (
-      preventBlockActions(event, {
-        canEditTask: this.props.canEditTask,
-        vm: this.props.vm,
-        workspace: this.getWorkspace(),
-        blockId: event.blockId,
-      })
-    ) {
-      return;
+    const isBlocked = shouldPreventBlocksActions(event, {
+      canEditTask: this.props.canEditTask,
+      vm: this.props.vm,
+      workspace: this.getWorkspace(),
+      blockId: event.blockId,
+    });
+
+    if (!isBlocked) {
+      this.props.vm.blockListener(event);
     }
 
-    this.props.vm.blockListener(event);
-  }
-
-  onWorkspaceChange(event: WorkspaceChangeEvent) {
     if (!this.blocks) {
       // if the blocks are not yet mounted, ignore the event
       return;
@@ -1138,6 +1129,10 @@ class Blocks extends React.Component<Props, State> {
       filterNonNull,
       updateSingleBlockConfigButton,
     });
+
+    if (isBlocked) {
+      return;
+    }
 
     const eventAction = mapScratchEventTypeToStudentActionType(event.type);
 

--- a/backend/src/api/tasks/tasks.service.ts
+++ b/backend/src/api/tasks/tasks.service.ts
@@ -355,25 +355,17 @@ export class TasksService {
         ...updatedReferenceSolutions,
       ];
 
-      await Promise.all(
-        allReferenceSolutionInputs.map(({ file, fileHash }) =>
-          tx.solution.upsert({
-            where: {
-              taskId_hash: {
-                hash: fileHash,
-                taskId: id,
-              },
-            },
-            create: {
-              data: file.buffer,
-              mimeType: file.mimetype,
-              hash: fileHash,
-              taskId: id,
-            },
-            update: {},
-          }),
-        ),
-      );
+      if (allReferenceSolutionInputs.length > 0) {
+        await tx.solution.createMany({
+          data: allReferenceSolutionInputs.map(({ file, fileHash }) => ({
+            taskId: id,
+            hash: fileHash,
+            data: file.buffer,
+            mimeType: file.mimetype,
+          })),
+          skipDuplicates: true,
+        });
+      }
 
       // update the task
       return tx.task.update({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Makes initial task blocks immutable in solve mode and prevents creating/duplicating blocks when limits would be exceeded. Blocked actions are immediately undone and skipped by the VM and activity tracking; also batches saving reference solutions to reduce DB work.

- **Bug Fixes**
  - Prevent deleting task blocks in solve mode (undo on delete).
  - Block creation/duplication when limits are exceeded (including drag-to-sprite); update tests to assert immutable initial blocks and correct limit updates for student-added blocks.

- **Refactors**
  - Replace per-file solution upserts with createMany + skipDuplicates when saving reference solutions.

<sup>Written for commit c23c95297d5f8197944f5d36e85334e13b2676b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

