### PR TITLE
[CRT-361] Anonymization toggle for public sessions

### DIFF
--- a/frontend/src/components/header/Header.tsx
+++ b/frontend/src/components/header/Header.tsx
@@ -28,12 +28,14 @@ const Header = ({
   description,
   children,
   hideSignIn = false,
+  showAnonymizationToggle = false,
 }: {
   title: MessageDescriptor;
   titleParameters?: Record<string, PrimitiveType>;
   description?: MessageDescriptor;
   children?: React.ReactNode;
   hideSignIn?: boolean;
+  showAnonymizationToggle?: boolean;
 }) => {
   return (
     <>
@@ -47,7 +49,12 @@ const Header = ({
         <Container>
           <HeaderInner>
             <HeaderLogo />
-            <HeaderMenu hideSignIn={hideSignIn}>{children}</HeaderMenu>
+            <HeaderMenu
+              hideSignIn={hideSignIn}
+              showAnonymizationToggle={showAnonymizationToggle}
+            >
+              {children}
+            </HeaderMenu>
           </HeaderInner>
         </Container>
       </StyledHeader>

--- a/frontend/src/components/header/HeaderMenu.tsx
+++ b/frontend/src/components/header/HeaderMenu.tsx
@@ -6,6 +6,7 @@ import { chakra } from "@chakra-ui/react";
 import { useIsAuthenticated } from "@/hooks/useIsAuthenticated";
 import AvatarMenu from "../Avatar";
 import LanguageChooser from "../LanguageChooser";
+import AnonymizationToggle from "../AnonymizationToggle";
 
 const Menu = chakra("menu", {
   base: {
@@ -21,15 +22,22 @@ const Menu = chakra("menu", {
 const HeaderMenu = ({
   children,
   hideSignIn = false,
+  showAnonymizationToggle = false,
 }: {
   children?: React.ReactNode;
   hideSignIn?: boolean;
+  showAnonymizationToggle?: boolean;
 }) => {
   const isAuthenticated = useIsAuthenticated();
 
   return (
     <Menu>
       {children ?? null}
+      {showAnonymizationToggle && (
+        <li>
+          <AnonymizationToggle />
+        </li>
+      )}
       <li>
         <LanguageChooser />
       </li>

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/progress/index.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/progress/index.tsx
@@ -12,7 +12,7 @@ import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import MultiSwrContent from "@/components/MultiSwrContent";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import PageHeading from "@/components/PageHeading";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import SessionActions from "@/components/session/SessionActions";
 import { ShareModal } from "@/components/modals/ShareModal";
 import { SessionShareMessages } from "@/i18n/session-share-messages";
@@ -87,9 +87,8 @@ const SessionProgress = () => {
         titleParameters={{
           title: session?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/analysis.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/analysis.tsx
@@ -13,7 +13,7 @@ import Analyzer from "@/components/dashboard/Analyzer";
 import { useTask } from "@/api/collimator/hooks/tasks/useTask";
 import PageHeading from "@/components/PageHeading";
 import TaskInstanceNavigation from "@/components/task-instance/TaskInstanceNavigation";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
 
@@ -57,9 +57,8 @@ const TaskInstanceAnalysis = () => {
         titleParameters={{
           title: task?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/dissimilar-pairs.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/dissimilar-pairs.tsx
@@ -13,7 +13,7 @@ import DissimilarPairs from "@/components/dashboard/DissimilarPairs";
 import { useTask } from "@/api/collimator/hooks/tasks/useTask";
 import PageHeading from "@/components/PageHeading";
 import TaskInstanceNavigation from "@/components/task-instance/TaskInstanceNavigation";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
 
@@ -57,9 +57,8 @@ const DissimilarAnalysisPairs = () => {
         titleParameters={{
           title: task?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/dissimilar-solutions.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/dissimilar-solutions.tsx
@@ -13,7 +13,7 @@ import DissimilarityAnalysis from "@/components/dashboard/DissimilarityAnalysis"
 import { useTask } from "@/api/collimator/hooks/tasks/useTask";
 import PageHeading from "@/components/PageHeading";
 import TaskInstanceNavigation from "@/components/task-instance/TaskInstanceNavigation";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import PageFooter from "@/components/PageFooter";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 
@@ -57,9 +57,8 @@ const DissimilarSolutions = () => {
         titleParameters={{
           title: task?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/showcase/index.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/showcase/index.tsx
@@ -12,7 +12,7 @@ import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession
 import { useTask } from "@/api/collimator/hooks/tasks/useTask";
 import PageHeading from "@/components/PageHeading";
 import TaskInstanceNavigation from "@/components/task-instance/TaskInstanceNavigation";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import Showcase from "@/components/dashboard/Showcase";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
@@ -57,9 +57,8 @@ const TaskInstanceShowcase = () => {
         titleParameters={{
           title: task?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/showcase/present.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/showcase/present.tsx
@@ -8,7 +8,7 @@ import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import MultiSwrContent from "@/components/MultiSwrContent";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import { useTask } from "@/api/collimator/hooks/tasks/useTask";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import ShowcasePresentation from "@/components/dashboard/ShowcasePresentation";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
@@ -66,9 +66,8 @@ const TaskInstanceShowcasePresent = () => {
         titleParameters={{
           title: task?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Button variant="subtle" onClick={() => router.back()}>
           <HStack>

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/student/[studentId]/index.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/student/[studentId]/index.tsx
@@ -16,7 +16,7 @@ import PageHeading from "@/components/PageHeading";
 import TaskInstanceNavigation from "@/components/task-instance/TaskInstanceNavigation";
 import { useAllSessionTaskSolutions } from "@/api/collimator/hooks/solutions/useAllSessionTaskSolutions";
 import { ExistingStudentSolution } from "@/api/collimator/models/solutions/existing-student-solutions";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
 
@@ -81,9 +81,8 @@ const StudentTaskInstance = () => {
         titleParameters={{
           name: name ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/student/index.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/student/index.tsx
@@ -10,7 +10,7 @@ import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import MultiSwrContent from "@/components/MultiSwrContent";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import PageHeading from "@/components/PageHeading";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import { useTask } from "@/api/collimator/hooks/tasks/useTask";
 import TaskInstanceNavigation from "@/components/task-instance/TaskInstanceNavigation";
 import TaskInstanceProgressList from "@/components/task-instance/TaskInstanceProgressList";
@@ -57,9 +57,8 @@ const TaskInstanceProgress = () => {
         titleParameters={{
           title: task?.title ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={session?.isAnonymous === false}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />

--- a/frontend/src/pages/class/[classId]/students.tsx
+++ b/frontend/src/pages/class/[classId]/students.tsx
@@ -9,7 +9,7 @@ import SwrContent from "@/components/SwrContent";
 import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import StudentList from "@/components/student/StudentList";
 import PageHeading from "@/components/PageHeading";
-import AnonymizationToggle from "@/components/AnonymizationToggle";
+
 import ClassActions from "@/components/class/ClassActions";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
@@ -36,9 +36,8 @@ const ClassUserList = () => {
         titleParameters={{
           name: klass?.name ?? "",
         }}
-      >
-        <AnonymizationToggle />
-      </Header>
+        showAnonymizationToggle={true}
+      />
       <Container>
         <Breadcrumbs>
           <CrtNavigation breadcrumb klass={klass} />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide the anonymization switch in anonymous lessons by moving it into the header menu and gating it behind a prop. Satisfies CRT-361 by showing the switch only for non-anonymous sessions.

- **Bug Fixes**
  - Added `showAnonymizationToggle` prop to `Header` and `HeaderMenu`; conditionally render `AnonymizationToggle` inside `HeaderMenu`.
  - Updated session/task pages to pass `showAnonymizationToggle={session?.isAnonymous === false}` and removed inline toggles.
  - Kept the toggle visible on the class students page by passing `true`.

<sup>Written for commit 7051fd9b5fb5daabda0bc07ee9f5f2f040a3e7dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

