### PR TITLE
[CRT-384] Resolve n+1 query

### DIFF
--- a/backend/src/api/tasks/tasks.service.ts
+++ b/backend/src/api/tasks/tasks.service.ts
@@ -355,25 +355,17 @@ export class TasksService {
         ...updatedReferenceSolutions,
       ];
 
-      await Promise.all(
-        allReferenceSolutionInputs.map(({ file, fileHash }) =>
-          tx.solution.upsert({
-            where: {
-              taskId_hash: {
-                hash: fileHash,
-                taskId: id,
-              },
-            },
-            create: {
-              data: file.buffer,
-              mimeType: file.mimetype,
-              hash: fileHash,
-              taskId: id,
-            },
-            update: {},
-          }),
-        ),
-      );
+      if (allReferenceSolutionInputs.length > 0) {
+        await tx.solution.createMany({
+          data: allReferenceSolutionInputs.map(({ file, fileHash }) => ({
+            taskId: id,
+            hash: fileHash,
+            data: file.buffer,
+            mimeType: file.mimetype,
+          })),
+          skipDuplicates: true,
+        });
+      }
 
       // update the task
       return tx.task.update({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Batch-inserts task solutions to remove the N+1 query and hardens the Scratch editor to block duplicate or over-limit blocks. Addresses CRT-384 by reducing DB roundtrips during solution saves.

- **Bug Fixes**
  - Backend: Replaced per-solution upserts with a single `createMany({ skipDuplicates: true })`, guarded to no-op when there are no solutions (CRT-384).
  - Scratch: Added guards to block actions to prevent creating blocks when limits are reached, block duplication via drag-to-sprite or paste, and undo deletion of immutable task blocks in solve mode; skipped activity tracking for blocked actions.
  - Typings/Tests: Added `isOutside` to `WorkspaceChangeEvent` and `getAllBlocks()` typing; updated tests and set `allowedBlocks.motion_movesteps` to 6.

<sup>Written for commit 1082a0606ab432aaf3d07683d9f0804fa49e7c63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

