### PR TITLE
[CRT-387] Further CI fixes

### DIFF
--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -35,8 +35,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
           submodules: "true"
           lfs: "true"
           fetch-depth: 0
@@ -65,7 +67,7 @@ jobs:
             echo ""
             echo "To fix this:"
             echo "  1. Run: task frontend:api:generate"
-            echo "  3. Commit the changes"
+            echo "  2. Commit the changes"
             echo ""
             exit 1
           fi

--- a/.github/workflows/api-check.yml
+++ b/.github/workflows/api-check.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -27,8 +27,8 @@ env:
   APP_SCRATCH_SENTRY_DSN: ${{ vars.APP_SCRATCH_SENTRY_DSN }}
 
 permissions:
-  id-token: write # This is required for requesting the JWT
-  contents: read # This is required for actions/checkout
+  contents: read
+  pull-requests: read
 
 jobs:
   tests:
@@ -61,10 +61,15 @@ jobs:
     env:
         DATABASE_URL: "postgresql://postgres:postgres@localhost:5433/collimator?schema=public"
 
+    permissions:
+      id-token: write # This is required for requesting the JWT
+
     steps:
       - name: Git clone the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
           submodules: 'true'
           lfs: 'true'
           fetch-depth: 0

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -66,7 +66,7 @@ jobs:
 
     steps:
       - name: Git clone the repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           persist-credentials: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,12 +8,16 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
 
     # Postgres is required because `task setup` runs `db:migrate:deploy`.
-    services:
+    services: &services
       postgres:
         image: postgres:18
         env:
@@ -28,7 +32,7 @@ jobs:
           # Maps TCP port 5433 on the host to Postgres
           - 5433:5432
 
-    env:
+    env: &job_env
       DATABASE_URL: "postgresql://postgres:postgres@localhost:5433/collimator?schema=public"
       NODE_OPTIONS: "--max-old-space-size=4096"
 
@@ -40,8 +44,10 @@ jobs:
           sudo docker builder prune -a
 
       - name: Check out repository code
-        uses: actions/checkout@v6
-        with:
+        uses: actions/checkout@v5
+        with: &checkout_options
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
           submodules: "true"
           lfs: "true"
           fetch-depth: 0
@@ -94,23 +100,8 @@ jobs:
 
   app-tests:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:18
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5433:5432
-
-    env:
-      DATABASE_URL: "postgresql://postgres:postgres@localhost:5433/collimator?schema=public"
-      NODE_OPTIONS: "--max-old-space-size=4096"
+    services: *services
+    env: *job_env
 
     steps:
       - name: Maximise disk space
@@ -120,11 +111,8 @@ jobs:
           sudo docker builder prune -a
 
       - name: Check out repository code
-        uses: actions/checkout@v6
-        with:
-          submodules: "true"
-          lfs: "true"
-          fetch-depth: 0
+        uses: actions/checkout@v5
+        with: *checkout_options
 
       - name: Setup CI environment
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -159,23 +147,8 @@ jobs:
 
   e2e-tests:
     runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:18
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5433:5432
-
-    env:
-      DATABASE_URL: "postgresql://postgres:postgres@localhost:5433/collimator?schema=public"
-      NODE_OPTIONS: "--max-old-space-size=4096"
+    services: *services
+    env: *job_env
 
     steps:
       - name: Maximise disk space
@@ -185,11 +158,8 @@ jobs:
           sudo docker builder prune -a
 
       - name: Check out repository code
-        uses: actions/checkout@v6
-        with:
-          submodules: "true"
-          lfs: "true"
-          fetch-depth: 0
+        uses: actions/checkout@v5
+        with: *checkout_options
 
       - name: Setup CI environment
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
@@ -234,8 +204,10 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v5
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: true
           submodules: "true"
           lfs: "true"
           fetch-depth: 0

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -306,7 +306,7 @@ tasks:
   frontend:build:
     desc: Build frontend
     dir: ./frontend
-    deps: [frontend:setup, frontend:api:generate]
+    deps: [frontend:api:generate]
     cmds:
       - yarn build
 
@@ -541,6 +541,7 @@ tasks:
   storybook:start:
     desc: Start storybook
     dir: ./frontend
+    deps: [frontend:setup]
     cmds:
       - cmd: yarn storybook:background:start
 

--- a/apps/jupyter/Taskfile.yml
+++ b/apps/jupyter/Taskfile.yml
@@ -240,6 +240,7 @@ tasks:
       - cp {{.OUTPUT_DIR}}/lab/index.html .cache/lab.html
 
   build:inject-iframe-script:
+    internal: true
     cmds:
       - cmd: pwsh -Command "echo '<script>' (Get-Content iframe-message-buffering.js) '</script>' | Out-File -Append -FilePath {{.OUTPUT_DIR}}/lab/index.html -Encoding utf8 -Force"
         platforms: [windows]

--- a/apps/jupyter/extensions/notebook-runner/src/command.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/command.ts
@@ -10,7 +10,7 @@ export const runGradingCommand = "notebook-runner:run-grading";
 export const runAllCellsCommand = "notebook-runner:run-all-cells";
 
 export enum CommandType {
-  RunNotebook =  "run_notebook",
+  RunNotebook = "run_notebook",
 }
 
 export const executeRunNotebookCommand = async (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes CI and deployment for CRT-387 by standardizing checkout and tightening workflow permissions. Cleans up test workflows and Taskfiles for simpler, more reliable runs.

- **Bug Fixes**
  - Use `actions/checkout@v5` with `${{ secrets.GITHUB_TOKEN }}` and `persist-credentials: true` in `api-check`, `tests`, and `deployment` to reliably fetch submodules and LFS.
  - Scope permissions across CI: set `contents: read`, `pull-requests: read`; grant `id-token: write` only to the deployment job.
  - Correct API check hint numbering; mark Jupyter task `build:inject-iframe-script` as internal.

- **Refactors**
  - DRY `tests.yml` with YAML anchors for Postgres service, env, and checkout options; reuse across unit/app/e2e jobs.
  - Taskfile tweaks: `frontend:build` depends only on `frontend:api:generate`; add `frontend:setup` to `storybook:start`. Minor enum formatting in `notebook-runner` (no behavior change).

<sup>Written for commit a1dc251e15fac12816cb80bf264a941fb07c0e35. Summary will update on new commits. <a href="https://cubic.dev/pr/crt25/collimator/pull/578?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

