### PR TITLE
Users are able to submit forms more than once at a time

### DIFF
--- a/frontend/src/components/class/ClassForm.tsx
+++ b/frontend/src/components/class/ClassForm.tsx
@@ -67,7 +67,7 @@ const ClassForm = ({
 }: {
   submitMessage: MessageDescriptor;
   initialValues?: ClassFormValues;
-  onSubmit: (data: ClassFormValues) => void;
+  onSubmit: (data: ClassFormValues) => void | Promise<void>;
 }) => {
   const intl = useIntl();
 
@@ -127,8 +127,8 @@ const ClassForm = ({
         <>
           <FormContainer
             as="form"
-            onSubmit={handleSubmit((values) => {
-              onSubmit(values);
+            onSubmit={handleSubmit(async (values) => {
+              await onSubmit(values);
               reset(values);
             })}
             data-testid="class-form"

--- a/frontend/src/components/lesson/LessonForm.tsx
+++ b/frontend/src/components/lesson/LessonForm.tsx
@@ -25,7 +25,7 @@ const LessonForm = ({
 }: {
   submitMessage: MessageDescriptor;
   initialValues?: LessonFormProps;
-  onSubmit: (data: LessonFormProps) => void;
+  onSubmit: (data: LessonFormProps) => void | Promise<void>;
 }) => {
   const schema = useYupSchema({
     name: yup.string().required(),
@@ -37,7 +37,7 @@ const LessonForm = ({
     register,
     handleSubmit,
     reset,
-    formState: { errors, dirtyFields },
+    formState: { errors, dirtyFields, isSubmitting },
   } = useForm<LessonFormProps>({
     resolver,
     defaultValues: initialValues,
@@ -48,8 +48,8 @@ const LessonForm = ({
 
   return (
     <form
-      onSubmit={handleSubmit((values) => {
-        onSubmit(values);
+      onSubmit={handleSubmit(async (values) => {
+        await onSubmit(values);
         reset(values);
       })}
     >
@@ -59,7 +59,7 @@ const LessonForm = ({
         {...register("name")}
         labelBadge={showEditedBadges && dirtyFields.name && <EditedBadge />}
       />
-      <SubmitFormButton label={submitMessage} />
+      <SubmitFormButton label={submitMessage} disabled={isSubmitting} />
     </form>
   );
 };

--- a/frontend/src/components/session/SessionForm.tsx
+++ b/frontend/src/components/session/SessionForm.tsx
@@ -157,7 +157,7 @@ const SessionForm = ({
 }: {
   submitMessage: MessageDescriptor;
   initialValues?: Partial<SessionFormValues>;
-  onSubmit: (data: SessionFormValues) => void;
+  onSubmit: (data: SessionFormValues) => void | Promise<void>;
   classId: number;
   editingMode?: EditingMode;
 }) => {
@@ -204,7 +204,7 @@ const SessionForm = ({
     watch,
     setValue,
     reset,
-    formState: { errors, dirtyFields, isDirty },
+    formState: { errors, dirtyFields, isDirty, isSubmitting },
     control,
   } = useForm<SessionFormValues>({
     resolver,
@@ -345,8 +345,8 @@ const SessionForm = ({
       {(tasks) => (
         <>
           <form
-            onSubmit={handleSubmit((values) => {
-              onSubmit(values);
+            onSubmit={handleSubmit(async (values) => {
+              await onSubmit(values);
               reset(values);
             })}
             data-testid="session-form"
@@ -480,7 +480,10 @@ const SessionForm = ({
             </Grid>
             {!isReadOnly && (
               <SubmitButtonWrapper>
-                <SubmitFormButton label={submitMessage} disabled={!isDirty} />
+                <SubmitFormButton
+                  label={submitMessage}
+                  disabled={!isDirty || isSubmitting}
+                />
               </SubmitButtonWrapper>
             )}
           </form>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents duplicate form submissions by awaiting async submit handlers and disabling submit buttons while a submit is in progress.

- **Bug Fixes**
  - ClassForm: allow async `onSubmit` and await it before reset.
  - LessonForm: await `onSubmit` and disable `SubmitFormButton` using `isSubmitting`.
  - SessionForm: await `onSubmit` and disable `SubmitFormButton` when `!isDirty || isSubmitting`.

<sup>Written for commit 1887e728fab30a6ef82c5770d362c8017b153bcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/579?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

