### PR TITLE
[CRT-411] Snapshot task block ids & reset after import export roundtrip

### DIFF
--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -8,7 +8,7 @@ import {
   restoreSpriteStateForSerialization,
   restoreStageStateForSerialization,
 } from "./target-state";
-import { allBlocks } from "./utils";
+import { iterateAllBlocks } from "./utils";
 
 const clearStartState = (startState: StartState): void => {
   startState.sprites.clear();
@@ -84,7 +84,7 @@ const initializeTaskBlocksOnLoad = (vm: VM, startState: StartState): void => {
   vm.runtime.on("PROJECT_LOADED", () => {
     // iterate over all the blocks in the runtime
     // and mark them as initial blocks
-    for (const block of allBlocks(vm.runtime)) {
+    for (const block of iterateAllBlocks(vm.runtime)) {
       block.isTaskBlock = vm.taskBlockIds
         ? vm.taskBlockIds.has(block.id)
         : true;

--- a/apps/scratch/src/vm/index.ts
+++ b/apps/scratch/src/vm/index.ts
@@ -8,6 +8,7 @@ import {
   restoreSpriteStateForSerialization,
   restoreStageStateForSerialization,
 } from "./target-state";
+import { allBlocks } from "./utils";
 
 const clearStartState = (startState: StartState): void => {
   startState.sprites.clear();
@@ -83,12 +84,10 @@ const initializeTaskBlocksOnLoad = (vm: VM, startState: StartState): void => {
   vm.runtime.on("PROJECT_LOADED", () => {
     // iterate over all the blocks in the runtime
     // and mark them as initial blocks
-    for (const target of vm.runtime.targets) {
-      for (const block of Object.values(target.blocks._blocks)) {
-        block.isTaskBlock = vm.taskBlockIds
-          ? vm.taskBlockIds.has(block.id)
-          : true;
-      }
+    for (const block of allBlocks(vm.runtime)) {
+      block.isTaskBlock = vm.taskBlockIds
+        ? vm.taskBlockIds.has(block.id)
+        : true;
     }
 
     clearStartState(startState);

--- a/apps/scratch/src/vm/save-crt-project.ts
+++ b/apps/scratch/src/vm/save-crt-project.ts
@@ -50,9 +50,8 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
 
   for (const target of vm.runtime.targets) {
     for (const block of Object.values(target.blocks._blocks)) {
-      const previous = isTaskBlockById.get(block.id);
-      if (previous !== undefined) {
-        block.isTaskBlock = previous;
+      if (isTaskBlockById.has(block.id)) {
+        block.isTaskBlock = isTaskBlockById.get(block.id);
       }
     }
   }

--- a/apps/scratch/src/vm/save-crt-project.ts
+++ b/apps/scratch/src/vm/save-crt-project.ts
@@ -45,11 +45,13 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
     isTaskBlockById.set(block.id, block.isTaskBlock);
   }
 
-  await loadCrtProject(vm, exportedTask);
-
-  for (const block of allBlocks(vm.runtime)) {
-    if (isTaskBlockById.has(block.id)) {
-      block.isTaskBlock = isTaskBlockById.get(block.id);
+  try {
+    await loadCrtProject(vm, exportedTask);
+  } finally {
+    for (const block of allBlocks(vm.runtime)) {
+      if (isTaskBlockById.has(block.id)) {
+        block.isTaskBlock = isTaskBlockById.get(block.id);
+      }
     }
   }
 

--- a/apps/scratch/src/vm/save-crt-project.ts
+++ b/apps/scratch/src/vm/save-crt-project.ts
@@ -1,7 +1,7 @@
 import VM from "@scratch/scratch-vm";
 import JSZip from "jszip";
 import { loadCrtProject } from "./load-crt-project";
-import { allBlocks } from "./utils";
+import { iterateAllBlocks } from "./utils";
 
 /**
  * @returns Project in a Scratch 3.0 JSON representation.
@@ -38,7 +38,7 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
 
   const isTaskBlockById = new Map<string, boolean | undefined>();
 
-  for (const block of allBlocks(vm.runtime)) {
+  for (const block of iterateAllBlocks(vm.runtime)) {
     // the round trip reload here calls the PROJECT_LOADED listener
     // in the assertion extension, which re-marks every block in the workspace as a task block and makes them undeletable.
     // snapshot isTaskBlock here for every block and restore it after the reload to work around this.
@@ -48,7 +48,7 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
   try {
     await loadCrtProject(vm, exportedTask);
   } finally {
-    for (const block of allBlocks(vm.runtime)) {
+    for (const block of iterateAllBlocks(vm.runtime)) {
       if (isTaskBlockById.has(block.id)) {
         block.isTaskBlock = isTaskBlockById.get(block.id);
       }

--- a/apps/scratch/src/vm/save-crt-project.ts
+++ b/apps/scratch/src/vm/save-crt-project.ts
@@ -40,7 +40,7 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
 
   for (const block of allBlocks(vm.runtime)) {
     // the round trip reload here calls the PROJECT_LOADED listener
-    // in the assertion extension, which re mark every block in the workspace as a task block and makes them undeletable.
+    // in the assertion extension, which re-marks every block in the workspace as a task block and makes them undeletable.
     // snapshot isTaskBlock here for every block and restore it after the reload to work around this.
     isTaskBlockById.set(block.id, block.isTaskBlock);
   }

--- a/apps/scratch/src/vm/save-crt-project.ts
+++ b/apps/scratch/src/vm/save-crt-project.ts
@@ -1,6 +1,7 @@
 import VM from "@scratch/scratch-vm";
 import JSZip from "jszip";
 import { loadCrtProject } from "./load-crt-project";
+import { allBlocks } from "./utils";
 
 /**
  * @returns Project in a Scratch 3.0 JSON representation.
@@ -37,22 +38,18 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
 
   const isTaskBlockById = new Map<string, boolean | undefined>();
 
-  for (const target of vm.runtime.targets) {
-    for (const block of Object.values(target.blocks._blocks)) {
-      // the round trip reload here calls the PROJECT_LOADED listener
-      // in the assertion extension, which re mark every block in the workspace as a task block and makes them undeletable.
-      // snapshot isTaskBlock here for every block and restore it after the reload to work around this.
-      isTaskBlockById.set(block.id, block.isTaskBlock);
-    }
+  for (const block of allBlocks(vm.runtime)) {
+    // the round trip reload here calls the PROJECT_LOADED listener
+    // in the assertion extension, which re mark every block in the workspace as a task block and makes them undeletable.
+    // snapshot isTaskBlock here for every block and restore it after the reload to work around this.
+    isTaskBlockById.set(block.id, block.isTaskBlock);
   }
 
   await loadCrtProject(vm, exportedTask);
 
-  for (const target of vm.runtime.targets) {
-    for (const block of Object.values(target.blocks._blocks)) {
-      if (isTaskBlockById.has(block.id)) {
-        block.isTaskBlock = isTaskBlockById.get(block.id);
-      }
+  for (const block of allBlocks(vm.runtime)) {
+    if (isTaskBlockById.has(block.id)) {
+      block.isTaskBlock = isTaskBlockById.get(block.id);
     }
   }
 

--- a/apps/scratch/src/vm/save-crt-project.ts
+++ b/apps/scratch/src/vm/save-crt-project.ts
@@ -35,7 +35,27 @@ export const prepareCrtProjectForExport = async (vm: VM): Promise<Blob> => {
   // To work around this, we re-load the project we just saved, which ensures that the asset ids in the task and the submission are the same.
   const exportedTask = await task.arrayBuffer();
 
+  const isTaskBlockById = new Map<string, boolean | undefined>();
+
+  for (const target of vm.runtime.targets) {
+    for (const block of Object.values(target.blocks._blocks)) {
+      // the round trip reload here calls the PROJECT_LOADED listener
+      // in the assertion extension, which re mark every block in the workspace as a task block and makes them undeletable.
+      // snapshot isTaskBlock here for every block and restore it after the reload to work around this.
+      isTaskBlockById.set(block.id, block.isTaskBlock);
+    }
+  }
+
   await loadCrtProject(vm, exportedTask);
+
+  for (const target of vm.runtime.targets) {
+    for (const block of Object.values(target.blocks._blocks)) {
+      const previous = isTaskBlockById.get(block.id);
+      if (previous !== undefined) {
+        block.isTaskBlock = previous;
+      }
+    }
+  }
 
   const reExportedTask = await saveCrtProject(vm);
 

--- a/apps/scratch/src/vm/utils.ts
+++ b/apps/scratch/src/vm/utils.ts
@@ -1,8 +1,6 @@
-import { BlockExtended } from "@scratch/scratch-vm";
-
 export function* iterateAllBlocks(
   runtime: VMExtended.RuntimeExtended,
-): Generator<BlockExtended> {
+): Generator<VMExtended.BlockExtended> {
   for (const target of runtime.targets) {
     for (const block of Object.values(target.blocks._blocks)) {
       yield block;

--- a/apps/scratch/src/vm/utils.ts
+++ b/apps/scratch/src/vm/utils.ts
@@ -1,0 +1,11 @@
+import { BlockExtended } from "@scratch/scratch-vm";
+
+export function* allBlocks(
+  runtime: VMExtended.RuntimeExtended,
+): Generator<BlockExtended> {
+  for (const target of runtime.targets) {
+    for (const block of Object.values(target.blocks._blocks)) {
+      yield block;
+    }
+  }
+}

--- a/apps/scratch/src/vm/utils.ts
+++ b/apps/scratch/src/vm/utils.ts
@@ -1,6 +1,6 @@
 import { BlockExtended } from "@scratch/scratch-vm";
 
-export function* allBlocks(
+export function* iterateAllBlocks(
   runtime: VMExtended.RuntimeExtended,
 ): Generator<BlockExtended> {
   for (const target of runtime.targets) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents blocks from becoming undeletable after an export/import roundtrip by snapshotting and restoring each block’s `isTaskBlock` (including `undefined`) around the reload, even if it fails. Addresses CRT-411 so task marks stay correct and blocks remain editable.

- **Bug Fixes**
  - Snapshot `isTaskBlock` for all runtime blocks before `loadCrtProject` and restore in a `try/finally` after the reload or failure.
  - Neutralizes `PROJECT_LOADED` side effects by restoring pre-reload values so workspace blocks aren’t locked as task blocks.

- **Refactors**
  - Added `iterateAllBlocks` and derived the `BlockExtended` type from the VM for safer traversal; used in load init and the export roundtrip.

<sup>Written for commit b5199fa5f35a61c7a6f425b7bd0ca23eacfba5bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

