### PR TITLE
[CRT-412] Only consider non reference entries in progress list

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,6 @@
     "socket.io-client": "^4.8.1",
     "swr": "^2.3.3",
     "ts-pattern": "^5.7.0",
-    "unique-names-generator": "^4.7.1",
     "yup": "^1.6.1"
   },
   "devDependencies": {

--- a/frontend/src/components/encryption/StudentName.tsx
+++ b/frontend/src/components/encryption/StudentName.tsx
@@ -54,7 +54,7 @@ export const StudentName = ({
 
     return (
       <NameWrapper data-testid={testId}>
-        {getStudentNickname(studentId, pseudonym, locale)}{" "}
+        {getStudentNickname(studentId, locale)}{" "}
         <FontAwesomeIcon
           icon={faInfoCircle}
           title={intl.formatMessage(messages.cannotDecrypt)}

--- a/frontend/src/components/header/StudentHeader.tsx
+++ b/frontend/src/components/header/StudentHeader.tsx
@@ -69,9 +69,8 @@ const StudentHeader = ({
     isFullyAuthenticated(authContext)
   ) {
     const locale = isLanguage(intl.locale) ? intl.locale : undefined;
-    const pseudonym = authContext.isAnonymous ? null : authContext.pseudonym;
 
-    studentName = getStudentNickname(authContext.studentId, pseudonym, locale);
+    studentName = getStudentNickname(authContext.studentId, locale);
   }
 
   return (

--- a/frontend/src/hooks/useStudentName.ts
+++ b/frontend/src/hooks/useStudentName.ts
@@ -85,16 +85,10 @@ export const useStudentName = ({
   const locale = isLanguage(intl.locale) ? intl.locale : undefined;
 
   const name = useMemo(() => {
-    return !anonymizationState.showActualName || !pseudonym
-      ? getStudentNickname(studentId, pseudonym, locale)
+    return !anonymizationState.showActualName
+      ? getStudentNickname(studentId, locale)
       : decryptedName;
-  }, [
-    anonymizationState.showActualName,
-    decryptedName,
-    studentId,
-    pseudonym,
-    locale,
-  ]);
+  }, [anonymizationState.showActualName, decryptedName, studentId, locale]);
 
   return {
     name,

--- a/frontend/src/utilities/student-name.ts
+++ b/frontend/src/utilities/student-name.ts
@@ -1,4 +1,3 @@
-import { uniqueNamesGenerator } from "unique-names-generator";
 import { Language } from "iframe-rpc-react/src";
 import animals from "../../content/dictionaries/animals";
 import numbers from "../../content/dictionaries/numbers";
@@ -11,14 +10,12 @@ export function getStudentNickname(
   // We would prefer prefixing the pseudonym to avoid the two name spaces
   // from clashing.
   // However for backwards compatibility we don't, see https://github.com/crt25/collimator/pull/286/files#r2054086764.
-  const seed = pseudonym ? pseudonym : `anonymous_${studentId}`;
-  const animalNames = animals.map((animal) => animal[locale]);
-
-  return uniqueNamesGenerator({
-    dictionaries: [animalNames, numbers],
-    separator: "-",
-    length: 2,
-    style: "lowerCase",
-    seed,
-  });
+  return pseudonym ? pseudonym : generateAnonymousName(studentId, locale);
 }
+
+const generateAnonymousName = (studentId: number, locale: Language): string => {
+  const animalIndex = studentId % animals.length;
+  const numberIndex = studentId % numbers.length;
+
+  return `${animals[animalIndex][locale]}-${numbers[numberIndex]}`;
+};

--- a/frontend/src/utilities/student-name.ts
+++ b/frontend/src/utilities/student-name.ts
@@ -4,15 +4,11 @@ import numbers from "../../content/dictionaries/numbers";
 
 export function getStudentNickname(
   studentId: number,
-  pseudonym?: string | null,
   locale: Language = Language.en,
 ): string {
-  // We would prefer prefixing the pseudonym to avoid the two name spaces
-  // from clashing.
-  // However for backwards compatibility we don't, see https://github.com/crt25/collimator/pull/286/files#r2054086764.
-  const seed = pseudonym ? pseudonym : `anonymous_${studentId}`;
-  const hash = hashString(seed);
-  const animalIndex = hash % animals.length;
+  const animalIndex = studentId % animals.length;
+
+  const hash = hashString(studentId.toString());
   const numberIndex = hash % numbers.length;
 
   return `${animals[animalIndex][locale]}-${numbers[numberIndex]}`;

--- a/frontend/src/utilities/student-name.ts
+++ b/frontend/src/utilities/student-name.ts
@@ -10,12 +10,19 @@ export function getStudentNickname(
   // We would prefer prefixing the pseudonym to avoid the two name spaces
   // from clashing.
   // However for backwards compatibility we don't, see https://github.com/crt25/collimator/pull/286/files#r2054086764.
-  return pseudonym ? pseudonym : generateAnonymousName(studentId, locale);
-}
-
-const generateAnonymousName = (studentId: number, locale: Language): string => {
-  const animalIndex = studentId % animals.length;
-  const numberIndex = studentId % numbers.length;
+  const seed = pseudonym ? pseudonym : `anonymous_${studentId}`;
+  const hash = hashString(seed);
+  const animalIndex = hash % animals.length;
+  const numberIndex = hash % numbers.length;
 
   return `${animals[animalIndex][locale]}-${numbers[numberIndex]}`;
+}
+
+// source: https://ssojet.com/hashing/bernsteins-hash-djb2-in-nodejs
+const hashString = (input: string): number => {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash << 5) + hash + input.charCodeAt(i); /* hash * 33 + c */
+  }
+  return hash >>> 0; // Ensure unsigned 32-bit integer
 };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8004,7 +8004,6 @@ __metadata:
     ts-node: "npm:^10.9.2"
     ts-pattern: "npm:^5.7.0"
     typescript: "npm:^5.9.3"
-    unique-names-generator: "npm:^4.7.1"
     vitest: "npm:^4.0.16"
     wait-for-expect: "npm:^4.0.0"
     yup: "npm:^1.6.1"
@@ -15804,13 +15803,6 @@ __metadata:
   dependencies:
     unique-slug: "npm:^5.0.0"
   checksum: 10c0/38ae681cceb1408ea0587b6b01e29b00eee3c84baee1e41fd5c16b9ed443b80fba90c40e0ba69627e30855570a34ba8b06702d4a35035d4b5e198bf5a64c9ddc
-  languageName: node
-  linkType: hard
-
-"unique-names-generator@npm:^4.7.1":
-  version: 4.7.1
-  resolution: "unique-names-generator@npm:4.7.1"
-  checksum: 10c0/db07b9a0fee6eac4a21cf567c9744ee97895aa744d51ec913557205173a65c1a7a4d12470295796acb7247e6646e7975c340bb634c7adf41e5d950fa5cf94375
   languageName: node
   linkType: hard
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes duplicate students in the progress report by excluding reference solutions when building the list (CRT-412). Replaces `unique-names-generator` with a deterministic nickname generator based on `studentId` and `locale`, decorrelates animal/number indices, and removes use of pseudonyms entirely.

<sup>Written for commit 377a1d47528827f3f80d620a21be74f371161d85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

