### PR TITLE
[CRT-415] Restrict showcase sortable list input drag to vertical & parent element

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "@chakra-ui/react": "^3.28.0",
     "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",

--- a/frontend/src/components/form/SortableList.tsx
+++ b/frontend/src/components/form/SortableList.tsx
@@ -13,6 +13,10 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import {
+  restrictToVerticalAxis,
+  restrictToParentElement,
+} from "@dnd-kit/modifiers";
 import { useCallback } from "react";
 import styled from "@emotion/styled";
 
@@ -96,6 +100,7 @@ const SortableListInput = <TItem extends { id: number | string }>({
         sensors={sensors}
         collisionDetection={closestCenter}
         onDragEnd={handleDragEnd}
+        modifiers={[restrictToVerticalAxis, restrictToParentElement]}
       >
         <SortableContext items={items} strategy={verticalListSortingStrategy}>
           <ItemList noGap={noGap}>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -872,6 +872,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@dnd-kit/modifiers@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@dnd-kit/modifiers@npm:9.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.3.0
+    react: ">=16.8.0"
+  checksum: 10c0/ca8cc9da8296df10774d779c1611074dc327ccc3c49041c102111c98c7f2b2b73b6af5209c0eef6b2fe978ac63dc2a985efa87c85a8d786577304bd2e64cee1d
+  languageName: node
+  linkType: hard
+
 "@dnd-kit/sortable@npm:^10.0.0":
   version: 10.0.0
   resolution: "@dnd-kit/sortable@npm:10.0.0"
@@ -7915,6 +7928,7 @@ __metadata:
   dependencies:
     "@chakra-ui/react": "npm:^3.28.0"
     "@dnd-kit/core": "npm:^6.3.1"
+    "@dnd-kit/modifiers": "npm:^9.0.0"
     "@dnd-kit/sortable": "npm:^10.0.0"
     "@emotion/react": "npm:^11.14.0"
     "@emotion/styled": "npm:^11.14.0"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lock the showcase sortable list drag to vertical-only within its parent to stop out-of-bound scrolling and drops. Addresses CRT-415.

- **Bug Fixes**
  - Applied `restrictToVerticalAxis` and `restrictToParentElement` from `@dnd-kit/modifiers` to `DndContext` to constrain dragging to the vertical axis and parent bounds.

- **Dependencies**
  - Added `@dnd-kit/modifiers`.

<sup>Written for commit 51a09e09d8e0d7da4424d4f0cfa49637e2a804dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

