### PR TITLE
[CRT-390] Block limits are not persisted on reload

### DIFF
--- a/apps/scratch/src/hooks/useEmbeddedScratch.ts
+++ b/apps/scratch/src/hooks/useEmbeddedScratch.ts
@@ -25,6 +25,7 @@ import {
   CannotLoadProjectError,
   CannotSaveProjectError,
   MissingAssetsError,
+  MissingProjectJsonError,
   ScratchProjectError,
   ScratchProjectErrorCode,
   TimeoutExceededError,
@@ -349,6 +350,22 @@ export class EmbeddedScratchCallbacks {
 
     const zip = new JSZip();
     await zip.loadAsync(sb3Project);
+
+    const taskProjectFile = zip.file("project.json");
+
+    if (!taskProjectFile) {
+      throw new MissingProjectJsonError();
+    }
+
+    const taskProjectJson = await taskProjectFile.async("string");
+    const taskProject = JSON.parse(taskProjectJson);
+
+    // collect all block ids in the project before merging the initial task with the submission
+    const taskBlockIds = new Set<string>(
+      taskProject.targets.flatMap((target) => Object.keys(target.blocks ?? {})),
+    );
+
+    this.vm.taskBlockIds = taskBlockIds;
 
     zip.remove("project.json");
     zip.file("project.json", submission);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -35,7 +35,9 @@ export const patchScratchVm = (vm: VM): void => {
     // and mark them as initial blocks
     for (const target of vm.runtime.targets) {
       for (const block of Object.values(target.blocks._blocks)) {
-        block.isTaskBlock = true;
+        block.isTaskBlock = vm.taskBlockIds
+          ? vm.taskBlockIds.has(block.id)
+          : true;
       }
     }
   });

--- a/apps/scratch/types/scratch-vm.d.ts
+++ b/apps/scratch/types/scratch-vm.d.ts
@@ -300,6 +300,11 @@ declare class VMExtended extends VM {
   flyoutBlockListener: Function;
   monitorBlockListener: Function;
 
+    /**
+   * Set of block ids that are considered as task blocks.
+    */
+  taskBlockIds?: Set<string>;
+
   // add a custom config
   crtConfig?: import("../src/types/scratch-vm-custom").ScratchCrtConfig;
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Persist block limits on task reload by identifying task blocks from the original task `project.json` before merging the student submission (CRT-390).

- **Bug Fixes**
  - In `useEmbeddedScratch`, parse the task’s `project.json`, collect block IDs, and set `vm.taskBlockIds` before merging the submission.
  - Update VM patch to set `isTaskBlock` using `taskBlockIds` (fallback to true if not set) so limits persist after reload.
  - Throw `MissingProjectJsonError` when `project.json` is missing and add `taskBlockIds` to the `scratch-vm` types.

<sup>Written for commit 1a5b3b18ee76b32f557ae7f4039f917c5dc2b2ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

