### PR TITLE
[CRT-395] Removing tasks from lessons do not remove them from lesson instances

### DIFF
--- a/backend/src/api/sessions/sessions.service.ts
+++ b/backend/src/api/sessions/sessions.service.ts
@@ -11,6 +11,7 @@ import { TaskProgress } from "./task-progress";
 
 const compactInclude = {
   tasks: {
+    where: { deletedAt: null },
     orderBy: { index: "asc" as Prisma.SortOrder },
     select: {
       taskId: true,
@@ -22,6 +23,7 @@ const compactInclude = {
 
 const fullInclude = {
   tasks: {
+    where: { deletedAt: null },
     orderBy: { index: "asc" as Prisma.SortOrder },
     select: {
       index: true,
@@ -151,7 +153,7 @@ export class SessionsService {
               taskId,
             },
           },
-          update: { index },
+          update: { index, deletedAt: null },
           create: {
             taskId,
             index,
@@ -271,6 +273,7 @@ export class SessionsService {
           : { id: sourceSessionId, deletedAt: null },
         include: {
           tasks: {
+            where: { deletedAt: null },
             orderBy: { index: "asc" },
             select: {
               taskId: true,

--- a/e2e/tests/sessions/session-management.spec.ts
+++ b/e2e/tests/sessions/session-management.spec.ts
@@ -98,6 +98,30 @@ test.describe("session management", () => {
           updatedSessionName,
         );
       });
+
+      test("removed task is not surfaced when the session is re-fetched", async ({
+        page: pwPage,
+      }) => {
+        const form = await SessionFormPageModel.create(pwPage);
+        const before = await form.getSelectedTaskIds();
+        expect(before.length).toBeGreaterThan(0);
+
+        const removedTaskId = before[before.length - 1];
+        await form.removeTask(removedTaskId);
+        expect((await form.getSelectedTaskIds()).length).toBe(
+          before.length - 1,
+        );
+
+        await form.submitButton.click();
+
+        await pwPage.reload();
+
+        const refreshedForm = await SessionFormPageModel.create(pwPage);
+        const after = await refreshedForm.getSelectedTaskIds();
+
+        expect(after).not.toContain(removedTaskId);
+        expect(after.length).toBe(before.length - 1);
+      });
     });
 
     test.describe("/class/{id}/session/{id}/progress", () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CRT-395 by excluding soft‑deleted tasks from session responses and clearing the soft‑delete flag when a task is re‑added. Removed tasks no longer resurface in lesson instances.

- **Bug Fixes**
  - Filter session tasks with `where: { deletedAt: null }` in `compactInclude`, `fullInclude`, and source session queries.
  - On upsert, set `update: { index, deletedAt: null }` to undelete when re-adding a task.
  - Added an e2e test to ensure a removed task does not return after reloading the session form.

<sup>Written for commit d8367020f37b4969ad02bdfd73b6c57d8f0ced81. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

