### PR TITLE
[CRT-423] Prevent task revalidation while solving

### DIFF
--- a/frontend/src/api/collimator/hooks/tasks/useTask.ts
+++ b/frontend/src/api/collimator/hooks/tasks/useTask.ts
@@ -1,4 +1,4 @@
-import useSWR from "swr";
+import useSWR, { SWRConfiguration } from "swr";
 import { fetchFile } from "@/api/fetch";
 import { ApiResponse, getIdOrNaN } from "../helpers";
 import { ExistingTask } from "../../models/tasks/existing-task";
@@ -19,29 +19,39 @@ const fetchAndTransform = (
 
 export const useTask = (
   id?: number | string,
+  swrConfig?: SWRConfiguration<GetTaskReturnType, Error>,
 ): ApiResponse<GetTaskReturnType, Error> => {
   const numericId = getIdOrNaN(id);
   const authOptions = useAuthenticationOptions();
 
-  return useSWR(getTasksControllerFindOneV0Url(numericId, {}), () =>
-    isNaN(numericId)
-      ? // return a never-resolving promise to prevent SWR from retrying with the same invalid id
-        new Promise<GetTaskReturnType>(() => {})
-      : fetchAndTransform(authOptions, numericId),
+  return useSWR(
+    getTasksControllerFindOneV0Url(numericId, {}),
+    () =>
+      isNaN(numericId)
+        ? // return a never-resolving promise to prevent SWR from retrying with the same invalid id
+          new Promise<GetTaskReturnType>(() => {})
+        : fetchAndTransform(authOptions, numericId),
+    swrConfig,
   );
 };
 
-export const useTaskFile = (id?: number | string): ApiResponse<Blob, Error> => {
+export const useTaskFile = (
+  id?: number | string,
+  swrConfig?: SWRConfiguration<Blob, Error>,
+): ApiResponse<Blob, Error> => {
   const numericId = getIdOrNaN(id);
   const authOptions = useAuthenticationOptions();
 
-  return useSWR(getTasksControllerDownloadOneV0Url(numericId, {}), () =>
-    isNaN(numericId)
-      ? // return a never-resolving promise to prevent SWR from retrying with the same invalid id
-        new Promise<Blob>(() => {})
-      : fetchFile(getTasksControllerDownloadOneV0Url(numericId, {}), {
-          ...authOptions,
-          method: "GET",
-        }),
+  return useSWR(
+    getTasksControllerDownloadOneV0Url(numericId, {}),
+    () =>
+      isNaN(numericId)
+        ? // return a never-resolving promise to prevent SWR from retrying with the same invalid id
+          new Promise<Blob>(() => {})
+        : fetchFile(getTasksControllerDownloadOneV0Url(numericId, {}), {
+            ...authOptions,
+            method: "GET",
+          }),
+    swrConfig,
   );
 };

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -71,17 +71,27 @@ const SolveTaskPage = () => {
     isLoading: isLoadingSession,
   } = useClassSession(classId, sessionId);
 
+  // do not revalidate the task and task file while solving to prevent app reloads
+  const noTaskRevalidation = useMemo(
+    () => ({
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      revalidateIfStale: false,
+    }),
+    [],
+  );
+
   const {
     data: task,
     error: taskError,
     isLoading: isLoadingTask,
-  } = useTask(taskId);
+  } = useTask(taskId, noTaskRevalidation);
 
   const {
     data: taskFile,
     error: taskFileError,
     isLoading: isLoadingTaskFile,
-  } = useTaskFile(taskId);
+  } = useTaskFile(taskId, noTaskRevalidation);
 
   const fetchLatestSolutionFile = useFetchLatestSolutionFile();
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented task and task file revalidation while solving to stop student solutions from reloading unexpectedly. Addresses CRT-423.

- **Bug Fixes**
  - Added optional `SWRConfiguration` params to `useTask` and `useTaskFile`.
  - In `SolveTaskPage`, pass a no-revalidation config (no focus/reconnect/stale revalidate) to keep the solve view stable.

<sup>Written for commit 514c2ac1c59b597258988dd7d360fdf1c380fa96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

