### PR TITLE
[CRT-418] HTTP 500 - timeout when selecting reference - missing index

### DIFF
--- a/backend/prisma/migrations/20260601000000_add_composite_indexes_to_student_activity/migration.sql
+++ b/backend/prisma/migrations/20260601000000_add_composite_indexes_to_student_activity/migration.sql
@@ -1,0 +1,5 @@
+-- Composite indexes on StudentActivity to fix transaction timeouts in
+-- updateStudentActivityIsReference (studentId + solutionHash)
+-- the (taskId, solutionHash) for joins in getCurrentAnalysesWithActivities.
+CREATE INDEX "StudentActivity_studentId_solutionHash_idx" ON "StudentActivity"("studentId", "solutionHash");
+CREATE INDEX "StudentActivity_taskId_solutionHash_idx" ON "StudentActivity"("taskId", "solutionHash");

--- a/backend/prisma/migrations/20260601000000_add_index_to_student_activity_solution_hash/migration.sql
+++ b/backend/prisma/migrations/20260601000000_add_index_to_student_activity_solution_hash/migration.sql
@@ -1,2 +1,0 @@
--- Add index on solutionHash in StudentActivity to fix transaction timeouts
-CREATE INDEX "StudentActivity_solutionHash_idx" ON "StudentActivity"("solutionHash");

--- a/backend/prisma/migrations/20260601000000_add_index_to_student_activity_solution_hash/migration.sql
+++ b/backend/prisma/migrations/20260601000000_add_index_to_student_activity_solution_hash/migration.sql
@@ -1,0 +1,2 @@
+-- Add index on solutionHash in StudentActivity to fix transaction timeouts
+CREATE INDEX "StudentActivity_solutionHash_idx" ON "StudentActivity"("solutionHash");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -353,7 +353,8 @@ model StudentActivity {
   appActivity StudentActivityApp?
 
   @@unique([studentId, type, happenedAt, happenedAtCounter], name: "uniqueStudentActivityPerTypeAndTime")
-  @@index([solutionHash])
+  @@index([studentId, solutionHash])
+  @@index([taskId, solutionHash])
 }
 
 model StudentActivityApp {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -353,6 +353,7 @@ model StudentActivity {
   appActivity StudentActivityApp?
 
   @@unique([studentId, type, happenedAt, happenedAtCounter], name: "uniqueStudentActivityPerTypeAndTime")
+  @@index([solutionHash])
 }
 
 model StudentActivityApp {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CRT-418 by indexing `StudentActivity` queries to stop HTTP 500 timeouts when selecting a reference. Solution-hash lookups are now fast and do not block transactions.

- **Bug Fixes**
  - Add Prisma `@@index([studentId, solutionHash])` and `@@index([taskId, solutionHash])` on `StudentActivity` to speed `updateStudentActivityIsReference` and joins in `getCurrentAnalysesWithActivities`.

- **Migration**
  - Apply the Prisma migration to create both indexes.

<sup>Written for commit e44542b90f19928693101c49bb57c5d4344a8c64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

