### PR TITLE
[CRT-378-381-380] Scratch ast parser corner cases fix

### DIFF
--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -32,7 +32,19 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
     throw new Error(`Language version ${version} is not supported`);
   }
 
-  const codeCells = input.cells.filter((c) => c.cell_type === "code");
+  const getCellSource = (cell: { source: string | string[] }): string =>
+    Array.isArray(cell.source) ? cell.source.join("\n") : cell.source;
+
+  const hasExecutableCode = (source: string): boolean =>
+    source
+      .split("\n")
+      // check if there's any line that isn't empty or a comment
+      .map((line) => line.trim())
+      .some((line) => line && !line.startsWith("#"));
+
+  const codeCells = input.cells.filter(
+    (c) => c.cell_type === "code" && hasExecutableCode(getCellSource(c)),
+  );
 
   const conversionFunction = match(language)
     .returnType<(input: string, version?: string) => StatementWithFunctions>()
@@ -41,7 +53,7 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
 
   const convertedCodeCells = codeCells.map((cell) => {
     const { node, functionDeclarations } = conversionFunction(
-      Array.isArray(cell.source) ? cell.source.join("\n") : cell.source,
+      getCellSource(cell),
       version,
     );
 

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -40,7 +40,7 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
       .split("\n")
       // check if there's any line that isn't empty or a comment
       .map((line) => line.trim())
-      .some((line) => line && !line.startsWith("#"));
+      .some((line) => !!line && !line.startsWith("#"));
 
   const codeCells = input.cells.filter(
     (c) => c.cell_type === "code" && hasExecutableCode(getCellSource(c)),

--- a/backend/src/ast/converters/python/nodes/misc/file-input.ts
+++ b/backend/src/ast/converters/python/nodes/misc/file-input.ts
@@ -5,5 +5,12 @@ import { IPythonAstVisitor } from "../../python-ast-visitor-interface";
 export const convertFileInput = (
   visitor: IPythonAstVisitor,
   ctx: File_inputContext,
-): PythonVisitorReturnValue =>
-  visitor.getStatements(ctx.statements().statement_list());
+): PythonVisitorReturnValue => {
+  const statements = ctx.statements();
+
+  if (!statements) {
+    return visitor.getStatements([]);
+  }
+
+  return visitor.getStatements(statements.statement_list());
+};

--- a/backend/src/ast/converters/python/nodes/statements/simple-stmts.ts
+++ b/backend/src/ast/converters/python/nodes/statements/simple-stmts.ts
@@ -5,4 +5,12 @@ import { Simple_stmtsContext } from "../../generated/PythonParser";
 export const convertSimpleStmts = (
   visitor: IPythonAstVisitor,
   ctx: Simple_stmtsContext,
-): PythonVisitorReturnValue => visitor.getStatements(ctx.simple_stmt_list());
+): PythonVisitorReturnValue => {
+  const simpleStmtList = ctx.simple_stmt_list();
+
+  if (!simpleStmtList) {
+    return visitor.getStatements([]);
+  }
+
+  return visitor.getStatements(simpleStmtList);
+};

--- a/backend/src/ast/converters/python/nodes/statements/statements.ts
+++ b/backend/src/ast/converters/python/nodes/statements/statements.ts
@@ -5,4 +5,12 @@ import { IPythonAstVisitor } from "../../python-ast-visitor-interface";
 export const convertStatements = (
   visitor: IPythonAstVisitor,
   ctx: StatementsContext,
-): PythonVisitorReturnValue => visitor.getStatements(ctx.statement_list());
+): PythonVisitorReturnValue => {
+  const statementList = ctx.statement_list();
+
+  if (!statementList) {
+    return visitor.getStatements([]);
+  }
+
+  return visitor.getStatements(statementList);
+};

--- a/backend/src/ast/converters/scratch/__tests__/scratch-ast-converter.service.spec.ts
+++ b/backend/src/ast/converters/scratch/__tests__/scratch-ast-converter.service.spec.ts
@@ -308,40 +308,60 @@ describe("Scratch AST converter", () => {
   describe("Code blocks", () => {
     describe("Control Blocks", () => {
       it("can convert 'control_stop' blocks to general AST nodes", () => {
-        const ast = convertScratchToGeneralAst(
-          createScratchCodeInput([
-            {
-              opcode: "control_stop",
-              inputs: {},
-              fields: { STOP_OPTION: ["all"] },
-              shadow: false,
-              topLevel: false,
-              mutation: {
-                tagName: "mutation",
-                children: [],
-                hasnext: "false",
-              },
-            },
-          ]),
-        );
-
-        expect(ast).toEqual(
-          createScratchCodeOutput([
-            {
-              nodeType: AstNodeType.statement,
-              statementType: StatementNodeType.functionCall,
-              name: "control_stop",
-              arguments: [
-                {
-                  nodeType: AstNodeType.expression,
-                  expressionType: ExpressionNodeType.literal,
-                  type: "string",
-                  value: "all",
+        const asts = [
+          convertScratchToGeneralAst(
+            createScratchCodeInput([
+              {
+                opcode: "control_stop",
+                inputs: {},
+                fields: { STOP_OPTION: ["all"] },
+                shadow: false,
+                topLevel: false,
+                mutation: {
+                  tagName: "mutation",
+                  children: [],
+                  hasnext: "false",
                 },
-              ],
-            },
-          ]),
-        );
+              },
+            ]),
+          ),
+          convertScratchToGeneralAst(
+            createScratchCodeInput([
+              {
+                opcode: "control_stop",
+                inputs: {},
+                fields: { STOP_OPTION: ["all", null] },
+                shadow: false,
+                topLevel: false,
+                mutation: {
+                  tagName: "mutation",
+                  children: [],
+                  hasnext: "false",
+                },
+              },
+            ]),
+          ),
+        ];
+
+        asts.forEach((ast) => {
+          expect(ast).toEqual(
+            createScratchCodeOutput([
+              {
+                nodeType: AstNodeType.statement,
+                statementType: StatementNodeType.functionCall,
+                name: "control_stop",
+                arguments: [
+                  {
+                    nodeType: AstNodeType.expression,
+                    expressionType: ExpressionNodeType.literal,
+                    type: "string",
+                    value: "all",
+                  },
+                ],
+              },
+            ]),
+          );
+        });
       });
 
       it("can convert 'control_delete_this_clone' blocks to general AST nodes", () => {

--- a/backend/src/ast/converters/scratch/__tests__/scratch-ast-converter.service.spec.ts
+++ b/backend/src/ast/converters/scratch/__tests__/scratch-ast-converter.service.spec.ts
@@ -313,7 +313,7 @@ describe("Scratch AST converter", () => {
             {
               opcode: "control_stop",
               inputs: {},
-              fields: { STOP_OPTION: ["all", null] },
+              fields: { STOP_OPTION: ["all"] },
               shadow: false,
               topLevel: false,
               mutation: {
@@ -3650,6 +3650,29 @@ describe("Scratch AST converter", () => {
                 value: "q",
               },
             ],
+          }),
+        );
+      });
+
+      it("can convert 'sensing_keyoptions' blocks with single-element KEY_OPTION to general AST nodes", () => {
+        const ast = convertScratchToGeneralAst(
+          createScratchExpressionInput([
+            {
+              opcode: "sensing_keyoptions",
+              inputs: {},
+              fields: { KEY_OPTION: ["space"] },
+              shadow: false,
+              topLevel: false,
+            },
+          ]),
+        );
+
+        expect(ast).toEqual(
+          createScratchExpressionOutput({
+            nodeType: AstNodeType.expression,
+            expressionType: ExpressionNodeType.literal,
+            type: "string",
+            value: "space",
           }),
         );
       });

--- a/backend/src/ast/converters/scratch/helpers.ts
+++ b/backend/src/ast/converters/scratch/helpers.ts
@@ -234,7 +234,7 @@ export const convertChildWithReferenceId = <T extends TreeNode, ReturnType>(
 ): ReturnType => {
   const reference = getReference(block);
   if (!reference) {
-    if (fallbackValue) {
+    if (fallbackValue !== undefined) {
       return fallbackValue;
     }
 
@@ -245,7 +245,7 @@ export const convertChildWithReferenceId = <T extends TreeNode, ReturnType>(
   const child = block.__children.find((b) => b.__id === id);
 
   if (!child) {
-    if (fallbackValue) {
+    if (fallbackValue !== undefined) {
       return fallbackValue;
     }
 

--- a/backend/src/ast/converters/scratch/helpers.ts
+++ b/backend/src/ast/converters/scratch/helpers.ts
@@ -216,6 +216,7 @@ const getParametersFromFields = (fields: Block["fields"]): ExpressionNode[] => {
           .with([P.string, P.string], (value) =>
             createVariableExpressionBlock(value[0]),
           )
+          .with([P.string], (value) => createLiteralNode("string", value[0]))
           .otherwise(() => {
             throw new Error(
               `Unexpected values for name '${parameterName}': '${JSON.stringify(value)}'`,

--- a/backend/src/ast/converters/solution-conversion-worker.piscina.ts
+++ b/backend/src/ast/converters/solution-conversion-worker.piscina.ts
@@ -1,4 +1,5 @@
 import { Solution, TaskType } from "@prisma/client";
+import * as Sentry from "@sentry/node";
 import { GeneralAst } from "../types/general-ast";
 import { convertScratchToGeneralAst } from "./scratch";
 import { convertJupyterToGeneralAst } from "./jupyter";
@@ -10,29 +11,38 @@ const SolutionConversionWorker = ({
   taskType: TaskType;
   solution: Solution;
 }): GeneralAst => {
-  let ast: GeneralAst;
+  return Sentry.withScope((scope) => {
+    const hashHexVal = Buffer.from(solution.hash).toString("hex");
 
-  if (
-    taskType === TaskType.SCRATCH &&
-    solution.mimeType === "application/json"
-  ) {
-    ast = convertScratchToGeneralAst(
-      JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
-    );
-  } else if (
-    taskType === TaskType.JUPYTER &&
-    solution.mimeType === "application/json"
-  ) {
-    ast = convertJupyterToGeneralAst(
-      JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
-    );
-  } else {
-    throw new Error(
-      `Unsupported (task, solution mime type) tuple '(${taskType}, ${solution.mimeType})'`,
-    );
-  }
+    scope.setTag("solution.taskId", solution.taskId.toString());
+    scope.setTag("solution.hash", hashHexVal);
+    scope.setTag("solution.taskType", taskType);
+    scope.setTag("solution.mimeType", solution.mimeType);
 
-  return ast;
+    let ast: GeneralAst;
+
+    if (
+      taskType === TaskType.SCRATCH &&
+      solution.mimeType === "application/json"
+    ) {
+      ast = convertScratchToGeneralAst(
+        JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
+      );
+    } else if (
+      taskType === TaskType.JUPYTER &&
+      solution.mimeType === "application/json"
+    ) {
+      ast = convertJupyterToGeneralAst(
+        JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
+      );
+    } else {
+      throw new Error(
+        `Unsupported (task, solution mime type) tuple '(${taskType}, ${solution.mimeType})'`,
+      );
+    }
+
+    return ast;
+  });
 };
 
 export default SolutionConversionWorker;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix Scratch AST corner cases and harden Python/Jupyter conversion. Skip blank/comment-only Jupyter code cells and tag Sentry events with solution context (CRT-378, CRT-380, CRT-393).

- **Bug Fixes**
  - Parse single-element `KEY_OPTION` and `STOP_OPTION` fields; add tests.
  - Honor falsy `fallbackValue`; explicitly cast line truthiness; return empty lists for missing Python `statements`/`simple_stmts`/`file_input`.

<sup>Written for commit db6186ce39c037861177b016dd8b3a9b6ded59d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

