### PR TITLE
[CRT-387] Fix taskfiles / CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,8 @@
 # see https://stackoverflow.com/a/40537078/2897827
 *.sh text eol=lf
 
+# Set the default behavior for mise.lock
+mise.lock text eol=lf
+
 # Ignore Orval-generated files
 frontend/src/api/collimator/generated/** linguist-generated

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,7 +33,18 @@ tasks:
 
   build:
     desc: Build all packages
-    deps: [frontend:build, backend:build, apps:build]
+    deps: [backend:build]
+    cmds:
+      - task: build:ui
+
+  # we need this split because the frontend depends on the backend,
+  # so we can't build the backend and the frontend at the same time.
+  # Taskfiles don't seem to deal well with parallelizing dependencies
+  # which have transitive dependencies between themselves.
+  build:ui:
+    desc: Build non-backend packages
+    internal: true
+    deps: [frontend:build, apps:build]
 
   test:
     desc: Run unit and e2e tests


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes CI for CRT-387 (production deploy) by forcing LF line endings for `mise.lock` and fixing the Taskfile build order so the backend builds before the frontend/apps.

- **Bug Fixes**
  - Set `mise.lock` to `eol=lf` in `.gitattributes` to avoid cross-OS diffs and CI cache issues.
  - Split `build` in `Taskfile.yml`: run `backend:build` first, then `build:ui` (frontend, apps) to prevent parallel dependency conflicts.

<sup>Written for commit 59e191587ff2a36c181c51a6d06f58c80ac3042f. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/577?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

