### PR TITLE
[CRT-424] Student activity counter is monotonical

### DIFF
--- a/frontend/src/api/collimator/hooks/student-activity/useTrackStudentActivity.ts
+++ b/frontend/src/api/collimator/hooks/student-activity/useTrackStudentActivity.ts
@@ -18,7 +18,6 @@ type TrackActivityType = (trackActivityDto: ActivityDto) => Promise<void>;
 type TrackActivityFailure = boolean;
 
 let activitiesToTrack: ActivityDtoWithDate[] = [];
-let lastTimestamp = 0;
 let counter = 0;
 
 export const studentActivityControllerTrack = async (

--- a/frontend/src/api/collimator/hooks/student-activity/useTrackStudentActivity.ts
+++ b/frontend/src/api/collimator/hooks/student-activity/useTrackStudentActivity.ts
@@ -60,12 +60,9 @@ const getActivityTimestamp = (): {
 } => {
   const now = Date.now();
 
-  if (now === lastTimestamp) {
-    counter++;
-  } else {
-    lastTimestamp = now;
-    counter = 0;
-  }
+  // use a monotonically increasing counter, such that a single session
+  // will record all activities in-order, even across tasks.
+  counter++;
 
   return { happenedAt: new Date(now), happenedAtCounter: counter };
 };


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the student activity counter monotonically increase per session to guarantee in-order event tracking across tasks, even when multiple events share the same millisecond. Addresses CRT-424 by removing timestamp-based logic so `happenedAtCounter` only increments and never resets during a session.

- **Refactors**
  - Removed unused `lastTimestamp` variable.

<sup>Written for commit c46cacac3a793bcf36ec9163e9368f6936e0c3d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

