### PR TITLE
[CRT-413] Student don't show up in progress report until they click "Submit"

### DIFF
--- a/frontend/src/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses.ts
+++ b/frontend/src/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses.ts
@@ -1,0 +1,50 @@
+import useSWR from "swr";
+import { ApiResponse } from "../helpers";
+import { getSolutionsControllerFindCurrentAnalysesV0Url } from "../../generated/endpoints/solutions/solutions";
+import { useClassSession } from "../sessions/useClassSession";
+import { useAuthenticationOptions } from "../authentication/useAuthenticationOptions";
+import {
+  fetchSolutionsAndTransform,
+  GetCurrentAnalysisReturnType,
+} from "./useCurrentSessionTaskSolutions";
+
+export const allTasksPlaceholder = -1;
+
+type SessionAnalyses = {
+  taskId: number;
+  analyses: GetCurrentAnalysisReturnType;
+};
+
+export const useAllSessionCurrentAnalyses = (
+  classId: number,
+  sessionId: number,
+): ApiResponse<SessionAnalyses[], Error> => {
+  const authOptions = useAuthenticationOptions();
+  const { data } = useClassSession(classId, sessionId);
+
+  return useSWR(
+    data &&
+      getSolutionsControllerFindCurrentAnalysesV0Url(
+        classId,
+        sessionId,
+        allTasksPlaceholder /* use placeholder to represent 'all'*/,
+        {},
+      ),
+    () =>
+      data
+        ? Promise.all(
+            data.tasks.map((task) =>
+              fetchSolutionsAndTransform(
+                authOptions,
+                classId,
+                sessionId,
+                task.id,
+              ).then(
+                (analyses) =>
+                  ({ taskId: task.id, analyses }) as SessionAnalyses,
+              ),
+            ),
+          )
+        : Promise.resolve([] as SessionAnalyses[]),
+  );
+};

--- a/frontend/src/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses.ts
+++ b/frontend/src/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses.ts
@@ -7,8 +7,7 @@ import {
   fetchSolutionsAndTransform,
   GetCurrentAnalysisReturnType,
 } from "./useCurrentSessionTaskSolutions";
-
-export const allTasksPlaceholder = -1;
+import { allTasksPlaceholder } from "./useAllSessionSolutions";
 
 type SessionAnalyses = {
   taskId: number;

--- a/frontend/src/api/collimator/hooks/solutions/useRevalidateSolutionList.ts
+++ b/frontend/src/api/collimator/hooks/solutions/useRevalidateSolutionList.ts
@@ -39,6 +39,15 @@ export const useRevalidateSolutionList = (): ((
           allTasksPlaceholder,
         ),
       );
+
+      mutate(
+        getSolutionsControllerFindCurrentAnalysesV0Url(
+          classId,
+          sessionId,
+          allTasksPlaceholder,
+          {},
+        ),
+      );
     },
     [mutate],
   );

--- a/frontend/src/components/dashboard/ProgressList.tsx
+++ b/frontend/src/components/dashboard/ProgressList.tsx
@@ -5,7 +5,6 @@ import { HStack, Icon, Link, Status, Text } from "@chakra-ui/react";
 import { LuHand } from "react-icons/lu";
 import { ColumnDef } from "@tanstack/react-table";
 import { useAllSessionSolutions } from "@/api/collimator/hooks/solutions/useAllSessionSolutions";
-import { useAllSessionCurrentAnalyses } from "@/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import { ClassStudent } from "@/api/collimator/models/classes/class-student";
@@ -17,6 +16,7 @@ import MultiSwrContent from "../MultiSwrContent";
 import { StudentName } from "../encryption/StudentName";
 import ChakraDataTable, { ColumnSize } from "../ChakraDataTable";
 import { EmptyState } from "../EmptyState";
+import { useAllSessionCurrentAnalyses } from "@/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses";
 
 const ProgressListWrapper = styled.div`
   margin: 1rem 0;

--- a/frontend/src/components/dashboard/ProgressList.tsx
+++ b/frontend/src/components/dashboard/ProgressList.tsx
@@ -5,10 +5,12 @@ import { HStack, Icon, Link, Status, Text } from "@chakra-ui/react";
 import { LuHand } from "react-icons/lu";
 import { ColumnDef } from "@tanstack/react-table";
 import { useAllSessionSolutions } from "@/api/collimator/hooks/solutions/useAllSessionSolutions";
+import { useAllSessionCurrentAnalyses } from "@/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import { ClassStudent } from "@/api/collimator/models/classes/class-student";
 import { ExistingStudentSolution } from "@/api/collimator/models/solutions/existing-student-solutions";
+import { CurrentStudentAnalysis } from "@/api/collimator/models/solutions/current-student-analysis";
 import { ColumnType } from "@/types/tanstack-types";
 import { ProgressMessages } from "@/i18n/progress-messages";
 import MultiSwrContent from "../MultiSwrContent";
@@ -195,6 +197,11 @@ const ProgressList = ({
     isLoading: isLoadingSolutions,
   } = useAllSessionSolutions(classId, sessionId);
 
+  const { data: currentAnalyses } = useAllSessionCurrentAnalyses(
+    classId,
+    sessionId,
+  );
+
   const studentIds = useMemo(() => {
     if (!klass || !solutions) {
       return [];
@@ -203,9 +210,17 @@ const ProgressList = ({
     const studentIdsSet = new Set([
       ...klass.students.map((student) => student.studentId),
       ...solutions.flatMap((s) => s.solutions.map((s) => s.studentId)),
+      ...(currentAnalyses ?? []).flatMap((s) =>
+        s.analyses
+          .filter(
+            (a): a is CurrentStudentAnalysis =>
+              a instanceof CurrentStudentAnalysis,
+          )
+          .map((a) => a.studentId),
+      ),
     ]);
     return [...studentIdsSet];
-  }, [klass, solutions]);
+  }, [klass, solutions, currentAnalyses]);
 
   const progress = useMemo(() => {
     if (!klass || !session || !solutions) {

--- a/frontend/src/components/dashboard/ProgressList.tsx
+++ b/frontend/src/components/dashboard/ProgressList.tsx
@@ -12,11 +12,11 @@ import { ExistingStudentSolution } from "@/api/collimator/models/solutions/exist
 import { CurrentStudentAnalysis } from "@/api/collimator/models/solutions/current-student-analysis";
 import { ColumnType } from "@/types/tanstack-types";
 import { ProgressMessages } from "@/i18n/progress-messages";
+import { useAllSessionCurrentAnalyses } from "@/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses";
 import MultiSwrContent from "../MultiSwrContent";
 import { StudentName } from "../encryption/StudentName";
 import ChakraDataTable, { ColumnSize } from "../ChakraDataTable";
 import { EmptyState } from "../EmptyState";
-import { useAllSessionCurrentAnalyses } from "@/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses";
 
 const ProgressListWrapper = styled.div`
   margin: 1rem 0;

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -115,11 +115,13 @@ const TaskTemplate = ({
   );
 
   const status = useMemo(() => {
-    if (!solutionToDisplay) {
+    if (!solutionToDisplay && !rowData.currentAnalysis) {
       // if solution has an analysis then it should be displayed as in progress
-      return rowData.currentAnalysis
-        ? TaskStatus.incomplete
-        : TaskStatus.notStarted;
+      return TaskStatus.notStarted;
+    }
+
+    if (!solutionToDisplay) {
+      return TaskStatus.incomplete;
     }
 
     if (solutionToDisplay.tests.every((test) => test.passed)) {
@@ -130,8 +132,13 @@ const TaskTemplate = ({
   }, [solutionToDisplay, rowData.currentAnalysis]);
 
   const color = useMemo((): StatusColor => {
+    if (!solutionToDisplay && !rowData.currentAnalysis) {
+      // if solution has an analysis then it should be displayed as in progress
+      return "neutral";
+    }
+
     if (!solutionToDisplay) {
-      return rowData.currentAnalysis ? "error" : "neutral";
+      return "error";
     }
 
     if (solutionToDisplay.tests.every((test) => test.passed)) {

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -240,9 +240,9 @@ const TaskInstanceProgressList = ({
       );
 
       // A student is either already in the showcase (teacher needs to unstar)
-      // or not yet (teacher needs to star). findShowcaseAnalysis prefers the
-      // starred analysis so the button reflects the current state and allows
-      // removal; falls back to the latest non-reference analysis to add it.
+      // or not yet (teacher needs to star). findAnalysisToDisplay returns the
+      // latest non-starred analysis so the button is starrable.
+      // It falls back to the starred analysis when that's all the student has.
       const currentAnalysis = CurrentStudentAnalysis.findAnalysisToDisplay(
         currentAnalyses ?? [],
         student.studentId,

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -116,7 +116,10 @@ const TaskTemplate = ({
 
   const status = useMemo(() => {
     if (!solutionToDisplay) {
-      return TaskStatus.notStarted;
+      // if solution has an analysis then it should be displayed as in progress
+      return rowData.currentAnalysis
+        ? TaskStatus.incomplete
+        : TaskStatus.notStarted;
     }
 
     if (solutionToDisplay.tests.every((test) => test.passed)) {
@@ -124,11 +127,11 @@ const TaskTemplate = ({
     }
 
     return TaskStatus.incomplete;
-  }, [solutionToDisplay]);
+  }, [solutionToDisplay, rowData.currentAnalysis]);
 
   const color = useMemo((): StatusColor => {
     if (!solutionToDisplay) {
-      return "neutral";
+      return rowData.currentAnalysis ? "error" : "neutral";
     }
 
     if (solutionToDisplay.tests.every((test) => test.passed)) {
@@ -136,7 +139,7 @@ const TaskTemplate = ({
     }
 
     return "error";
-  }, [solutionToDisplay]);
+  }, [solutionToDisplay, rowData.currentAnalysis]);
 
   const statusText = useMemo(() => {
     switch (status) {

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -204,9 +204,15 @@ const TaskInstanceProgressList = ({
     const studentIdsSet = new Set([
       ...klass.students.map((student) => student.studentId),
       ...solutions.map((s) => s.studentId),
+      ...(currentAnalyses ?? [])
+        .filter(
+          (a): a is CurrentStudentAnalysis =>
+            a instanceof CurrentStudentAnalysis,
+        )
+        .map((a) => a.studentId),
     ]);
     return [...studentIdsSet];
-  }, [klass, solutions]);
+  }, [klass, solutions, currentAnalyses]);
 
   const progress = useMemo(() => {
     if (!klass || !session || !solutions) {

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -120,11 +120,7 @@ const TaskTemplate = ({
       return TaskStatus.notStarted;
     }
 
-    if (!solutionToDisplay) {
-      return TaskStatus.incomplete;
-    }
-
-    if (solutionToDisplay.tests.every((test) => test.passed)) {
+    if (solutionToDisplay && solutionToDisplay.tests.every((t) => t.passed)) {
       return TaskStatus.complete;
     }
 
@@ -137,11 +133,7 @@ const TaskTemplate = ({
       return "neutral";
     }
 
-    if (!solutionToDisplay) {
-      return "error";
-    }
-
-    if (solutionToDisplay.tests.every((test) => test.passed)) {
+    if (solutionToDisplay && solutionToDisplay.tests.every((t) => t.passed)) {
       return "success";
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes progress reports so students who start an analysis appear and are marked In Progress before submitting, and auto-refreshes the list after submit. Addresses CRT-413.

- **Bug Fixes**
  - Add `useAllSessionCurrentAnalyses` in progress lists to include students with active analyses across tasks.
  - Update status/color and deps: analyses-only -> In Progress (error); memo deps include `currentAnalyses`/`rowData.currentAnalysis`; `findAnalysisToDisplay` prefers latest non-starred (fallback to starred).
  - Revalidate cached “current analyses” after submit via `useRevalidateSolutionList`; reuse `allTasksPlaceholder` when building current-analyses URLs.

<sup>Written for commit 65d8ae08e614ab3d0ca91be3cc1a5fc03e8fc275. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

