### PR TITLE
[CRT-426] Remove redundant project loading causing race condition

### DIFF
--- a/apps/scratch/src/hooks/useEmbeddedScratch.ts
+++ b/apps/scratch/src/hooks/useEmbeddedScratch.ts
@@ -409,12 +409,7 @@ export class EmbeddedScratchCallbacks {
   }
 
   async setLocale(request: SetLocale["request"]): Promise<undefined> {
-    // save content
-    const sb3Project = await saveCrtProject(this.vm);
-
-    // change language - apparently scratch resets the content with this?
     this.setScratchLocale(request.params);
-    await loadCrtProject(this.vm, await sb3Project.arrayBuffer());
   }
 
   private setScratchLocale(language: Language): void {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent toolbox blocks from being cleared when switching Scratch language by removing a redundant project save/load in `useEmbeddedScratch.setLocale`, eliminating the race condition.

- **Bug Fixes**
  - Removed project save/load around locale change; rely on `setScratchLocale` only.
  - Eliminates the VM race that reset state and wiped toolbox blocks during language switch.

<sup>Written for commit 7e65d06a3511f0d502d7cdfc236964b9a646ee47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

