### PR TITLE
Correct task template assertions

### DIFF
--- a/apps/jupyter/files/task.ipynb
+++ b/apps/jupyter/files/task.ipynb
@@ -96,7 +96,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "square(1) == 1"
+        "assert square(1) == 1"
       ]
     },
     {
@@ -105,7 +105,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "square(0) == 0"
+        "assert square(0) == 0"
       ]
     },
     {
@@ -115,7 +115,7 @@
       "outputs": [],
       "source": [
         "# HIDDEN\n",
-        "square(2.5) == 6.25"
+        "assert square(2.5) == 6.25"
       ]
     },
     {
@@ -305,7 +305,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "len(data[\"flavor\"].unique()) == 4"
+        "assert len(data[\"flavor\"].unique()) == 4"
       ]
     },
     {
@@ -343,7 +343,7 @@
       "outputs": [],
       "source": [
         "# HIDDEN\n",
-        "bool(np.isclose(price_by_flavor[\"chocolate\"], 3.33333333))"
+        "assert bool(np.isclose(price_by_flavor[\"chocolate\"], 3.33333333))"
       ]
     },
     {
@@ -353,7 +353,7 @@
       "outputs": [],
       "source": [
         "# HIDDEN\n",
-        "bool(np.isclose(price_by_flavor[\"mint\"], 4.5))"
+        "assert bool(np.isclose(price_by_flavor[\"mint\"], 4.5))"
       ]
     },
     {
@@ -363,7 +363,7 @@
       "outputs": [],
       "source": [
         "# HIDDEN\n",
-        "bool(np.isclose(price_by_flavor[\"strawberry\"], 3))"
+        "assert bool(np.isclose(price_by_flavor[\"strawberry\"], 3))"
       ]
     },
     {
@@ -373,7 +373,7 @@
       "outputs": [],
       "source": [
         "# HIDDEN\n",
-        "bool(np.isclose(price_by_flavor[\"vanilla\"], 1.75))"
+        "assert bool(np.isclose(price_by_flavor[\"vanilla\"], 1.75))"
       ]
     },
     {

--- a/frontend/src/components/modals/EditTaskModal.tsx
+++ b/frontend/src/components/modals/EditTaskModal.tsx
@@ -40,7 +40,7 @@ const EditTaskModal = ({
     async (embeddedApp: EmbeddedAppRef) => {
       const task = await executeAsyncWithToasts(
         () => embeddedApp.sendRequest("getTask", undefined),
-        intl.formatMessage(taskMessages.cannotSaveTask),
+        { intl, descriptor: taskMessages.cannotSaveTask },
       );
       onSave(task.result);
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Convert all equality checks in the Jupyter task template to assert statements so grading fails on wrong outputs. Update the Edit Task modal to show localized error toasts from embedded app responses.

- **Bug Fixes**
  - Jupyter task: replace comparison lines and numeric checks with `assert` (including hidden cells) so the autograder fails correctly.
  - Frontend: pass `{ intl, descriptor: taskMessages.cannotSaveTask }` to `executeAsyncWithToasts` so app errors display with the right localization.

<sup>Written for commit 11f6b8f2b85f3d46434734ec77f5d4c06a40f453. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/572?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

