### PR TITLE
[CRT-397] Changing locale while having unsaved changes breaks notebook

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
@@ -24,7 +24,7 @@ export class TaskAutoSaver {
   public static readonly debounceInterval = 30000;
 
   constructor(
-    notebookTracker: INotebookTracker,
+    private readonly notebookTracker: INotebookTracker,
     private readonly sendRequest: AppCrtIframeApi["sendRequest"],
   ) {
     notebookTracker.widgetAdded.connect((_sender, panel: NotebookPanel) => {
@@ -41,6 +41,16 @@ export class TaskAutoSaver {
     sendRequest: AppCrtIframeApi["sendRequest"],
   ): TaskAutoSaver {
     return new TaskAutoSaver(notebookTracker, sendRequest);
+  }
+
+  public async saveAllNotebooks(): Promise<void> {
+    const saves: Promise<void>[] = [];
+
+    this.notebookTracker.forEach((panel) => {
+      saves.push(this.saveNotebook(panel, panel.context.model));
+    });
+
+    await Promise.all(saves);
   }
 
   private registerNotebook(panel: NotebookPanel, model: INotebookModel): void {

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -100,6 +100,8 @@ export class EmbeddedPythonCallbacks {
   public static readonly gradingSrcLocation: string = "/grading_src";
   public static readonly pluginId = "@jupyterlab/translation-extension:plugin";
 
+  private readonly beforeReloadCallbacks: Array<() => Promise<void>> = [];
+
   constructor(
     private readonly mode: Mode,
     private readonly app: JupyterFrontEnd,
@@ -107,6 +109,10 @@ export class EmbeddedPythonCallbacks {
     private readonly fileBrowser: FileBrowser,
     private readonly settingRegistry: ISettingRegistry,
   ) {}
+
+  addBeforeReloadCallback(callback: () => Promise<void>): void {
+    this.beforeReloadCallbacks.push(callback);
+  }
 
   async getHeight(): Promise<number> {
     return document.body.scrollHeight || DEFAULT_SCROLL_HEIGHT;
@@ -321,12 +327,45 @@ export class EmbeddedPythonCallbacks {
 
     await settings.set("locale", toJupyterLocale(locale));
 
+    for (const callback of this.beforeReloadCallbacks) {
+      try {
+        await callback();
+      } catch (error) {
+        console.error(`${logModule} before-reload hook failed:`, error);
+      }
+    }
+
+    await this.saveAllDocuments();
+
     // we force-navigate to the current URL with the desired mode param
     // instead of using window.location.reload(), because the jupyter loaded
     // with a different mode that gets reapplied on a plain reload, which overrides our custom mode.
     const url = new URL(window.location.href);
     url.searchParams.set("mode", Mode[this.mode]);
     window.location.href = url.toString();
+  }
+
+  private async saveAllDocuments(): Promise<void> {
+    const widgets = Array.from(this.app.shell.widgets("main"));
+
+    await Promise.all(
+      widgets.map(async (widget) => {
+        const context = this.documentManager.contextForWidget(widget);
+
+        if (!context?.model.dirty) {
+          return;
+        }
+
+        try {
+          await context.save();
+        } catch (error) {
+          console.error(
+            `${logModule} Failed to save ${context.path} before locale change:`,
+            error,
+          );
+        }
+      }),
+    );
   }
 
   private async closeAllDocuments(): Promise<void> {

--- a/apps/jupyter/extensions/notebook-runner/src/index.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/index.ts
@@ -72,15 +72,14 @@ const plugin: JupyterFrontEndPlugin<void> = {
 
     const mode = getModeFromUrl();
 
-    const platform = setupIframeApi(
-      new EmbeddedPythonCallbacks(
-        mode,
-        app,
-        documentManager,
-        fileBrowser,
-        settingRegistry,
-      ),
+    const callbacks = new EmbeddedPythonCallbacks(
+      mode,
+      app,
+      documentManager,
+      fileBrowser,
+      settingRegistry,
     );
+    const platform = setupIframeApi(callbacks);
 
     try {
       const translationSettings = await settingRegistry.load(
@@ -104,10 +103,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
     }
 
     if (mode === Mode.solve) {
-      TaskAutoSaver.trackNotebook(
+      const taskAutoSaver = TaskAutoSaver.trackNotebook(
         notebookTracker,
         platform.sendRequest.bind(platform),
       );
+
+      callbacks.addBeforeReloadCallback(() => taskAutoSaver.saveAllNotebooks());
     }
 
     simplifyUserInterface(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Save all dirty notebooks before locale changes to prevent data loss and broken notebook state. Fixes CRT-397 where reloading with unsaved changes caused “could not find content” errors.

- **Bug Fixes**
  - Added a before-reload hook in the iframe API to save all open, dirty documents, then navigate to the same URL with the correct mode.
  - Implemented `TaskAutoSaver.saveAllNotebooks()` and registered it as a before-reload callback in solve mode.
  - Minor hardening: consistent use of `notebookTracker`, and error-tolerant saves with logging.

<sup>Written for commit 3c3329e2a61d130d5b7e14326a1d85c2c0fc3583. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/565?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

