### PR TITLE
[CRT-414] Scratch doesn't reset to correct position after reloading the task

### DIFF
--- a/apps/scratch/src/components/TaskConfig.tsx
+++ b/apps/scratch/src/components/TaskConfig.tsx
@@ -55,7 +55,7 @@ const TaskConfig = ({
   const [allowCustomProcedureBlocks, setAllowCustomProcedureBlocks] =
     useState(false);
   const [allowVariableBlocks, setAllowVariableBlocks] = useState(false);
-  const [enableStageInteractions, setEnableStageInteractions] = useState(true);
+  const [enableStageInteractions, setEnableStageInteractions] = useState(false);
 
   const configSnapshot = useRef<{
     allowedBlocks: BlockLimits;
@@ -112,7 +112,7 @@ const TaskConfig = ({
       (vm.crtConfig?.maximumExecutionTimeInMs ??
         defaultMaximumExecutionTimeInMs) / 1000,
     );
-    setEnableStageInteractions(vm.crtConfig?.enableStageInteractions ?? true);
+    setEnableStageInteractions(vm.crtConfig?.enableStageInteractions ?? false);
   }, [
     vm.crtConfig,
     vm.crtConfig?.allowedBlocks.customBlocks,
@@ -171,7 +171,7 @@ const TaskConfig = ({
     if (isShown && vm.crtConfig) {
       configSnapshot.current = {
         allowedBlocks: { ...vm.crtConfig.allowedBlocks },
-        enableStageInteractions: vm.crtConfig.enableStageInteractions ?? true,
+        enableStageInteractions: vm.crtConfig.enableStageInteractions ?? false,
       };
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/scratch/src/extensions/assertions/index.ts
+++ b/apps/scratch/src/extensions/assertions/index.ts
@@ -7,6 +7,14 @@ import { BlockType } from "../../blocks/block-type";
 import { ArgumentType } from "../../blocks/argument-type";
 import { formatMessage } from "../../i18n";
 import { Assertion } from "../../types/scratch-vm-custom";
+import {
+  RememberedSpriteState,
+  RememberedStageState,
+  rememberSpriteState,
+  rememberStageState,
+  restoreSpriteStateForExecution,
+  restoreStageStateForExecution,
+} from "../../vm/target-state";
 import testIconWhite from "./test-icon-white.svg";
 import testIconBlack from "./test-icon-black.svg";
 
@@ -87,28 +95,6 @@ const setCustomState = (
     state,
   );
 };
-
-interface RememberedTargetState {
-  currentCostume: number;
-  volume: number;
-  customState: Partial<VM.CustomState>;
-}
-
-interface RememberedStageState extends RememberedTargetState {
-  tempo: number;
-  videoTransparency: number;
-}
-
-interface RememberedSpriteState extends RememberedTargetState {
-  name: string;
-  x: number;
-  y: number;
-  size: number;
-  direction: number;
-  draggable: boolean;
-  rotationStyle: VM.RotationStyle;
-  layerOrder: number;
-}
 
 /**
  * Adds assertions to the Scratch VM.
@@ -257,27 +243,9 @@ class AssertionExtension {
 
     for (const target of this.runtime.targets) {
       if (target.isStage) {
-        this.rememberedStageState = {
-          currentCostume: target.currentCostume,
-          volume: target.volume,
-          tempo: target.tempo,
-          videoTransparency: target.videoTransparency,
-          customState: target._customState,
-        };
+        this.rememberedStageState = rememberStageState(target);
       } else if (target.isSprite()) {
-        this.rememberedSpriteState[target.id] = {
-          currentCostume: target.currentCostume,
-          volume: target.volume,
-          name: target.getName(),
-          x: target.x,
-          y: target.y,
-          size: target.size,
-          direction: target.direction,
-          draggable: target.draggable,
-          rotationStyle: target.rotationStyle,
-          layerOrder: target.getLayerOrder(),
-          customState: target._customState,
-        };
+        this.rememberedSpriteState[target.id] = rememberSpriteState(target);
       }
     }
   };
@@ -293,32 +261,12 @@ class AssertionExtension {
       // reset the state for each target
 
       if (target.isStage && this.rememberedStageState) {
-        target.setCostume(this.rememberedStageState.currentCostume);
-        target.volume = this.rememberedStageState.volume;
-        target.tempo = this.rememberedStageState.tempo;
-        target.videoTransparency = this.rememberedStageState.videoTransparency;
-
-        target._customState = this.rememberedStageState.customState;
+        restoreStageStateForExecution(target, this.rememberedStageState);
       } else if (target.isSprite() && this.rememberedSpriteState[target.id]) {
-        const state = this.rememberedSpriteState[target.id];
-
-        target.setCostume(state.currentCostume);
-        target.volume = state.volume;
-        target.sprite.name = state.name;
-        target.setXY(state.x, state.y);
-        target.setSize(state.size);
-        target.setDirection(state.direction);
-        target.setDraggable(state.draggable);
-        target.setRotationStyle(state.rotationStyle);
-
-        // see https://github.com/scratchfoundation/scratch-vm/blob/bb1659e1f42de5bd28d7233c8e418c4e536a2bf0/src/sprites/rendered-target.js#L850C71-L850C97
-        target.renderer?.setDrawableOrder(
-          target.drawableID,
-          state.layerOrder,
-          "sprite",
+        restoreSpriteStateForExecution(
+          target,
+          this.rememberedSpriteState[target.id],
         );
-
-        target._customState = state.customState;
       }
 
       // reset the assertions state for each target

--- a/apps/scratch/src/vm/default-crt-config.ts
+++ b/apps/scratch/src/vm/default-crt-config.ts
@@ -5,5 +5,5 @@ export const defaultCrtConfig: ScratchCrtConfig = {
   allowedBlocks: {},
   freezeStateByBlockId: {},
   maximumExecutionTimeInMs: defaultMaximumExecutionTimeInMs,
-  enableStageInteractions: true,
+  enableStageInteractions: false,
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -3,7 +3,6 @@ import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
 import {
   RememberedSpriteState,
-  refreshSpriteEditorState,
   rememberSpriteState,
   restoreSpriteStateForSerialization,
 } from "./target-state";
@@ -148,32 +147,8 @@ const wrapPostSpriteInfo = (vm: VM): void => {
   };
 };
 
-const mirrorEditsOnTargetsUpdate = (vm: VM): void => {
-  const startState = getTargetStartState(vm);
-  // rename and costume changes trigger a TARGETS_UPDATE
-  vm.runtime.on("TARGETS_UPDATE", () => {
-    if (vm.runtime.threads.length > 0) {
-      return;
-    }
-
-    for (const target of vm.runtime.targets) {
-      // skip original and stage targets
-      if (!isTrackableSprite(target)) {
-        continue;
-      }
-
-      const snap = startState.get(target.id);
-
-      if (snap) {
-        refreshSpriteEditorState(snap, target);
-      }
-    }
-  });
-};
-
 const wrapEditorMutators = (vm: VM): void => {
   wrapPostSpriteInfo(vm);
-  mirrorEditsOnTargetsUpdate(vm);
 };
 
 const snapshotOnTargetLifecycle = (vm: VM): void => {

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -3,54 +3,80 @@ import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
 import {
   RememberedSpriteState,
+  RememberedStageState,
   rememberSpriteState,
+  rememberStageState,
   restoreSpriteStateForExecution,
   restoreSpriteStateForSerialization,
+  restoreStageStateForExecution,
+  restoreStageStateForSerialization,
 } from "./target-state";
 
-const startStateByVm = new Map<VM, Map<string, RememberedSpriteState>>();
+const spriteStartStateByVm = new Map<VM, Map<string, RememberedSpriteState>>();
+const stageStartStateByVm = new Map<VM, RememberedStageState>();
 
-export const getTargetStartState = (
+export const getSpriteStartState = (
   vm: VM,
 ): Map<string, RememberedSpriteState> => {
-  let map = startStateByVm.get(vm);
+  let map = spriteStartStateByVm.get(vm);
 
   if (!map) {
     map = new Map();
-    startStateByVm.set(vm, map);
+    spriteStartStateByVm.set(vm, map);
   }
 
   return map;
 };
 
+export const getStageStartState = (vm: VM): RememberedStageState | undefined =>
+  stageStartStateByVm.get(vm);
+
 const clearStartState = (vm: VM): void => {
-  getTargetStartState(vm).clear();
+  getSpriteStartState(vm).clear();
+  stageStartStateByVm.delete(vm);
 };
 
-/**
- * Temporarily set each target's mutable sprite state to its tracked
- * starting state so the serializer doesn't capture runtime drift caused
- * by scripts. Returns a restore callback.
- */
+const isStageWithStartState = (
+  target: VM.Target,
+  vm: VM,
+  stage: RememberedStageState | undefined,
+): stage is RememberedStageState =>
+  target.isStage && stageStartStateByVm.has(vm) && stage !== undefined;
+
 export const swapToStartState = (vm: VM): (() => void) => {
-  const snapshot = getTargetStartState(vm);
-  if (snapshot.size === 0) {
+  const sprites = getSpriteStartState(vm);
+  const stage = getStageStartState(vm);
+
+  // if there is no stage or trackable sprites with start state, we don't need to do anything
+  if (sprites.size === 0 && !stage) {
     return () => {};
   }
 
-  const runtimeState: Array<{
+  const spriteRuntimeState: Array<{
     target: VM.Target;
     runtime: RememberedSpriteState;
   }> = [];
 
+  let stageRuntime: {
+    target: VM.Target;
+    runtime: RememberedStageState;
+  } | null = null;
+
   for (const target of vm.runtime.targets) {
-    const start = snapshot.get(target.id);
+    if (isStageWithStartState(target, vm, stage)) {
+      // store the current stage state before restoring so we can put it back later
+      stageRuntime = { target, runtime: rememberStageState(target) };
+      restoreStageStateForSerialization(target, stage);
+      continue;
+    }
+
+    const start = sprites.get(target.id);
 
     if (!start) {
       continue;
     }
 
-    runtimeState.push({
+    spriteRuntimeState.push({
       target,
       runtime: rememberSpriteState(target),
     });
@@ -59,8 +85,17 @@ export const swapToStartState = (vm: VM): (() => void) => {
   }
 
   return () => {
-    for (const { target, runtime } of runtimeState) {
+    // restore the current runtime state after serialisation
+    for (const { target, runtime } of spriteRuntimeState) {
       restoreSpriteStateForSerialization(target, runtime);
+    }
+
+    // restore the stage state after serialisation if we modified it
+    if (stageRuntime) {
+      restoreStageStateForSerialization(
+        stageRuntime.target,
+        stageRuntime.runtime,
+      );
     }
   };
 };
@@ -114,30 +149,51 @@ const initializeTaskBlocksOnLoad = (vm: VM): void => {
   });
 };
 
-const snapshotOnRunStart = (vm: VM): void => {
-  const startState = getTargetStartState(vm);
+const snapshotBeforeHats = (vm: VM): void => {
+  const sprites = getSpriteStartState(vm);
+  const originalStartHats = vm.runtime.startHats.bind(vm.runtime);
 
-  vm.runtime.on("PROJECT_RUN_START", () => {
-    startState.clear();
-    for (const target of vm.runtime.targets) {
-      if (!isTrackableSprite(target)) {
-        continue;
+  vm.runtime.startHats = (
+    requestedHatOpcode: string,
+    optMatchFields?: Record<string, unknown>,
+    optTarget?: VM.Target,
+  ): globalThis.VM.Thread[] | undefined => {
+    // snapshot only on the first hat-start of a new run sequence
+    if (sprites.size === 0 && !stageStartStateByVm.has(vm)) {
+      for (const target of vm.runtime.targets) {
+        if (target.isStage) {
+          stageStartStateByVm.set(vm, rememberStageState(target));
+          continue;
+        }
+
+        if (!isTrackableSprite(target)) {
+          continue;
+        }
+
+        sprites.set(target.id, rememberSpriteState(target));
       }
-
-      startState.set(target.id, rememberSpriteState(target));
     }
-  });
+
+    return originalStartHats(requestedHatOpcode, optMatchFields, optTarget);
+  };
 };
 
 const resetOnRunStop = (vm: VM): void => {
-  const startState = getTargetStartState(vm);
+  const sprites = getSpriteStartState(vm);
 
   vm.runtime.on("PROJECT_RUN_STOP", () => {
+    const stage = stageStartStateByVm.get(vm);
+
     for (const target of vm.runtime.targets) {
-      const snap = startState.get(target.id);
+      if (isStageWithStartState(target, vm, stage)) {
+        restoreStageStateForExecution(target, stage);
+        continue;
+      }
+
+      const snap = sprites.get(target.id);
 
       if (snap) {
-        // restore all sprites to the state they had when the project started running
+        // restore all sprites & stage to the state they had when the project started running
         restoreSpriteStateForExecution(target, snap);
       }
     }
@@ -165,7 +221,7 @@ const patchSerialization = (vm: VM): void => {
 export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
   initializeTaskBlocksOnLoad(vm);
-  snapshotOnRunStart(vm);
+  snapshotBeforeHats(vm);
   resetOnRunStop(vm);
   patchSerialization(vm);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -1,33 +1,24 @@
 import VM from "@scratch/scratch-vm";
 import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
+import {
+  RememberedSpriteState,
+  rememberSpriteState,
+  restoreSpriteStateForSerialization,
+} from "./target-state";
 
-export interface TargetStartState {
-  x: number;
-  y: number;
-  direction: number;
-  size: number;
-  visible: boolean;
-}
-
-const startStateByVm = new Map<VM, Map<string, TargetStartState>>();
-
-const snapshotTarget = (target: VM.Target): TargetStartState =>
-  ({
-    x: target.x,
-    y: target.y,
-    direction: target.direction,
-    size: target.size,
-    visible: target.visible,
-  }) satisfies TargetStartState;
+const startStateByVm = new Map<VM, Map<string, RememberedSpriteState>>();
 
 /**
- * Snapshot on project load and on user-initiated postSpriteInfo calls
- * (stage drag, sprite-info pane). Used by saveCrtProject so that running
- * a script and then saving doesn't introduce runtime differences into the
+ * Snapshot on project load, on `targetWasCreated`, and on user-initiated
+ * postSpriteInfo calls (stage drag, sprite-info pane). Used by the
+ * vm.toJSON wrap below so that running a script and then serialising
+ * doesn't introduce runtime differences into the
  * project as the new starting point.
  */
-export const getTargetStartState = (vm: VM): Map<string, TargetStartState> => {
+export const getTargetStartState = (
+  vm: VM,
+): Map<string, RememberedSpriteState> => {
   let map = startStateByVm.get(vm);
 
   if (!map) {
@@ -38,26 +29,10 @@ export const getTargetStartState = (vm: VM): Map<string, TargetStartState> => {
   return map;
 };
 
-const assignIfPosted = <K extends keyof TargetStartState>(
-  data: VM.PostedSpriteInfo,
-  snap: TargetStartState,
-  target: VM.Target,
-  key: K,
-  expectedType: "number" | "boolean",
-): void => {
-  if (typeof data[key] === expectedType) {
-    snap[key] = target[key];
-  }
-};
-
 /**
  * Temporarily set each target's mutable sprite state to its tracked
  * starting state so the serializer doesn't capture runtime drift caused
  * by scripts. Returns a restore callback.
- *
- * Fields are assigned directly (rather than via target.setXY/setDirection/
- * setSize/setVisible) so we don't trigger renderer updates or pen draws —
- * the sprite stays visually where the runtime had it.
  */
 export const swapToStartState = (vm: VM): (() => void) => {
   const snapshot = getTargetStartState(vm);
@@ -65,8 +40,10 @@ export const swapToStartState = (vm: VM): (() => void) => {
     return () => {};
   }
 
-  const runtimeState: Array<{ target: VM.Target; runtime: TargetStartState }> =
-    [];
+  const runtimeState: Array<{
+    target: VM.Target;
+    runtime: RememberedSpriteState;
+  }> = [];
 
   for (const target of vm.runtime.targets) {
     const start = snapshot.get(target.id);
@@ -77,29 +54,15 @@ export const swapToStartState = (vm: VM): (() => void) => {
 
     runtimeState.push({
       target,
-      runtime: {
-        x: target.x,
-        y: target.y,
-        direction: target.direction,
-        size: target.size,
-        visible: target.visible,
-      },
+      runtime: rememberSpriteState(target),
     });
 
-    target.x = start.x;
-    target.y = start.y;
-    target.direction = start.direction;
-    target.size = start.size;
-    target.visible = start.visible;
+    restoreSpriteStateForSerialization(target, start);
   }
 
   return () => {
     for (const { target, runtime } of runtimeState) {
-      target.x = runtime.x;
-      target.y = runtime.y;
-      target.direction = runtime.direction;
-      target.size = runtime.size;
-      target.visible = runtime.visible;
+      restoreSpriteStateForSerialization(target, runtime);
     }
   };
 };
@@ -139,7 +102,7 @@ export const patchScratchVm = (vm: VM): void => {
       return;
     }
 
-    startState.set(target.id, snapshotTarget(target));
+    startState.set(target.id, rememberSpriteState(target));
   };
 
   vm.runtime.on("PROJECT_LOADED", () => {
@@ -180,11 +143,33 @@ export const patchScratchVm = (vm: VM): void => {
       return;
     }
 
-    assignIfPosted(data, snap, target, "x", "number");
-    assignIfPosted(data, snap, target, "y", "number");
-    assignIfPosted(data, snap, target, "direction", "number");
-    assignIfPosted(data, snap, target, "size", "number");
-    assignIfPosted(data, snap, target, "visible", "boolean");
+    if (typeof data.x === "number") {
+      snap.x = target.x;
+    }
+
+    if (typeof data.y === "number") {
+      snap.y = target.y;
+    }
+
+    if (typeof data.direction === "number") {
+      snap.direction = target.direction;
+    }
+
+    if (typeof data.size === "number") {
+      snap.size = target.size;
+    }
+
+    if (typeof data.visible === "boolean") {
+      snap.visible = target.visible;
+    }
+
+    if (typeof data.draggable === "boolean") {
+      snap.draggable = target.draggable;
+    }
+
+    if (typeof data.rotationStyle === "string") {
+      snap.rotationStyle = target.rotationStyle;
+    }
   };
 
   // Wrap vm.toJSON so every serialisation path uses the tracked starting

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -147,10 +147,6 @@ const wrapPostSpriteInfo = (vm: VM): void => {
   };
 };
 
-const wrapEditorMutators = (vm: VM): void => {
-  wrapPostSpriteInfo(vm);
-};
-
 const snapshotOnTargetLifecycle = (vm: VM): void => {
   const startState = getTargetStartState(vm);
 
@@ -207,6 +203,6 @@ const patchSerialization = (vm: VM): void => {
 export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
   snapshotOnTargetLifecycle(vm);
-  wrapEditorMutators(vm);
+  wrapPostSpriteInfo(vm);
   patchSerialization(vm);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -4,18 +4,12 @@ import AssertionExtension from "../extensions/assertions";
 import {
   RememberedSpriteState,
   rememberSpriteState,
+  restoreSpriteStateForExecution,
   restoreSpriteStateForSerialization,
 } from "./target-state";
 
 const startStateByVm = new Map<VM, Map<string, RememberedSpriteState>>();
 
-/**
- * Snapshot on project load, on `targetWasCreated`, and on user-initiated
- * postSpriteInfo calls (stage drag, sprite-info pane). Used by the
- * vm.toJSON wrap below so that running a script and then serialising
- * doesn't introduce runtime differences into the
- * project as the new starting point.
- */
 export const getTargetStartState = (
   vm: VM,
 ): Map<string, RememberedSpriteState> => {
@@ -27,6 +21,10 @@ export const getTargetStartState = (
   }
 
   return map;
+};
+
+const clearStartState = (vm: VM): void => {
+  getTargetStartState(vm).clear();
 };
 
 /**
@@ -67,6 +65,10 @@ export const swapToStartState = (vm: VM): (() => void) => {
   };
 };
 
+const isTrackableSprite = (target: VM.Target): boolean =>
+  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
+  !target.isStage && target.isOriginal !== false;
+
 const patchExtensionManager = (vm: VM): void => {
   // patch extension manager load function with a custom implementation
   vm.extensionManager.loadExtensionURL = async (
@@ -96,58 +98,6 @@ const patchExtensionManager = (vm: VM): void => {
   };
 };
 
-const wrapPostSpriteInfo = (vm: VM): void => {
-  const startState = getTargetStartState(vm);
-  const originalPostSpriteInfo = vm.postSpriteInfo.bind(vm);
-  vm.postSpriteInfo = (data: VM.PostedSpriteInfo): void => {
-    originalPostSpriteInfo(data);
-
-    const target = vm._dragTarget ?? vm.editingTarget;
-
-    if (!target || target.isStage) {
-      return;
-    }
-
-    const snap = startState.get(target.id);
-
-    if (!snap) {
-      return;
-    }
-
-    if (typeof data.x === "number") {
-      snap.x = target.x;
-    }
-
-    if (typeof data.y === "number") {
-      snap.y = target.y;
-    }
-
-    if (typeof data.direction === "number") {
-      snap.direction = target.direction;
-    }
-
-    if (typeof data.size === "number") {
-      snap.size = target.size;
-    }
-
-    if (typeof data.visible === "boolean") {
-      snap.visible = target.visible;
-    }
-
-    if (typeof data.draggable === "boolean") {
-      snap.draggable = target.draggable;
-    }
-
-    if (typeof data.rotationStyle === "string") {
-      snap.rotationStyle = target.rotationStyle;
-    }
-  };
-};
-
-const isTrackableSprite = (target: VM.Target): boolean =>
-  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
-  !target.isStage && target.isOriginal !== false;
-
 const initializeTaskBlocksOnLoad = (vm: VM): void => {
   vm.runtime.on("PROJECT_LOADED", () => {
     // iterate over all the blocks in the runtime
@@ -159,39 +109,46 @@ const initializeTaskBlocksOnLoad = (vm: VM): void => {
           : true;
       }
     }
+
+    clearStartState(vm);
   });
 };
 
-const snapshotOnTargetLifecycle = (vm: VM): void => {
+const snapshotOnRunStart = (vm: VM): void => {
   const startState = getTargetStartState(vm);
 
-  const trackTargetStartState = (target: VM.Target): void => {
-    if (!isTrackableSprite(target)) {
-      return;
-    }
-
-    startState.set(target.id, rememberSpriteState(target));
-  };
-
-  vm.runtime.on("PROJECT_LOADED", () => {
+  vm.runtime.on("PROJECT_RUN_START", () => {
     startState.clear();
     for (const target of vm.runtime.targets) {
-      trackTargetStartState(target);
-    }
-  });
+      if (!isTrackableSprite(target)) {
+        continue;
+      }
 
-  // Sprites added or duplicated after project load also need a starting snapshot
-  vm.runtime.on("targetWasCreated", (newTarget: VM.Target) => {
-    trackTargetStartState(newTarget);
+      startState.set(target.id, rememberSpriteState(target));
+    }
   });
 };
 
-// Wrap vm.toJSON so every serialisation path uses the tracked starting
-// state: saveProjectSb3 (calls this.toJSON internally), exportSprite,
-// and the direct callers in Controls.tsx (postSolutionRun) and
-// Blocks.tsx (student activity tracking). Without this, those direct
-// callers serialise runtime drift caused by scripts and end up sending
-// the runtime sprite position to the backend as the new starting point.
+const resetOnRunStop = (vm: VM): void => {
+  const startState = getTargetStartState(vm);
+
+  vm.runtime.on("PROJECT_RUN_STOP", () => {
+    for (const target of vm.runtime.targets) {
+      const snap = startState.get(target.id);
+
+      if (snap) {
+        // restore all sprites to the state they had when the project started running
+        restoreSpriteStateForExecution(target, snap);
+      }
+    }
+
+    clearStartState(vm);
+  });
+};
+
+// temporarily swap to start state during serialization to ensure
+// the project is saved with original positions, not changes occured in runtime.
+// immediately restore the current runtime state after serialization.
 const patchSerialization = (vm: VM): void => {
   const originalToJSON = vm.toJSON.bind(vm);
   vm.toJSON = (optTargetId?: string): string => {
@@ -208,7 +165,7 @@ const patchSerialization = (vm: VM): void => {
 export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
   initializeTaskBlocksOnLoad(vm);
-  snapshotOnTargetLifecycle(vm);
-  wrapPostSpriteInfo(vm);
+  snapshotOnRunStart(vm);
+  resetOnRunStop(vm);
   patchSerialization(vm);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -176,6 +176,23 @@ const snapshotBeforeHats = (vm: VM): void => {
   };
 };
 
+/**
+ * Clears the start state snapshot on PROJECT_STOP_ALL rather than PROJECT_RUN_STOP because
+ * PROJECT_RUN_STOP only fires inside the runtime's step loop,
+ * not synchronously from stopAll(). This matters because getSubmission
+ * calls stopAll() and then vm.toJSON() in the same turn, before the next
+ * step, so a stale snapshot would still be in the map and cause toJSON
+ * to serialize the wrong starting state.
+ *
+ * PROJECT_STOP_ALL fires synchronously inside stopAll() itself, so the
+ * snapshot is cleared before toJSON runs. It also covers the green-flag
+ * path: greenFlag() calls stopAll() first, so the subsequent startHats
+ * always captures a fresh snapshot.
+ *
+ * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2249 stopAll()}
+ * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2251 emits PROJECT_STOP_ALL}
+ * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2235 greenFlag() calls stopAll()}
+ */
 const clearOnStopAll = (vm: VM): void => {
   vm.runtime.on("PROJECT_STOP_ALL", () => {
     clearStartState(vm);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -4,16 +4,13 @@ import AssertionExtension from "../extensions/assertions";
 import {
   RememberedSpriteState,
   RememberedStageState,
+  StartState,
+  backupTargetsState,
   rememberSpriteState,
   rememberStageState,
   restoreSpriteStateForSerialization,
   restoreStageStateForSerialization,
 } from "./target-state";
-
-interface StartState {
-  sprites: Map<string, RememberedSpriteState>;
-  stage: RememberedStageState | undefined;
-}
 
 const clearStartState = (startState: StartState): void => {
   startState.sprites.clear();
@@ -79,10 +76,6 @@ const swapToStartState = (vm: VM, startState: StartState): (() => void) => {
   };
 };
 
-const isTrackableSprite = (target: VM.Target): boolean =>
-  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
-  !target.isStage && target.isOriginal !== false;
-
 const patchExtensionManager = (vm: VM): void => {
   // patch extension manager load function with a custom implementation
   vm.extensionManager.loadExtensionURL = async (
@@ -131,22 +124,11 @@ const initializeTaskBlocksOnLoad = (vm: VM, startState: StartState): void => {
 const snapshotOnGreenFlag = (vm: VM, startState: StartState): void => {
   const originalGreenFlag = vm.greenFlag.bind(vm);
 
+  // depends on the fact that we listen on PROJECT_STOP_ALL in the assertion extension to reset the position of the sprite
+  // this ensures that when the green flag is clicked, we snapshot the position of the sprites when the project is in its original state
+  vm.runtime.emit("PROJECT_STOP_ALL");
   vm.greenFlag = (): void => {
-    if (startState.sprites.size === 0 && !startState.stage) {
-      for (const target of vm.runtime.targets) {
-        if (target.isStage) {
-          startState.stage = rememberStageState(target);
-          continue;
-        }
-
-        if (!isTrackableSprite(target)) {
-          continue;
-        }
-
-        startState.sprites.set(target.id, rememberSpriteState(target));
-      }
-    }
-
+    backupTargetsState(vm, startState);
     originalGreenFlag();
   };
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -148,6 +148,20 @@ const isTrackableSprite = (target: VM.Target): boolean =>
   // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
   !target.isStage && target.isOriginal !== false;
 
+const initializeTaskBlocksOnLoad = (vm: VM): void => {
+  vm.runtime.on("PROJECT_LOADED", () => {
+    // iterate over all the blocks in the runtime
+    // and mark them as initial blocks
+    for (const target of vm.runtime.targets) {
+      for (const block of Object.values(target.blocks._blocks)) {
+        block.isTaskBlock = vm.taskBlockIds
+          ? vm.taskBlockIds.has(block.id)
+          : true;
+      }
+    }
+  });
+};
+
 const snapshotOnTargetLifecycle = (vm: VM): void => {
   const startState = getTargetStartState(vm);
 
@@ -160,16 +174,6 @@ const snapshotOnTargetLifecycle = (vm: VM): void => {
   };
 
   vm.runtime.on("PROJECT_LOADED", () => {
-    // iterate over all the blocks in the runtime
-    // and mark them as initial blocks
-    for (const target of vm.runtime.targets) {
-      for (const block of Object.values(target.blocks._blocks)) {
-        block.isTaskBlock = vm.taskBlockIds
-          ? vm.taskBlockIds.has(block.id)
-          : true;
-      }
-    }
-
     startState.clear();
     for (const target of vm.runtime.targets) {
       trackTargetStartState(target);
@@ -203,6 +207,7 @@ const patchSerialization = (vm: VM): void => {
 
 export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
+  initializeTaskBlocksOnLoad(vm);
   snapshotOnTargetLifecycle(vm);
   wrapPostSpriteInfo(vm);
   patchSerialization(vm);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -28,7 +28,7 @@ const resetTargetsForSerialization = (vm: VM, state: StartState): void => {
 
     const sprite = state.sprites.get(target.id);
     if (!sprite) {
-      return;
+      continue;
     }
 
     restoreSpriteStateForSerialization(target, sprite);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -128,40 +128,27 @@ const initializeTaskBlocksOnLoad = (vm: VM, startState: StartState): void => {
   });
 };
 
-const snapshotBeforeHats = (vm: VM, startState: StartState): void => {
-  const originalStartHats = vm.runtime.startHats.bind(vm.runtime);
+const snapshotOnGreenFlag = (vm: VM, startState: StartState): void => {
+  const originalGreenFlag = vm.greenFlag.bind(vm);
 
-  vm.runtime.startHats = (
-    requestedHatOpcode: string,
-    optMatchFields?: Record<string, unknown>,
-    optTarget?: VM.Target,
-  ): globalThis.VM.Thread[] | undefined => {
-    const wasIdle = vm.runtime.threads.length === 0;
-    const startedThreads = originalStartHats(
-      requestedHatOpcode,
-      optMatchFields,
-      optTarget,
-    );
-
-    // if the runtime is idle and the threads started by this hat are not empty
-    // we should refresh the start state to reflect the state right before the hat starts running
-    if (wasIdle && startedThreads && startedThreads.length > 0) {
-      clearStartState(startState);
-      for (const target of vm.runtime.targets) {
-        if (target.isStage) {
-          startState.stage = rememberStageState(target);
-          continue;
-        }
-
-        if (!isTrackableSprite(target)) {
-          continue;
-        }
-
-        startState.sprites.set(target.id, rememberSpriteState(target));
+  vm.greenFlag = (): void => {
+    // refresh the snapshot to reflect the target state at the moment the
+    // user pressed the green flag, before any script has run
+    clearStartState(startState);
+    for (const target of vm.runtime.targets) {
+      if (target.isStage) {
+        startState.stage = rememberStageState(target);
+        continue;
       }
+
+      if (!isTrackableSprite(target)) {
+        continue;
+      }
+
+      startState.sprites.set(target.id, rememberSpriteState(target));
     }
 
-    return startedThreads;
+    originalGreenFlag();
   };
 };
 
@@ -189,6 +176,6 @@ export const patchScratchVm = (vm: VM): void => {
 
   patchExtensionManager(vm);
   initializeTaskBlocksOnLoad(vm, startState);
-  snapshotBeforeHats(vm, startState);
+  snapshotOnGreenFlag(vm, startState);
   patchSerialization(vm, startState);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -10,43 +10,24 @@ import {
   restoreStageStateForSerialization,
 } from "./target-state";
 
-const spriteStartStateByVm = new Map<VM, Map<string, RememberedSpriteState>>();
-const stageStartStateByVm = new Map<VM, RememberedStageState>();
+interface StartState {
+  sprites: Map<string, RememberedSpriteState>;
+  stage: RememberedStageState | undefined;
+}
 
-export const getSpriteStartState = (
-  vm: VM,
-): Map<string, RememberedSpriteState> => {
-  let map = spriteStartStateByVm.get(vm);
-
-  if (!map) {
-    map = new Map();
-    spriteStartStateByVm.set(vm, map);
-  }
-
-  return map;
-};
-
-export const getStageStartState = (vm: VM): RememberedStageState | undefined =>
-  stageStartStateByVm.get(vm);
-
-const clearStartState = (vm: VM): void => {
-  getSpriteStartState(vm).clear();
-  stageStartStateByVm.delete(vm);
+const clearStartState = (startState: StartState): void => {
+  startState.sprites.clear();
+  startState.stage = undefined;
 };
 
 const isStageWithStartState = (
   target: VM.Target,
-  vm: VM,
   stage: RememberedStageState | undefined,
-): stage is RememberedStageState =>
-  target.isStage && stageStartStateByVm.has(vm) && stage !== undefined;
+): stage is RememberedStageState => target.isStage && stage !== undefined;
 
-export const swapToStartState = (vm: VM): (() => void) => {
-  const sprites = getSpriteStartState(vm);
-  const stage = getStageStartState(vm);
-
+const swapToStartState = (vm: VM, startState: StartState): (() => void) => {
   // if there is no stage or trackable sprites with start state, we don't need to do anything
-  if (sprites.size === 0 && !stage) {
+  if (startState.sprites.size === 0 && !startState.stage) {
     return () => {};
   }
 
@@ -61,14 +42,14 @@ export const swapToStartState = (vm: VM): (() => void) => {
   } | null = null;
 
   for (const target of vm.runtime.targets) {
-    if (isStageWithStartState(target, vm, stage)) {
+    if (isStageWithStartState(target, startState.stage)) {
       // store the current stage state before restoring so we can put it back later
       stageRuntime = { target, runtime: rememberStageState(target) };
-      restoreStageStateForSerialization(target, stage);
+      restoreStageStateForSerialization(target, startState.stage);
       continue;
     }
 
-    const start = sprites.get(target.id);
+    const start = startState.sprites.get(target.id);
 
     if (!start) {
       continue;
@@ -131,7 +112,7 @@ const patchExtensionManager = (vm: VM): void => {
   };
 };
 
-const initializeTaskBlocksOnLoad = (vm: VM): void => {
+const initializeTaskBlocksOnLoad = (vm: VM, startState: StartState): void => {
   vm.runtime.on("PROJECT_LOADED", () => {
     // iterate over all the blocks in the runtime
     // and mark them as initial blocks
@@ -143,12 +124,11 @@ const initializeTaskBlocksOnLoad = (vm: VM): void => {
       }
     }
 
-    clearStartState(vm);
+    clearStartState(startState);
   });
 };
 
-const snapshotBeforeHats = (vm: VM): void => {
-  const sprites = getSpriteStartState(vm);
+const snapshotBeforeHats = (vm: VM, startState: StartState): void => {
   const originalStartHats = vm.runtime.startHats.bind(vm.runtime);
 
   vm.runtime.startHats = (
@@ -157,10 +137,10 @@ const snapshotBeforeHats = (vm: VM): void => {
     optTarget?: VM.Target,
   ): globalThis.VM.Thread[] | undefined => {
     // snapshot only on the first hat-start of a new run sequence
-    if (sprites.size === 0 && !stageStartStateByVm.has(vm)) {
+    if (startState.sprites.size === 0 && !startState.stage) {
       for (const target of vm.runtime.targets) {
         if (target.isStage) {
-          stageStartStateByVm.set(vm, rememberStageState(target));
+          startState.stage = rememberStageState(target);
           continue;
         }
 
@@ -168,7 +148,7 @@ const snapshotBeforeHats = (vm: VM): void => {
           continue;
         }
 
-        sprites.set(target.id, rememberSpriteState(target));
+        startState.sprites.set(target.id, rememberSpriteState(target));
       }
     }
 
@@ -193,19 +173,19 @@ const snapshotBeforeHats = (vm: VM): void => {
  * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2251 emits PROJECT_STOP_ALL}
  * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2235 greenFlag() calls stopAll()}
  */
-const clearOnStopAll = (vm: VM): void => {
+const clearOnStopAll = (vm: VM, startState: StartState): void => {
   vm.runtime.on("PROJECT_STOP_ALL", () => {
-    clearStartState(vm);
+    clearStartState(startState);
   });
 };
 
 // temporarily swap to start state during serialization to ensure
 // the project is saved with original positions, not changes occured in runtime.
 // immediately restore the current runtime state after serialization.
-const patchSerialization = (vm: VM): void => {
+const patchSerialization = (vm: VM, startState: StartState): void => {
   const originalToJSON = vm.toJSON.bind(vm);
   vm.toJSON = (optTargetId?: string): string => {
-    const restore = swapToStartState(vm);
+    const restore = swapToStartState(vm, startState);
 
     try {
       return originalToJSON(optTargetId);
@@ -216,9 +196,14 @@ const patchSerialization = (vm: VM): void => {
 };
 
 export const patchScratchVm = (vm: VM): void => {
+  const startState: StartState = {
+    sprites: new Map(),
+    stage: undefined,
+  };
+
   patchExtensionManager(vm);
-  initializeTaskBlocksOnLoad(vm);
-  snapshotBeforeHats(vm);
-  clearOnStopAll(vm);
-  patchSerialization(vm);
+  initializeTaskBlocksOnLoad(vm, startState);
+  snapshotBeforeHats(vm, startState);
+  clearOnStopAll(vm, startState);
+  patchSerialization(vm, startState);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -67,10 +67,6 @@ export const swapToStartState = (vm: VM): (() => void) => {
   };
 };
 
-const isTrackableSprite = (target: VM.Target): boolean =>
-  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
-  !target.isStage && target.isOriginal !== false;
-
 const patchExtensionManager = (vm: VM): void => {
   // patch extension manager load function with a custom implementation
   vm.extensionManager.loadExtensionURL = async (
@@ -147,6 +143,10 @@ const wrapPostSpriteInfo = (vm: VM): void => {
     }
   };
 };
+
+const isTrackableSprite = (target: VM.Target): boolean =>
+  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
+  !target.isStage && target.isOriginal !== false;
 
 const snapshotOnTargetLifecycle = (vm: VM): void => {
   const startState = getTargetStartState(vm);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -68,6 +68,7 @@ export const swapToStartState = (vm: VM): (() => void) => {
 };
 
 const isTrackableSprite = (target: VM.Target): boolean =>
+  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
   !target.isStage && target.isOriginal !== false;
 
 const patchExtensionManager = (vm: VM): void => {

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -10,7 +10,7 @@ export const patchScratchVm = (vm: VM): void => {
     // modified logic from https://github.com/scratchfoundation/scratch-vm/blob/766c767c7a2f3da432480ade515de0a9f98804ba/src/extension-support/extension-manager.js#L142
 
     if (vm.extensionManager._loadedExtensions.has(id)) {
-      return Promise.resolve(0);
+      return 0;
     }
 
     switch (id) {
@@ -27,7 +27,7 @@ export const patchScratchVm = (vm: VM): void => {
         break;
     }
 
-    return Promise.resolve(0);
+    return 0;
   };
 
   vm.runtime.on("PROJECT_LOADED", () => {

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -28,7 +28,7 @@ const resetTargetsForSerialization = (vm: VM, state: StartState): void => {
 
     const sprite = state.sprites.get(target.id);
     if (!sprite) {
-      continue;
+      return;
     }
 
     restoreSpriteStateForSerialization(target, sprite);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -152,7 +152,7 @@ const snapshotOnGreenFlag = (vm: VM, startState: StartState): void => {
 };
 
 // temporarily swap to start state during serialization to ensure
-// the project is saved with original positions, not changes occured in runtime.
+// the project is saved with original positions, not changes occurred at runtime.
 // immediately restore the current runtime state after serialization.
 const patchSerialization = (vm: VM, startState: StartState): void => {
   const originalToJSON = vm.toJSON.bind(vm);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -22,7 +22,7 @@ const isStageWithStartState = (
   stage: RememberedStageState | undefined,
 ): stage is RememberedStageState => target.isStage && stage !== undefined;
 
-const swapToStartState = (vm: VM, startState: StartState): (() => void) => {
+const resetToStartState = (vm: VM, startState: StartState): (() => void) => {
   // if there is no stage or trackable sprites with start state, we don't need to do anything
   if (startState.sprites.size === 0 && !startState.stage) {
     return () => {};
@@ -133,18 +133,18 @@ const snapshotOnGreenFlag = (vm: VM, startState: StartState): void => {
   };
 };
 
-// temporarily swap to start state during serialization to ensure
+// temporarily reset to start state during serialization to ensure
 // the project is saved with original positions, not changes occured in runtime.
 // immediately restore the current runtime state after serialization.
 const patchSerialization = (vm: VM, startState: StartState): void => {
   const originalToJSON = vm.toJSON.bind(vm);
   vm.toJSON = (optTargetId?: string): string => {
-    const restore = swapToStartState(vm, startState);
+    const undo = resetToStartState(vm, startState);
 
     try {
       return originalToJSON(optTargetId);
     } finally {
-      restore();
+      undo();
     }
   };
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -132,20 +132,19 @@ const snapshotOnGreenFlag = (vm: VM, startState: StartState): void => {
   const originalGreenFlag = vm.greenFlag.bind(vm);
 
   vm.greenFlag = (): void => {
-    // refresh the snapshot to reflect the target state at the moment the
-    // user pressed the green flag, before any script has run
-    clearStartState(startState);
-    for (const target of vm.runtime.targets) {
-      if (target.isStage) {
-        startState.stage = rememberStageState(target);
-        continue;
-      }
+    if (startState.sprites.size === 0 && !startState.stage) {
+      for (const target of vm.runtime.targets) {
+        if (target.isStage) {
+          startState.stage = rememberStageState(target);
+          continue;
+        }
 
-      if (!isTrackableSprite(target)) {
-        continue;
-      }
+        if (!isTrackableSprite(target)) {
+          continue;
+        }
 
-      startState.sprites.set(target.id, rememberSpriteState(target));
+        startState.sprites.set(target.id, rememberSpriteState(target));
+      }
     }
 
     originalGreenFlag();

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -3,6 +3,7 @@ import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
 import {
   RememberedSpriteState,
+  refreshSpriteEditorState,
   rememberSpriteState,
   restoreSpriteStateForSerialization,
 } from "./target-state";
@@ -125,6 +126,26 @@ export const patchScratchVm = (vm: VM): void => {
   // Sprites added or duplicated after project load also need a starting snapshot
   vm.runtime.on("targetWasCreated", (newTarget: VM.Target) => {
     trackTargetStartState(newTarget);
+  });
+
+  // rename and costume changes trigger a TARGETS_UPDATE
+  vm.runtime.on("TARGETS_UPDATE", () => {
+    if (vm.runtime.threads.length > 0) {
+      return;
+    }
+
+    for (const target of vm.runtime.targets) {
+      // skip original and stage targets
+      if (target.isStage || target.isOriginal === false) {
+        continue;
+      }
+
+      const snap = startState.get(target.id);
+
+      if (snap) {
+        refreshSpriteEditorState(snap, target);
+      }
+    }
   });
 
   const originalPostSpriteInfo = vm.postSpriteInfo.bind(vm);

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -136,8 +136,17 @@ const snapshotBeforeHats = (vm: VM, startState: StartState): void => {
     optMatchFields?: Record<string, unknown>,
     optTarget?: VM.Target,
   ): globalThis.VM.Thread[] | undefined => {
-    // snapshot only on the first hat-start of a new run sequence
-    if (startState.sprites.size === 0 && !startState.stage) {
+    const wasIdle = vm.runtime.threads.length === 0;
+    const startedThreads = originalStartHats(
+      requestedHatOpcode,
+      optMatchFields,
+      optTarget,
+    );
+
+    // if the runtime is idle and the threads started by this hat are not empty
+    // we should refresh the start state to reflect the state right before the hat starts running
+    if (wasIdle && startedThreads && startedThreads.length > 0) {
+      clearStartState(startState);
       for (const target of vm.runtime.targets) {
         if (target.isStage) {
           startState.stage = rememberStageState(target);
@@ -152,31 +161,8 @@ const snapshotBeforeHats = (vm: VM, startState: StartState): void => {
       }
     }
 
-    return originalStartHats(requestedHatOpcode, optMatchFields, optTarget);
+    return startedThreads;
   };
-};
-
-/**
- * Clears the start state snapshot on PROJECT_STOP_ALL rather than PROJECT_RUN_STOP because
- * PROJECT_RUN_STOP only fires inside the runtime's step loop,
- * not synchronously from stopAll(). This matters because getSubmission
- * calls stopAll() and then vm.toJSON() in the same turn, before the next
- * step, so a stale snapshot would still be in the map and cause toJSON
- * to serialize the wrong starting state.
- *
- * PROJECT_STOP_ALL fires synchronously inside stopAll() itself, so the
- * snapshot is cleared before toJSON runs. It also covers the green-flag
- * path: greenFlag() calls stopAll() first, so the subsequent startHats
- * always captures a fresh snapshot.
- *
- * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2249 stopAll()}
- * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2251 emits PROJECT_STOP_ALL}
- * @see {@link https://github.com/scratchfoundation/scratch-vm/blob/b3266a0cfe5122f20b72ccd738a3dd4dff4fc5a5/src/engine/runtime.js#L2235 greenFlag() calls stopAll()}
- */
-const clearOnStopAll = (vm: VM, startState: StartState): void => {
-  vm.runtime.on("PROJECT_STOP_ALL", () => {
-    clearStartState(startState);
-  });
 };
 
 // temporarily swap to start state during serialization to ensure
@@ -204,6 +190,5 @@ export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
   initializeTaskBlocksOnLoad(vm, startState);
   snapshotBeforeHats(vm, startState);
-  clearOnStopAll(vm, startState);
   patchSerialization(vm, startState);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -68,7 +68,10 @@ export const swapToStartState = (vm: VM): (() => void) => {
   };
 };
 
-export const patchScratchVm = (vm: VM): void => {
+const isTrackableSprite = (target: VM.Target): boolean =>
+  !target.isStage && target.isOriginal !== false;
+
+const patchExtensionManager = (vm: VM): void => {
   // patch extension manager load function with a custom implementation
   vm.extensionManager.loadExtensionURL = async (
     id: string,
@@ -95,59 +98,10 @@ export const patchScratchVm = (vm: VM): void => {
 
     return 0;
   };
+};
 
+const wrapPostSpriteInfo = (vm: VM): void => {
   const startState = getTargetStartState(vm);
-
-  const trackTargetStartState = (target: VM.Target): void => {
-    if (target.isStage || target.isOriginal === false) {
-      return;
-    }
-
-    startState.set(target.id, rememberSpriteState(target));
-  };
-
-  vm.runtime.on("PROJECT_LOADED", () => {
-    // iterate over all the blocks in the runtime
-    // and mark them as initial blocks
-    for (const target of vm.runtime.targets) {
-      for (const block of Object.values(target.blocks._blocks)) {
-        block.isTaskBlock = vm.taskBlockIds
-          ? vm.taskBlockIds.has(block.id)
-          : true;
-      }
-    }
-
-    startState.clear();
-    for (const target of vm.runtime.targets) {
-      trackTargetStartState(target);
-    }
-  });
-
-  // Sprites added or duplicated after project load also need a starting snapshot
-  vm.runtime.on("targetWasCreated", (newTarget: VM.Target) => {
-    trackTargetStartState(newTarget);
-  });
-
-  // rename and costume changes trigger a TARGETS_UPDATE
-  vm.runtime.on("TARGETS_UPDATE", () => {
-    if (vm.runtime.threads.length > 0) {
-      return;
-    }
-
-    for (const target of vm.runtime.targets) {
-      // skip original and stage targets
-      if (target.isStage || target.isOriginal === false) {
-        continue;
-      }
-
-      const snap = startState.get(target.id);
-
-      if (snap) {
-        refreshSpriteEditorState(snap, target);
-      }
-    }
-  });
-
   const originalPostSpriteInfo = vm.postSpriteInfo.bind(vm);
   vm.postSpriteInfo = (data: VM.PostedSpriteInfo): void => {
     originalPostSpriteInfo(data);
@@ -192,13 +146,77 @@ export const patchScratchVm = (vm: VM): void => {
       snap.rotationStyle = target.rotationStyle;
     }
   };
+};
 
-  // Wrap vm.toJSON so every serialisation path uses the tracked starting
-  // state: saveProjectSb3 (calls this.toJSON internally), exportSprite,
-  // and the direct callers in Controls.tsx (postSolutionRun) and
-  // Blocks.tsx (student activity tracking). Without this, those direct
-  // callers serialise runtime drift caused by scripts and end up sending
-  // the runtime sprite position to the backend as the new starting point.
+const mirrorEditsOnTargetsUpdate = (vm: VM): void => {
+  const startState = getTargetStartState(vm);
+  // rename and costume changes trigger a TARGETS_UPDATE
+  vm.runtime.on("TARGETS_UPDATE", () => {
+    if (vm.runtime.threads.length > 0) {
+      return;
+    }
+
+    for (const target of vm.runtime.targets) {
+      // skip original and stage targets
+      if (!isTrackableSprite(target)) {
+        continue;
+      }
+
+      const snap = startState.get(target.id);
+
+      if (snap) {
+        refreshSpriteEditorState(snap, target);
+      }
+    }
+  });
+};
+
+const wrapEditorMutators = (vm: VM): void => {
+  wrapPostSpriteInfo(vm);
+  mirrorEditsOnTargetsUpdate(vm);
+};
+
+const snapshotOnTargetLifecycle = (vm: VM): void => {
+  const startState = getTargetStartState(vm);
+
+  const trackTargetStartState = (target: VM.Target): void => {
+    if (!isTrackableSprite(target)) {
+      return;
+    }
+
+    startState.set(target.id, rememberSpriteState(target));
+  };
+
+  vm.runtime.on("PROJECT_LOADED", () => {
+    // iterate over all the blocks in the runtime
+    // and mark them as initial blocks
+    for (const target of vm.runtime.targets) {
+      for (const block of Object.values(target.blocks._blocks)) {
+        block.isTaskBlock = vm.taskBlockIds
+          ? vm.taskBlockIds.has(block.id)
+          : true;
+      }
+    }
+
+    startState.clear();
+    for (const target of vm.runtime.targets) {
+      trackTargetStartState(target);
+    }
+  });
+
+  // Sprites added or duplicated after project load also need a starting snapshot
+  vm.runtime.on("targetWasCreated", (newTarget: VM.Target) => {
+    trackTargetStartState(newTarget);
+  });
+};
+
+// Wrap vm.toJSON so every serialisation path uses the tracked starting
+// state: saveProjectSb3 (calls this.toJSON internally), exportSprite,
+// and the direct callers in Controls.tsx (postSolutionRun) and
+// Blocks.tsx (student activity tracking). Without this, those direct
+// callers serialise runtime drift caused by scripts and end up sending
+// the runtime sprite position to the backend as the new starting point.
+const patchSerialization = (vm: VM): void => {
   const originalToJSON = vm.toJSON.bind(vm);
   vm.toJSON = (optTargetId?: string): string => {
     const restore = swapToStartState(vm);
@@ -209,4 +227,11 @@ export const patchScratchVm = (vm: VM): void => {
       restore();
     }
   };
+};
+
+export const patchScratchVm = (vm: VM): void => {
+  patchExtensionManager(vm);
+  snapshotOnTargetLifecycle(vm);
+  wrapEditorMutators(vm);
+  patchSerialization(vm);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -176,6 +176,12 @@ const snapshotBeforeHats = (vm: VM): void => {
   };
 };
 
+const clearOnStopAll = (vm: VM): void => {
+  vm.runtime.on("PROJECT_STOP_ALL", () => {
+    clearStartState(vm);
+  });
+};
+
 // temporarily swap to start state during serialization to ensure
 // the project is saved with original positions, not changes occured in runtime.
 // immediately restore the current runtime state after serialization.
@@ -196,5 +202,6 @@ export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
   initializeTaskBlocksOnLoad(vm);
   snapshotBeforeHats(vm);
+  clearOnStopAll(vm);
   patchSerialization(vm);
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -1,33 +1,24 @@
 import VM from "@scratch/scratch-vm";
 import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
+import {
+  RememberedSpriteState,
+  rememberSpriteState,
+  restoreSpriteStateForSerialization,
+} from "./target-state";
 
-export interface TargetStartState {
-  x: number;
-  y: number;
-  direction: number;
-  size: number;
-  visible: boolean;
-}
-
-const startStateByVm = new Map<VM, Map<string, TargetStartState>>();
-
-const snapshotTarget = (target: VM.Target): TargetStartState =>
-  ({
-    x: target.x,
-    y: target.y,
-    direction: target.direction,
-    size: target.size,
-    visible: target.visible,
-  }) satisfies TargetStartState;
+const startStateByVm = new Map<VM, Map<string, RememberedSpriteState>>();
 
 /**
- * Snapshot on project load and on user-initiated postSpriteInfo calls
- * (stage drag, sprite-info pane). Used by saveCrtProject so that running
- * a script and then saving doesn't introduce runtime differences into the
+ * Snapshot on project load, on `targetWasCreated`, and on user-initiated
+ * postSpriteInfo calls (stage drag, sprite-info pane). Used by the
+ * vm.toJSON wrap below so that running a script and then serialising
+ * doesn't introduce runtime differences into the
  * project as the new starting point.
  */
-export const getTargetStartState = (vm: VM): Map<string, TargetStartState> => {
+export const getTargetStartState = (
+  vm: VM,
+): Map<string, RememberedSpriteState> => {
   let map = startStateByVm.get(vm);
 
   if (!map) {
@@ -38,24 +29,12 @@ export const getTargetStartState = (vm: VM): Map<string, TargetStartState> => {
   return map;
 };
 
-const assignIfPosted = <K extends keyof TargetStartState>(
-  data: VM.PostedSpriteInfo,
-  snap: TargetStartState,
-  target: VM.Target,
-  key: K,
-  expectedType: "number" | "boolean",
-): void => {
-  if (typeof data[key] === expectedType) {
-    snap[key] = target[key];
-  }
-};
-
 /**
  * Temporarily set each target's mutable sprite state to its tracked
  * starting state so the serializer doesn't capture runtime drift caused
  * by scripts. Returns a restore callback.
  *
- * Fields are assigned directly (rather than via target.setXY/setDirection/
+ * Uses `restoreSpriteStateForSerialization`, which assignes directly (rather than via target.setXY/setDirection/
  * setSize/setVisible) so we don't trigger renderer updates or pen draws —
  * the sprite stays visually where the runtime had it.
  */
@@ -65,8 +44,10 @@ export const swapToStartState = (vm: VM): (() => void) => {
     return () => {};
   }
 
-  const runtimeState: Array<{ target: VM.Target; runtime: TargetStartState }> =
-    [];
+  const runtimeState: Array<{
+    target: VM.Target;
+    runtime: RememberedSpriteState;
+  }> = [];
 
   for (const target of vm.runtime.targets) {
     const start = snapshot.get(target.id);
@@ -77,29 +58,15 @@ export const swapToStartState = (vm: VM): (() => void) => {
 
     runtimeState.push({
       target,
-      runtime: {
-        x: target.x,
-        y: target.y,
-        direction: target.direction,
-        size: target.size,
-        visible: target.visible,
-      },
+      runtime: rememberSpriteState(target),
     });
 
-    target.x = start.x;
-    target.y = start.y;
-    target.direction = start.direction;
-    target.size = start.size;
-    target.visible = start.visible;
+    restoreSpriteStateForSerialization(target, start);
   }
 
   return () => {
     for (const { target, runtime } of runtimeState) {
-      target.x = runtime.x;
-      target.y = runtime.y;
-      target.direction = runtime.direction;
-      target.size = runtime.size;
-      target.visible = runtime.visible;
+      restoreSpriteStateForSerialization(target, runtime);
     }
   };
 };
@@ -139,7 +106,7 @@ export const patchScratchVm = (vm: VM): void => {
       return;
     }
 
-    startState.set(target.id, snapshotTarget(target));
+    startState.set(target.id, rememberSpriteState(target));
   };
 
   vm.runtime.on("PROJECT_LOADED", () => {
@@ -180,11 +147,33 @@ export const patchScratchVm = (vm: VM): void => {
       return;
     }
 
-    assignIfPosted(data, snap, target, "x", "number");
-    assignIfPosted(data, snap, target, "y", "number");
-    assignIfPosted(data, snap, target, "direction", "number");
-    assignIfPosted(data, snap, target, "size", "number");
-    assignIfPosted(data, snap, target, "visible", "boolean");
+    if (typeof data.x === "number") {
+      snap.x = target.x;
+    }
+
+    if (typeof data.y === "number") {
+      snap.y = target.y;
+    }
+
+    if (typeof data.direction === "number") {
+      snap.direction = target.direction;
+    }
+
+    if (typeof data.size === "number") {
+      snap.size = target.size;
+    }
+
+    if (typeof data.visible === "boolean") {
+      snap.visible = target.visible;
+    }
+
+    if (typeof data.draggable === "boolean") {
+      snap.draggable = target.draggable;
+    }
+
+    if (typeof data.rotationStyle === "string") {
+      snap.rotationStyle = target.rotationStyle;
+    }
   };
 
   // Wrap vm.toJSON so every serialisation path uses the tracked starting

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -2,6 +2,108 @@ import VM from "@scratch/scratch-vm";
 import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
 
+export interface TargetStartState {
+  x: number;
+  y: number;
+  direction: number;
+  size: number;
+  visible: boolean;
+}
+
+const startStateByVm = new Map<VM, Map<string, TargetStartState>>();
+
+const snapshotTarget = (target: VM.Target): TargetStartState =>
+  ({
+    x: target.x,
+    y: target.y,
+    direction: target.direction,
+    size: target.size,
+    visible: target.visible,
+  }) satisfies TargetStartState;
+
+/**
+ * Snapshot on project load and on user-initiated postSpriteInfo calls
+ * (stage drag, sprite-info pane). Used by saveCrtProject so that running
+ * a script and then saving doesn't introduce runtime differences into the
+ * project as the new starting point.
+ */
+export const getTargetStartState = (vm: VM): Map<string, TargetStartState> => {
+  let map = startStateByVm.get(vm);
+
+  if (!map) {
+    map = new Map();
+    startStateByVm.set(vm, map);
+  }
+
+  return map;
+};
+
+const assignIfPosted = <K extends keyof TargetStartState>(
+  data: VM.PostedSpriteInfo,
+  snap: TargetStartState,
+  target: VM.Target,
+  key: K,
+  expectedType: "number" | "boolean",
+): void => {
+  if (typeof data[key] === expectedType) {
+    snap[key] = target[key];
+  }
+};
+
+/**
+ * Temporarily set each target's mutable sprite state to its tracked
+ * starting state so the serializer doesn't capture runtime drift caused
+ * by scripts. Returns a restore callback.
+ *
+ * Fields are assigned directly (rather than via target.setXY/setDirection/
+ * setSize/setVisible) so we don't trigger renderer updates or pen draws —
+ * the sprite stays visually where the runtime had it.
+ */
+export const swapToStartState = (vm: VM): (() => void) => {
+  const snapshot = getTargetStartState(vm);
+  if (snapshot.size === 0) {
+    return () => {};
+  }
+
+  const runtimeState: Array<{ target: VM.Target; runtime: TargetStartState }> =
+    [];
+
+  for (const target of vm.runtime.targets) {
+    const start = snapshot.get(target.id);
+
+    if (!start) {
+      continue;
+    }
+
+    runtimeState.push({
+      target,
+      runtime: {
+        x: target.x,
+        y: target.y,
+        direction: target.direction,
+        size: target.size,
+        visible: target.visible,
+      },
+    });
+
+    target.x = start.x;
+    target.y = start.y;
+    target.direction = start.direction;
+    target.size = start.size;
+    target.visible = start.visible;
+  }
+
+  return () => {
+    for (const { target, runtime } of runtimeState) {
+      target.x = runtime.x;
+      target.y = runtime.y;
+      target.direction = runtime.direction;
+      target.size = runtime.size;
+      target.visible = runtime.visible;
+    }
+  };
+};
+
 export const patchScratchVm = (vm: VM): void => {
   // patch extension manager load function with a custom implementation
   vm.extensionManager.loadExtensionURL = async (
@@ -30,6 +132,16 @@ export const patchScratchVm = (vm: VM): void => {
     return 0;
   };
 
+  const startState = getTargetStartState(vm);
+
+  const trackTargetStartState = (target: VM.Target): void => {
+    if (target.isStage || target.isOriginal === false) {
+      return;
+    }
+
+    startState.set(target.id, snapshotTarget(target));
+  };
+
   vm.runtime.on("PROJECT_LOADED", () => {
     // iterate over all the blocks in the runtime
     // and mark them as initial blocks
@@ -40,5 +152,55 @@ export const patchScratchVm = (vm: VM): void => {
           : true;
       }
     }
+
+    startState.clear();
+    for (const target of vm.runtime.targets) {
+      trackTargetStartState(target);
+    }
   });
+
+  // Sprites added or duplicated after project load also need a starting snapshot
+  vm.runtime.on("targetWasCreated", (newTarget: VM.Target) => {
+    trackTargetStartState(newTarget);
+  });
+
+  const originalPostSpriteInfo = vm.postSpriteInfo.bind(vm);
+  vm.postSpriteInfo = (data: VM.PostedSpriteInfo): void => {
+    originalPostSpriteInfo(data);
+
+    const target = vm._dragTarget ?? vm.editingTarget;
+
+    if (!target || target.isStage) {
+      return;
+    }
+
+    const snap = startState.get(target.id);
+
+    if (!snap) {
+      return;
+    }
+
+    assignIfPosted(data, snap, target, "x", "number");
+    assignIfPosted(data, snap, target, "y", "number");
+    assignIfPosted(data, snap, target, "direction", "number");
+    assignIfPosted(data, snap, target, "size", "number");
+    assignIfPosted(data, snap, target, "visible", "boolean");
+  };
+
+  // Wrap vm.toJSON so every serialisation path uses the tracked starting
+  // state: saveProjectSb3 (calls this.toJSON internally), exportSprite,
+  // and the direct callers in Controls.tsx (postSolutionRun) and
+  // Blocks.tsx (student activity tracking). Without this, those direct
+  // callers serialise runtime drift caused by scripts and end up sending
+  // the runtime sprite position to the backend as the new starting point.
+  const originalToJSON = vm.toJSON.bind(vm);
+  vm.toJSON = (optTargetId?: string): string => {
+    const restore = swapToStartState(vm);
+
+    try {
+      return originalToJSON(optTargetId);
+    } finally {
+      restore();
+    }
+  };
 };

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -2,12 +2,9 @@ import VM from "@scratch/scratch-vm";
 import { ExtensionId } from "../extensions";
 import AssertionExtension from "../extensions/assertions";
 import {
-  RememberedSpriteState,
   RememberedStageState,
   StartState,
   backupTargetsState,
-  rememberSpriteState,
-  rememberStageState,
   restoreSpriteStateForSerialization,
   restoreStageStateForSerialization,
 } from "./target-state";
@@ -22,58 +19,35 @@ const isStageWithStartState = (
   stage: RememberedStageState | undefined,
 ): stage is RememberedStageState => target.isStage && stage !== undefined;
 
+const resetTargetsForSerialization = (vm: VM, state: StartState): void => {
+  for (const target of vm.runtime.targets) {
+    if (isStageWithStartState(target, state.stage)) {
+      restoreStageStateForSerialization(target, state.stage);
+      continue;
+    }
+
+    const sprite = state.sprites.get(target.id);
+    if (!sprite) {
+      continue;
+    }
+
+    restoreSpriteStateForSerialization(target, sprite);
+  }
+};
+
 const resetToStartState = (vm: VM, startState: StartState): (() => void) => {
   // if there is no stage or trackable sprites with start state, we don't need to do anything
   if (startState.sprites.size === 0 && !startState.stage) {
     return () => {};
   }
 
-  const spriteRuntimeState: Array<{
-    target: VM.Target;
-    runtime: RememberedSpriteState;
-  }> = [];
+  // snapshot the live runtime so we can put it back after serialization
+  const runtimeState: StartState = { sprites: new Map(), stage: undefined };
+  backupTargetsState(vm, runtimeState);
 
-  let stageRuntime: {
-    target: VM.Target;
-    runtime: RememberedStageState;
-  } | null = null;
+  resetTargetsForSerialization(vm, startState);
 
-  for (const target of vm.runtime.targets) {
-    if (isStageWithStartState(target, startState.stage)) {
-      // store the current stage state before restoring so we can put it back later
-      stageRuntime = { target, runtime: rememberStageState(target) };
-      restoreStageStateForSerialization(target, startState.stage);
-      continue;
-    }
-
-    const start = startState.sprites.get(target.id);
-
-    if (!start) {
-      continue;
-    }
-
-    spriteRuntimeState.push({
-      target,
-      runtime: rememberSpriteState(target),
-    });
-
-    restoreSpriteStateForSerialization(target, start);
-  }
-
-  return () => {
-    // restore the current runtime state after serialisation
-    for (const { target, runtime } of spriteRuntimeState) {
-      restoreSpriteStateForSerialization(target, runtime);
-    }
-
-    // restore the stage state after serialisation if we modified it
-    if (stageRuntime) {
-      restoreStageStateForSerialization(
-        stageRuntime.target,
-        stageRuntime.runtime,
-      );
-    }
-  };
+  return () => resetTargetsForSerialization(vm, runtimeState);
 };
 
 const patchExtensionManager = (vm: VM): void => {

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -6,9 +6,7 @@ import {
   RememberedStageState,
   rememberSpriteState,
   rememberStageState,
-  restoreSpriteStateForExecution,
   restoreSpriteStateForSerialization,
-  restoreStageStateForExecution,
   restoreStageStateForSerialization,
 } from "./target-state";
 
@@ -178,30 +176,6 @@ const snapshotBeforeHats = (vm: VM): void => {
   };
 };
 
-const resetOnRunStop = (vm: VM): void => {
-  const sprites = getSpriteStartState(vm);
-
-  vm.runtime.on("PROJECT_RUN_STOP", () => {
-    const stage = stageStartStateByVm.get(vm);
-
-    for (const target of vm.runtime.targets) {
-      if (isStageWithStartState(target, vm, stage)) {
-        restoreStageStateForExecution(target, stage);
-        continue;
-      }
-
-      const snap = sprites.get(target.id);
-
-      if (snap) {
-        // restore all sprites & stage to the state they had when the project started running
-        restoreSpriteStateForExecution(target, snap);
-      }
-    }
-
-    clearStartState(vm);
-  });
-};
-
 // temporarily swap to start state during serialization to ensure
 // the project is saved with original positions, not changes occured in runtime.
 // immediately restore the current runtime state after serialization.
@@ -222,6 +196,5 @@ export const patchScratchVm = (vm: VM): void => {
   patchExtensionManager(vm);
   initializeTaskBlocksOnLoad(vm);
   snapshotBeforeHats(vm);
-  resetOnRunStop(vm);
   patchSerialization(vm);
 };

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -135,7 +135,7 @@ export const backupTargetsState = (vm: VM, startState: StartState): void => {
     }
 
     // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
-    if (!target.isStage && target.isOriginal !== false) {
+    if (target.isOriginal === false) {
       continue;
     }
 

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -101,15 +101,6 @@ export const restoreStageStateForSerialization = (
   target._customState = cloneCustomState(state.customState);
 };
 
-export const refreshSpriteEditorState = (
-  snap: RememberedSpriteState,
-  target: VM.Target,
-): void => {
-  snap.name = target.getName();
-  snap.currentCostume = target.currentCostume;
-  snap.volume = target.volume;
-};
-
 export const restoreSpriteStateForSerialization = (
   target: VM.Target,
   state: RememberedSpriteState,

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -123,10 +123,6 @@ export interface StartState {
   stage: RememberedStageState | undefined;
 }
 
-export const isTrackableSprite = (target: VM.Target): boolean =>
-  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
-  !target.isStage && target.isOriginal !== false;
-
 export const backupTargetsState = (vm: VM, startState: StartState): void => {
   if (startState.sprites.size !== 0 || startState.stage) {
     return;
@@ -138,7 +134,8 @@ export const backupTargetsState = (vm: VM, startState: StartState): void => {
       continue;
     }
 
-    if (!isTrackableSprite(target)) {
+    // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
+    if (!target.isStage && target.isOriginal !== false) {
       continue;
     }
 

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -1,0 +1,115 @@
+import VM from "@scratch/scratch-vm";
+
+/**
+ * https://github.com/scratchfoundation/scratch-vm/blob/766c767c7a2f3da432480ade515de0a9f98804ba/src/serialization/sb3.js#L470-L500
+ */
+export interface RememberedTargetState {
+  currentCostume: number;
+  volume: number;
+  customState: Partial<VM.CustomState>;
+}
+
+export interface RememberedStageState extends RememberedTargetState {
+  tempo: number;
+  videoTransparency: number;
+}
+
+export interface RememberedSpriteState extends RememberedTargetState {
+  name: string;
+  x: number;
+  y: number;
+  size: number;
+  direction: number;
+  visible: boolean;
+  draggable: boolean;
+  rotationStyle: VM.RotationStyle;
+  layerOrder: number;
+}
+
+export const rememberStageState = (
+  target: VM.Target,
+): RememberedStageState => ({
+  currentCostume: target.currentCostume,
+  volume: target.volume,
+  tempo: target.tempo,
+  videoTransparency: target.videoTransparency,
+  customState: target._customState,
+});
+
+export const rememberSpriteState = (
+  target: VM.Target,
+): RememberedSpriteState => ({
+  currentCostume: target.currentCostume,
+  volume: target.volume,
+  name: target.getName(),
+  x: target.x,
+  y: target.y,
+  size: target.size,
+  direction: target.direction,
+  visible: target.visible,
+  draggable: target.draggable,
+  rotationStyle: target.rotationStyle,
+  layerOrder: target.getLayerOrder(),
+  customState: target._customState,
+});
+
+export const restoreStageStateForExecution = (
+  target: VM.Target,
+  state: RememberedStageState,
+): void => {
+  target.setCostume(state.currentCostume);
+  target.volume = state.volume;
+  target.tempo = state.tempo;
+  target.videoTransparency = state.videoTransparency;
+  target._customState = state.customState;
+};
+
+export const restoreSpriteStateForExecution = (
+  target: VM.Target,
+  state: RememberedSpriteState,
+): void => {
+  target.setCostume(state.currentCostume);
+  target.volume = state.volume;
+  target.sprite.name = state.name;
+  target.setXY(state.x, state.y);
+  target.setSize(state.size);
+  target.setDirection(state.direction);
+  target.setVisible(state.visible);
+  target.setDraggable(state.draggable);
+  target.setRotationStyle(state.rotationStyle);
+  // see https://github.com/scratchfoundation/scratch-vm/blob/bb1659e1f42de5bd28d7233c8e418c4e536a2bf0/src/sprites/rendered-target.js#L850
+  target.renderer?.setDrawableOrder(
+    target.drawableID,
+    state.layerOrder,
+    "sprite",
+  );
+  target._customState = state.customState;
+};
+
+export const restoreStageStateForSerialization = (
+  target: VM.Target,
+  state: RememberedStageState,
+): void => {
+  target.currentCostume = state.currentCostume;
+  target.volume = state.volume;
+  target.tempo = state.tempo;
+  target.videoTransparency = state.videoTransparency;
+  target._customState = state.customState;
+};
+
+export const restoreSpriteStateForSerialization = (
+  target: VM.Target,
+  state: RememberedSpriteState,
+): void => {
+  target.currentCostume = state.currentCostume;
+  target.volume = state.volume;
+  target.sprite.name = state.name;
+  target.x = state.x;
+  target.y = state.y;
+  target.size = state.size;
+  target.direction = state.direction;
+  target.visible = state.visible;
+  target.draggable = state.draggable;
+  target.rotationStyle = state.rotationStyle;
+  target._customState = state.customState;
+};

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -101,6 +101,15 @@ export const restoreStageStateForSerialization = (
   target._customState = cloneCustomState(state.customState);
 };
 
+export const refreshSpriteEditorState = (
+  snap: RememberedSpriteState,
+  target: VM.Target,
+): void => {
+  snap.name = target.getName();
+  snap.currentCostume = target.currentCostume;
+  snap.volume = target.volume;
+};
+
 export const restoreSpriteStateForSerialization = (
   target: VM.Target,
   state: RememberedSpriteState,

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -117,3 +117,31 @@ export const restoreSpriteStateForSerialization = (
   target.rotationStyle = state.rotationStyle;
   target._customState = cloneCustomState(state.customState);
 };
+
+export interface StartState {
+  sprites: Map<string, RememberedSpriteState>;
+  stage: RememberedStageState | undefined;
+}
+
+export const isTrackableSprite = (target: VM.Target): boolean =>
+  // track every sprite the project file defines whether shown or hidden, skip the stage and runtime clones.
+  !target.isStage && target.isOriginal !== false;
+
+export const backupTargetsState = (vm: VM, startState: StartState): void => {
+  if (startState.sprites.size !== 0 || startState.stage) {
+    return;
+  }
+
+  for (const target of vm.runtime.targets) {
+    if (target.isStage) {
+      startState.stage = rememberStageState(target);
+      continue;
+    }
+
+    if (!isTrackableSprite(target)) {
+      continue;
+    }
+
+    startState.sprites.set(target.id, rememberSpriteState(target));
+  }
+};

--- a/apps/scratch/src/vm/target-state.ts
+++ b/apps/scratch/src/vm/target-state.ts
@@ -26,6 +26,10 @@ export interface RememberedSpriteState extends RememberedTargetState {
   layerOrder: number;
 }
 
+const cloneCustomState = (
+  customState: Partial<VM.CustomState>,
+): Partial<VM.CustomState> => structuredClone(customState);
+
 export const rememberStageState = (
   target: VM.Target,
 ): RememberedStageState => ({
@@ -33,7 +37,7 @@ export const rememberStageState = (
   volume: target.volume,
   tempo: target.tempo,
   videoTransparency: target.videoTransparency,
-  customState: target._customState,
+  customState: cloneCustomState(target._customState),
 });
 
 export const rememberSpriteState = (
@@ -50,7 +54,7 @@ export const rememberSpriteState = (
   draggable: target.draggable,
   rotationStyle: target.rotationStyle,
   layerOrder: target.getLayerOrder(),
-  customState: target._customState,
+  customState: cloneCustomState(target._customState),
 });
 
 export const restoreStageStateForExecution = (
@@ -61,7 +65,7 @@ export const restoreStageStateForExecution = (
   target.volume = state.volume;
   target.tempo = state.tempo;
   target.videoTransparency = state.videoTransparency;
-  target._customState = state.customState;
+  target._customState = cloneCustomState(state.customState);
 };
 
 export const restoreSpriteStateForExecution = (
@@ -83,7 +87,7 @@ export const restoreSpriteStateForExecution = (
     state.layerOrder,
     "sprite",
   );
-  target._customState = state.customState;
+  target._customState = cloneCustomState(state.customState);
 };
 
 export const restoreStageStateForSerialization = (
@@ -94,7 +98,7 @@ export const restoreStageStateForSerialization = (
   target.volume = state.volume;
   target.tempo = state.tempo;
   target.videoTransparency = state.videoTransparency;
-  target._customState = state.customState;
+  target._customState = cloneCustomState(state.customState);
 };
 
 export const restoreSpriteStateForSerialization = (
@@ -111,5 +115,5 @@ export const restoreSpriteStateForSerialization = (
   target.visible = state.visible;
   target.draggable = state.draggable;
   target.rotationStyle = state.rotationStyle;
-  target._customState = state.customState;
+  target._customState = cloneCustomState(state.customState);
 };

--- a/apps/scratch/types/scratch-vm.d.ts
+++ b/apps/scratch/types/scratch-vm.d.ts
@@ -112,6 +112,8 @@ declare namespace VMExtended {
   }
 
   export type RotationStyle = VM.RotationStyle;
+  export type Target = VM.Target;
+  export type PostedSpriteInfo = VM.PostedSpriteInfo;
 
   type CrtBlock = import("../src/types/scratch-vm-custom").CrtBlock;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes sprites and stage not resetting after reload by snapshotting the start state on Green Flag and using it during serialization. Addresses CRT-414 so runtime changes no longer redefine the saved starting point.

- Bug Fixes
  - Snapshot stage and original sprites on Green Flag before scripts run; exclude clones; clear snapshot on project load.
  - On save, temporarily restore start state (costume, position, size, direction, visible, layer order, volume, tempo, draggable, rotation style, custom state), then restore live runtime.
  - Add `vm/target-state` helpers and use them in assertions to reset state for test execution.
  - Deep-copy `_customState` during snapshot/restore to avoid mutation bleed.
  - Align with `@scratch/scratch-vm`: `loadExtensionURL` returns `0`; export `Target` and `PostedSpriteInfo` types; default `enableStageInteractions` to false in config and UI.

<sup>Written for commit b726f6fdb22e66128a4a8277d4dfe6ccde4ca3bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

