### PR TITLE
[CRT-410] Scratch Block infinite limits does not allow any blocks

### DIFF
--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -177,7 +177,7 @@ export const wouldExceedLimits = (
   }
 
   // if allowed is a number, the block has a limit, it doesn't for every other type
-  const hasLimit = typeof allowed === "number";
+  const hasLimit = typeof allowed === "number" && allowed >= 0;
 
   // the create event fires on the main workspace before vm.blockListener updates target.blocks._blocks, so
   // countUsedBlocks does not yet include the new block.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CRT-410 by treating negative block limits as unlimited so “infinite” limits allow blocks again. Updates `wouldExceedLimits` to enforce only non‑negative numeric limits during block creation.

- **Bug Fixes**
  - `hasLimit` now checks `typeof allowed === "number" && allowed >= 0`; negative values (e.g., -1) are treated as no limit.

<sup>Written for commit b6e30480e1cc317180a74aca9a35de6ef79dbc7e. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/574?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

