### PR TITLE
[CRT-425] Cache and reuse task parent origin

### DIFF
--- a/libraries/iframe-rpc-react/src/useIframeParent.ts
+++ b/libraries/iframe-rpc-react/src/useIframeParent.ts
@@ -8,6 +8,8 @@ import {
 import { ParametersOf } from "iframe-rpc/src/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+let cachedParentOrigin: string | null = null;
+
 export const useIframeParent = (
   handleRequest: AppHandleRequestMap | null,
   initialMessages?: MessageEvent<unknown>[],
@@ -26,26 +28,34 @@ export const useIframeParent = (
 } => {
   const [hasLoaded, setHasLoaded] = useState(false);
   const [isInIframe, setIsInIframe] = useState(false);
-  const [taskOrigin, setTaskOrigin] = useState<string | null>(null);
+  const [taskOrigin, setTaskOrigin] = useState<string | null>(
+    cachedParentOrigin,
+  );
 
   const modifiedHandleRequest = useMemo(
-    () => handleRequest !== null ?({
-      ...handleRequest,
-      loadSubmission: async (
-        ...args: Parameters<typeof handleRequest.loadSubmission>
-      ): ReturnType<typeof handleRequest.loadSubmission> => {
-        setTaskOrigin(args[1].origin);
+    () =>
+      handleRequest !== null
+        ? {
+            ...handleRequest,
+            loadSubmission: async (
+              ...args: Parameters<typeof handleRequest.loadSubmission>
+            ): ReturnType<typeof handleRequest.loadSubmission> => {
+              // cache the parent origin and set it in state
+              cachedParentOrigin = args[1].origin;
+              setTaskOrigin(args[1].origin);
 
-        return handleRequest.loadSubmission(...args);
-      },
-      loadTask: async (
-        ...args: Parameters<typeof handleRequest.loadTask>
-      ): ReturnType<typeof handleRequest.loadTask> => {
-        setTaskOrigin(args[1].origin);
+              return handleRequest.loadSubmission(...args);
+            },
+            loadTask: async (
+              ...args: Parameters<typeof handleRequest.loadTask>
+            ): ReturnType<typeof handleRequest.loadTask> => {
+              cachedParentOrigin = args[1].origin;
+              setTaskOrigin(args[1].origin);
 
-        return handleRequest.loadTask(...args);
-      },
-    }) : null,
+              return handleRequest.loadTask(...args);
+            },
+          }
+        : null,
     [handleRequest],
   );
 

--- a/libraries/iframe-rpc-react/src/useIframeParent.ts
+++ b/libraries/iframe-rpc-react/src/useIframeParent.ts
@@ -8,6 +8,10 @@ import {
 import { ParametersOf } from "iframe-rpc/src/utils";
 import { useEffect, useMemo, useRef, useState } from "react";
 
+// We cache the parent origin as a workaround to prevent transient, reload bugs.
+// During an iframe reload, no RPC is called by the parent, which in turn means
+// that no origin is set in the crtPlatform and we become unable to communicate
+// with the parent. This fixes CRT-425 and similar classes of bugs.
 let cachedParentOrigin: string | null = null;
 
 export const useIframeParent = (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cache and reuse the parent origin in `useIframeParent` so RPC messages aren’t rejected after changing a scratch task’s language (CRT-425).

- **Bug Fixes**
  - Cache the parent origin at module scope, initialize `taskOrigin` from it, and document the reload-gap workaround.
  - Wrap `loadSubmission` and `loadTask` to refresh both the cache and state when a new origin is provided.

<sup>Written for commit 74e3f31b64b3c0abe37896407cef521da541fe69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

