### PR TITLE
[CRT-402] Prevent teacher notebook drag/drop

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -4,7 +4,7 @@ import { IPropertyInspectorProvider } from "@jupyterlab/property-inspector";
 import { FileBrowser } from "@jupyterlab/filebrowser";
 import { Contents } from "@jupyterlab/services";
 import { IDocumentManager } from "@jupyterlab/docmanager";
-import { DocumentRegistry } from "@jupyterlab/docregistry";
+import { DocumentRegistry, IDocumentWidget } from "@jupyterlab/docregistry";
 import { Kernel } from "@jupyterlab/services";
 import { KnownWidget } from "./known-widget";
 import { Mode } from "./mode";
@@ -157,26 +157,29 @@ const hideGradingFolders = (fileBrowser: FileBrowser): void => {
 const redirectTaskFileOpensToStudentVersion = (
   documentManager: IDocumentManager,
 ): void => {
+  const redirect = (path: string): string =>
+    path === "/task.ipynb" || path === "task.ipynb"
+      ? "/student/task.ipynb"
+      : path;
+
   const originalOpenOrReveal =
     documentManager.openOrReveal.bind(documentManager);
-
   documentManager.openOrReveal = (
     path: string,
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions,
-  ): ReturnType<IDocumentManager["openOrReveal"]> => {
-    if (path === "/task.ipynb" || path === "task.ipynb") {
-      return originalOpenOrReveal(
-        "/student/task.ipynb",
-        widgetName,
-        kernel,
-        options,
-      );
-    }
+  ): ReturnType<IDocumentManager["openOrReveal"]> =>
+    originalOpenOrReveal(redirect(path), widgetName, kernel, options);
 
-    return originalOpenOrReveal(path, widgetName, kernel, options);
-  };
+  const originalOpen = documentManager.open.bind(documentManager);
+  documentManager.open = (
+    path,
+    widgetName,
+    kernel,
+    options,
+  ): IDocumentWidget | undefined =>
+    originalOpen(redirect(path), widgetName, kernel, options);
 };
 
 class HiddenFolderError extends Error {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Redirects any open of the teacher notebook `task.ipynb` to `/student/task.ipynb`, blocking drag/drop or other opens of the teacher copy. Prevents students from accessing solutions and aligns with CRT-402.

- **Bug Fixes**
  - Intercepts both `documentManager.openOrReveal` and `documentManager.open` to rewrite `task.ipynb` → `/student/task.ipynb`.
  - Handles drag/drop, file browser open, and "Open With..." flows.
  - No change for other files.

<sup>Written for commit 0b2584a6b261215b51767515c955e538acc3c578. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/571?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

