### PR TITLE
[CRT-352] Disable pagination when no pages

### DIFF
--- a/frontend/src/components/dashboard/ShowcasePresentation.tsx
+++ b/frontend/src/components/dashboard/ShowcasePresentation.tsx
@@ -50,7 +50,7 @@ const ShowcasePresentationInternal = ({
     slideCount: selectedAnalyses.length,
     allowMouseDrag: true,
     slidesPerPage: 1,
-    loop: true,
+    loop: false,
   });
 
   const selectedSolution = useMemo(
@@ -66,7 +66,10 @@ const ShowcasePresentationInternal = ({
         justifyContent="space-between"
         gap="md"
       >
-        <Button onClick={() => carousel.scrollPrev()}>
+        <Button
+          onClick={() => carousel.scrollPrev()}
+          disabled={carousel.page === 0}
+        >
           <HStack>
             <Icon>
               <LuArrowLeft />
@@ -100,7 +103,10 @@ const ShowcasePresentationInternal = ({
             </Carousel.ItemGroup>
           </Carousel.RootProvider>
         </Box>
-        <Button onClick={() => carousel.scrollNext()}>
+        <Button
+          onClick={() => carousel.scrollNext()}
+          disabled={carousel.page === selectedAnalyses.length - 1}
+        >
           <HStack>
             <FormattedMessage
               id="ShowcasePresentation.next"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CRT-352: The showcase Next/Previous buttons now disable at the ends. The carousel no longer loops, preventing navigation past available references.

- **Bug Fixes**
  - Set carousel `loop` to false to stop wrap-around.
  - Disable Prev on the first page and Next on the last page using `carousel.page` and `selectedAnalyses.length`.

<sup>Written for commit fac1570eef99e566f257ebd9f0d5c6fd38c15f28. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

