### PR TITLE
[CRT-421] Clicking past solutions star removes them all

### DIFF
--- a/frontend/content/compiled-locales/en.json
+++ b/frontend/content/compiled-locales/en.json
@@ -2747,6 +2747,48 @@
       "value": "Number of passed tests"
     }
   ],
+  "UnstarPastSolutionsButton.ariaLabel": [
+    {
+      "type": 0,
+      "value": "Remove all previously starred solutions"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.body": [
+    {
+      "type": 0,
+      "value": "This will remove all previously starred solutions for this student. This action cannot be undone. Are you sure you want to continue?"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.cancel": [
+    {
+      "type": 0,
+      "value": "Cancel"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.confirm": [
+    {
+      "type": 0,
+      "value": "Remove"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.title": [
+    {
+      "type": 0,
+      "value": "Remove previously starred solutions"
+    }
+  ],
+  "UnstarPastSolutionsButton.errorToast": [
+    {
+      "type": 0,
+      "value": "There was an error removing previously starred solutions. Please try again!"
+    }
+  ],
+  "UnstarPastSolutionsButton.successToast": [
+    {
+      "type": 0,
+      "value": "Previously starred solutions removed."
+    }
+  ],
   "UserActions.copyRegistrationTokenSuccess": [
     {
       "type": 0,

--- a/frontend/content/compiled-locales/fr.json
+++ b/frontend/content/compiled-locales/fr.json
@@ -3211,6 +3211,48 @@
       "value": "Nombre de tests réussis"
     }
   ],
+  "UnstarPastSolutionsButton.ariaLabel": [
+    {
+      "type": 0,
+      "value": "Supprimer toutes les solutions précédemment étoilées"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.body": [
+    {
+      "type": 0,
+      "value": "Cette action supprimera toutes les solutions précédemment étoilées pour cet élève. Cette action est irréversible. Êtes-vous sûr de vouloir continuer ?"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.cancel": [
+    {
+      "type": 0,
+      "value": "Annuler"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.confirm": [
+    {
+      "type": 0,
+      "value": "Supprimer"
+    }
+  ],
+  "UnstarPastSolutionsButton.confirm.title": [
+    {
+      "type": 0,
+      "value": "Supprimer les solutions précédemment étoilées"
+    }
+  ],
+  "UnstarPastSolutionsButton.errorToast": [
+    {
+      "type": 0,
+      "value": "Une erreur est survenue lors de la suppression des solutions précédemment étoilées. Veuillez réessayer !"
+    }
+  ],
+  "UnstarPastSolutionsButton.successToast": [
+    {
+      "type": 0,
+      "value": "Solutions précédemment étoilées supprimées."
+    }
+  ],
   "UserActions.copyRegistrationTokenSuccess": [
     {
       "type": 0,

--- a/frontend/content/locales/en.json
+++ b/frontend/content/locales/en.json
@@ -1295,6 +1295,27 @@
   "TestCriterionFilterForm.count": {
     "message": "Number of passed tests"
   },
+  "UnstarPastSolutionsButton.ariaLabel": {
+    "message": "Remove all previously starred solutions"
+  },
+  "UnstarPastSolutionsButton.confirm.body": {
+    "message": "This will remove all previously starred solutions for this student. This action cannot be undone. Are you sure you want to continue?"
+  },
+  "UnstarPastSolutionsButton.confirm.cancel": {
+    "message": "Cancel"
+  },
+  "UnstarPastSolutionsButton.confirm.confirm": {
+    "message": "Remove"
+  },
+  "UnstarPastSolutionsButton.confirm.title": {
+    "message": "Remove previously starred solutions"
+  },
+  "UnstarPastSolutionsButton.errorToast": {
+    "message": "There was an error removing previously starred solutions. Please try again!"
+  },
+  "UnstarPastSolutionsButton.successToast": {
+    "message": "Previously starred solutions removed."
+  },
   "UserActions.copyRegistrationTokenSuccess": {
     "message": "Registration link copied to clipboard"
   },

--- a/frontend/content/locales/fr.json
+++ b/frontend/content/locales/fr.json
@@ -1535,6 +1535,27 @@
   "TestCriterionFilterForm.count": {
     "message": "Nombre de tests réussis"
   },
+  "UnstarPastSolutionsButton.ariaLabel": {
+    "message": "Supprimer toutes les solutions précédemment étoilées"
+  },
+  "UnstarPastSolutionsButton.confirm.body": {
+    "message": "Cette action supprimera toutes les solutions précédemment étoilées pour cet élève. Cette action est irréversible. Êtes-vous sûr de vouloir continuer ?"
+  },
+  "UnstarPastSolutionsButton.confirm.cancel": {
+    "message": "Annuler"
+  },
+  "UnstarPastSolutionsButton.confirm.confirm": {
+    "message": "Supprimer"
+  },
+  "UnstarPastSolutionsButton.confirm.title": {
+    "message": "Supprimer les solutions précédemment étoilées"
+  },
+  "UnstarPastSolutionsButton.errorToast": {
+    "message": "Une erreur est survenue lors de la suppression des solutions précédemment étoilées. Veuillez réessayer !"
+  },
+  "UnstarPastSolutionsButton.successToast": {
+    "message": "Solutions précédemment étoilées supprimées."
+  },
   "UserActions.copyRegistrationTokenSuccess": {
     "message": "Lien d’inscription copié dans le presse-papiers"
   },

--- a/frontend/src/components/solution/UnstarPastSolutionsButton.tsx
+++ b/frontend/src/components/solution/UnstarPastSolutionsButton.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import { defineMessages, useIntl } from "react-intl";
+import { Icon } from "@chakra-ui/react";
+import { LuStar } from "react-icons/lu";
+import Button from "../Button";
+import { ExistingStudentSolution } from "@/api/collimator/models/solutions/existing-student-solutions";
+import { usePatchStudentSolutionIsReference } from "@/api/collimator/hooks/solutions/usePatchStudentSolutionIsReference";
+import { Modal } from "@/components/form/Modal";
+import { toaster } from "@/components/Toaster";
+
+const messages = defineMessages({
+  ariaLabel: {
+    id: "UnstarPastSolutionsButton.ariaLabel",
+    defaultMessage: "Remove all previously starred solutions",
+  },
+  confirmTitle: {
+    id: "UnstarPastSolutionsButton.confirm.title",
+    defaultMessage: "Remove previously starred solutions",
+  },
+  confirmBody: {
+    id: "UnstarPastSolutionsButton.confirm.body",
+    defaultMessage:
+      "This will remove all previously starred solutions for this student. This action cannot be undone. Are you sure you want to continue?",
+  },
+  confirmButton: {
+    id: "UnstarPastSolutionsButton.confirm.confirm",
+    defaultMessage: "Remove",
+  },
+  cancelButton: {
+    id: "UnstarPastSolutionsButton.confirm.cancel",
+    defaultMessage: "Cancel",
+  },
+  successToast: {
+    id: "UnstarPastSolutionsButton.successToast",
+    defaultMessage: "Previously starred solutions removed.",
+  },
+  errorToast: {
+    id: "UnstarPastSolutionsButton.errorToast",
+    defaultMessage:
+      "There was an error removing previously starred solutions. Please try again!",
+  },
+});
+
+const UnstarPastSolutionsButton = ({
+  classId,
+  sessionId,
+  taskId,
+  taskSolutions,
+}: {
+  classId: number;
+  sessionId: number;
+  taskId: number;
+  taskSolutions: ExistingStudentSolution[];
+}) => {
+  const intl = useIntl();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const patchSolution = usePatchStudentSolutionIsReference();
+
+  const starredSolutions = useMemo(
+    () => taskSolutions.filter((s) => s.isReference),
+    [taskSolutions],
+  );
+
+  if (starredSolutions.length === 0) {
+    return null;
+  }
+
+  const handleConfirm = async () => {
+    try {
+      await Promise.all(
+        starredSolutions.map((s) =>
+          patchSolution(classId, sessionId, taskId, s.id, {
+            isReference: false,
+          }),
+        ),
+      );
+      toaster.success({
+        id: `unstar-past-solutions-success-${taskId}`,
+        title: intl.formatMessage(messages.successToast),
+      });
+    } catch {
+      toaster.error({
+        id: `unstar-past-solutions-error-${taskId}`,
+        title: intl.formatMessage(messages.errorToast),
+      });
+    }
+  };
+
+  return (
+    <>
+      <Button
+        aria-label={intl.formatMessage(messages.ariaLabel)}
+        onClick={() => setIsModalOpen(true)}
+        variant="ghost"
+        padding="0"
+      >
+        <Icon size="lg" color="orange.500">
+          <LuStar />
+        </Icon>
+      </Button>
+      <Modal
+        title={intl.formatMessage(messages.confirmTitle)}
+        description={intl.formatMessage(messages.confirmBody)}
+        confirmButtonText={intl.formatMessage(messages.confirmButton)}
+        cancelButtonText={intl.formatMessage(messages.cancelButton)}
+        onConfirm={handleConfirm}
+        open={isModalOpen}
+        onOpenChange={(details) => setIsModalOpen(details.open)}
+      />
+    </>
+  );
+};
+
+export default UnstarPastSolutionsButton;

--- a/frontend/src/components/solution/UnstarPastSolutionsButton.tsx
+++ b/frontend/src/components/solution/UnstarPastSolutionsButton.tsx
@@ -2,11 +2,11 @@ import { useMemo, useState } from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { Icon } from "@chakra-ui/react";
 import { LuStar } from "react-icons/lu";
-import Button from "../Button";
 import { ExistingStudentSolution } from "@/api/collimator/models/solutions/existing-student-solutions";
 import { usePatchStudentSolutionIsReference } from "@/api/collimator/hooks/solutions/usePatchStudentSolutionIsReference";
 import { Modal } from "@/components/form/Modal";
 import { toaster } from "@/components/Toaster";
+import Button from "../Button";
 
 const messages = defineMessages({
   ariaLabel: {

--- a/frontend/src/components/solution/UnstarPastSolutionsButton.tsx
+++ b/frontend/src/components/solution/UnstarPastSolutionsButton.tsx
@@ -56,19 +56,23 @@ const UnstarPastSolutionsButton = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const patchSolution = usePatchStudentSolutionIsReference();
 
-  const starredSolutions = useMemo(
-    () => taskSolutions.filter((s) => s.isReference),
-    [taskSolutions],
-  );
+  const starredPastSolutions = useMemo(() => {
+    const latestSolution =
+      ExistingStudentSolution.findSolutionToDisplay(taskSolutions);
 
-  if (starredSolutions.length === 0) {
+    return taskSolutions.filter(
+      (s) => s.isReference && s.id !== latestSolution?.id,
+    );
+  }, [taskSolutions]);
+
+  if (starredPastSolutions.length === 0) {
     return null;
   }
 
   const handleConfirm = async () => {
     try {
       await Promise.all(
-        starredSolutions.map((s) =>
+        starredPastSolutions.map((s) =>
           patchSolution(classId, sessionId, taskId, s.id, {
             isReference: false,
           }),

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { Button, HStack, Icon, Status } from "@chakra-ui/react";
 import { ColumnDef } from "@tanstack/react-table";
 import { useRouter } from "next/router";
-import { LuChevronRight, LuStar } from "react-icons/lu";
+import { LuChevronRight } from "react-icons/lu";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import { ClassStudent } from "@/api/collimator/models/classes/class-student";
@@ -20,6 +20,7 @@ import ChakraDataTable, { ColumnSize } from "../ChakraDataTable";
 import { StudentName } from "../encryption/StudentName";
 import MultiSwrContent from "../MultiSwrContent";
 import StarSolutionButton from "../solution/StarSolutionButton";
+import UnstarPastSolutionsButton from "../solution/UnstarPastSolutionsButton";
 
 const TaskInstanceProgressListWrapper = styled.div`
   margin: 1rem 0;
@@ -104,24 +105,23 @@ const CurrentVersionTemplate = ({
 };
 
 const PreviousVersionTemplate = ({
+  classId,
+  sessionId,
+  taskId,
   progress,
 }: {
+  classId: number;
+  sessionId: number;
+  taskId: number;
   progress: StudentProgress;
-}) => {
-  const hasStarredPastSolution = progress.taskSolutions.some(
-    (s) => s.isReference,
-  );
-
-  if (!hasStarredPastSolution) {
-    return null;
-  }
-
-  return (
-    <Icon size="lg" color="orange.500">
-      <LuStar />
-    </Icon>
-  );
-};
+}) => (
+  <UnstarPastSolutionsButton
+    classId={classId}
+    sessionId={sessionId}
+    taskId={taskId}
+    taskSolutions={progress.taskSolutions}
+  />
+);
 
 const TaskTemplate = ({
   classId: _classId,
@@ -331,7 +331,12 @@ const TaskInstanceProgressList = ({
         id: "previousVersion",
         header: intl.formatMessage(messages.previousVersionColumn),
         cell: (info) => (
-          <PreviousVersionTemplate progress={info.row.original} />
+          <PreviousVersionTemplate
+            classId={classId}
+            sessionId={sessionId}
+            taskId={taskId}
+            progress={info.row.original}
+          />
         ),
         meta: {
           columnType: ColumnType.text,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the confusing “past solutions” star in the results view by turning it into a clear action with confirmation. The star only shows when there are past starred solutions and lets you remove them all safely. (CRT-421)

- **Bug Fixes**
  - Added `UnstarPastSolutionsButton` that opens a confirm modal and unstars all past solutions.
  - Excludes the latest solution from bulk unstar.
  - Shows success/error toasts after the action.
  - Added i18n strings (EN/FR) and wired the button into `TaskInstanceProgressList`.

<sup>Written for commit bcfdf84f497041349078e7a3641f3692dd984e64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

