### PR TITLE
[CRT-409] Hide grading folders in edit/solve mode

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -73,12 +73,13 @@ export const simplifyUserInterface = async (
     runningSessions.dispose();
 
     throwOnRestrictedFileOperation(fileBrowser);
-    hideGradingFolders(fileBrowser);
 
     if (mode === Mode.solve && documentManager) {
       redirectTaskFileOpensToStudentVersion(documentManager);
     }
   }
+
+  hideGradingFolders(fileBrowser);
 
   // activate simple mode
   await app.commands.execute("application:toggle-mode");


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide `autograder` and `student` folders in the Jupyter file browser in both edit and solve modes to prevent accidental edits and confusion. Addresses CRT-409.

- **Bug Fixes**
  - Call `hideGradingFolders` unconditionally in `simplifyUserInterface` so folder hiding applies in any mode.

<sup>Written for commit 5194aa73a51c9374b8a1ce25e52df936566b1c6a. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/575?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

