### PR TITLE
[CRT-401] Reference solutions do not allow clicking "save" unless descriptions are filled

### DIFF
--- a/frontend/content/compiled-locales/en.json
+++ b/frontend/content/compiled-locales/en.json
@@ -2208,7 +2208,7 @@
   "TaskFormReferenceSolutions.referenceSolutionsLengthValidation": [
     {
       "type": 0,
-      "value": "The number of reference solutions must match the number of reference solution files"
+      "value": "Please create a reference solution in the external application for each entry before saving."
     }
   ],
   "TaskFormReferenceSolutions.solution.create": [

--- a/frontend/content/compiled-locales/fr.json
+++ b/frontend/content/compiled-locales/fr.json
@@ -2671,7 +2671,7 @@
   "TaskFormReferenceSolutions.referenceSolutionsLengthValidation": [
     {
       "type": 0,
-      "value": "Le nombre de solutions de référence doit correspondre au nombre de fichiers de solutions de référence"
+      "value": "Veuillez créer une solution de référence dans l’application externe pour chaque entrée avant d’enregistrer."
     }
   ],
   "TaskFormReferenceSolutions.solution.create": [

--- a/frontend/content/locales/en.json
+++ b/frontend/content/locales/en.json
@@ -1045,7 +1045,7 @@
     "message": "Attention: you may lose your work!"
   },
   "TaskFormReferenceSolutions.referenceSolutionsLengthValidation": {
-    "message": "The number of reference solutions must match the number of reference solution files"
+    "message": "Please create a reference solution in the external application for each entry before saving."
   },
   "TaskFormReferenceSolutions.solution.create": {
     "message": "Create reference solution in external application"

--- a/frontend/content/locales/fr.json
+++ b/frontend/content/locales/fr.json
@@ -1285,7 +1285,7 @@
     "message": "Attention : vous risquez de perdre votre travail !"
   },
   "TaskFormReferenceSolutions.referenceSolutionsLengthValidation": {
-    "message": "Le nombre de solutions de référence doit correspondre au nombre de fichiers de solutions de référence"
+    "message": "Veuillez créer une solution de référence dans l’application externe pour chaque entrée avant d’enregistrer."
   },
   "TaskFormReferenceSolutions.solution.create": {
     "message": "Créer une solution de référence dans une application externe"

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -286,9 +286,8 @@ const TaskFormReferenceSolutions = ({
       setValue("referenceSolutions", referenceSolutions, {
         shouldDirty: true,
       });
-      revalidate();
     },
-    [setValue, revalidate],
+    [setValue],
   );
 
   const updateReferenceSolution = useCallback(

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -302,23 +302,18 @@ const TaskFormReferenceSolutions = ({
 
   const onAddReferenceSolution = useCallback(
     () =>
-      setValue(
-        "referenceSolutions",
-        [
-          ...referenceSolutions,
-          {
-            // add unique synthetic id that will be removed later
-            id: Math.max(...referenceSolutions.map((s) => s.id), 0) + 1,
-            isNew: true,
-            isInitial: false,
-            title: "",
-            description: "",
-            tests: [],
-          },
-        ],
-        { shouldDirty: true },
-      ),
-    [referenceSolutions, setValue],
+      setReferenceSolutions([
+        ...referenceSolutions,
+        {
+          id: Math.max(...referenceSolutions.map((s) => s.id), 0) + 1,
+          isNew: true,
+          isInitial: false,
+          title: "",
+          description: "",
+          tests: [],
+        },
+      ]),
+    [referenceSolutions, setReferenceSolutions],
   );
 
   const shouldStopNavigation = useCallback(() => cannotNavigate.current, []);

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -262,6 +262,7 @@ const TaskFormReferenceSolutions = ({
     watch,
     reset,
     setValue,
+    trigger,
   } = useForm<TaskFormReferenceSolutionsValues & { _fileChanged: boolean }>({
     resolver,
     defaultValues,
@@ -499,8 +500,10 @@ const TaskFormReferenceSolutions = ({
                   <RemoveTask
                     data-testid={`remove-task-${solution.id}`}
                     onClick={() => {
-                      setReferenceSolutions(
+                      setValue(
+                        "referenceSolutions",
                         referenceSolutions.filter((s) => s !== solution),
+                        { shouldDirty: true },
                       );
 
                       const newObject = { ...referenceSolutionFiles };
@@ -508,8 +511,11 @@ const TaskFormReferenceSolutions = ({
 
                       setValue("referenceSolutionFiles", newObject, {
                         shouldDirty: true,
-                        shouldValidate: isSubmitted,
                       });
+
+                      if (isSubmitted) {
+                        trigger();
+                      }
                     }}
                   >
                     <FontAwesomeIcon icon={faTrash} />

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -331,9 +331,9 @@ const TaskFormReferenceSolutions = ({
     cannotNavigate.current = isDirty;
   }, [isDirty]);
 
-  const onSubmitWrapper = useCallback(
-    (e: React.FormEvent<HTMLFormElement>) => {
-      handleSubmit(async (data: TaskFormReferenceSolutionsValues) => {
+  const onSubmitWrapper = useCallback(() => {
+    handleSubmit(async (data: TaskFormReferenceSolutionsValues) => {
+      try {
         const referenceSolutions = data.referenceSolutions
           .toSorted((a, b) => a.id - b.id)
           .map((solution) => ({
@@ -365,7 +365,7 @@ const TaskFormReferenceSolutions = ({
           title: intl.formatMessage(messages.saveSuccess),
           closable: true,
         });
-      })(e).catch((err) => {
+      } catch (err) {
         console.error(`${logModule} Error saving task`, err);
 
         if (isApiErrorWithCode(err, ErrorCode.DUPLICATE_REFERENCE_SOLUTION)) {
@@ -382,10 +382,9 @@ const TaskFormReferenceSolutions = ({
           title: intl.formatMessage(messages.saveError),
           closable: true,
         });
-      });
-    },
-    [handleSubmit, onSubmit, reset, intl],
-  );
+      }
+    });
+  }, [handleSubmit, onSubmit, reset, intl]);
 
   const referenceSolutionFiles: { [key: number]: Blob } = watch(
     "referenceSolutionFiles",

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -95,7 +95,7 @@ const messages = defineMessages({
   referenceSolutionsLengthValidation: {
     id: "TaskFormReferenceSolutions.referenceSolutionsLengthValidation",
     defaultMessage:
-      "The number of reference solutions must match the number of reference solution files",
+      "Please create a reference solution in the external application for each entry before saving.",
   },
   closeConfirmationTitle: {
     id: "TaskFormReferenceSolutions.closeConfirmation.title",

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -263,6 +263,7 @@ const TaskFormReferenceSolutions = ({
     reset,
     setValue,
     trigger,
+    clearErrors,
   } = useForm<TaskFormReferenceSolutionsValues & { _fileChanged: boolean }>({
     resolver,
     defaultValues,
@@ -270,15 +271,24 @@ const TaskFormReferenceSolutions = ({
 
   const referenceSolutions = watch("referenceSolutions");
 
+  // after the first submit, every mutation should re-evaluate the full schema
+  // so cross-field errors and stale per-index errors get refreshed
+  const revalidate = useCallback(() => {
+    if (isSubmitted) {
+      clearErrors();
+      trigger();
+    }
+  }, [isSubmitted, clearErrors, trigger]);
+
   // ensure that the selected tasks are always in sync with the form
   const setReferenceSolutions = useCallback(
     (referenceSolutions: CreateReferenceSolutionDtoWithId[]) => {
       setValue("referenceSolutions", referenceSolutions, {
         shouldDirty: true,
-        shouldValidate: isSubmitted,
       });
+      revalidate();
     },
-    [setValue, isSubmitted],
+    [setValue, revalidate],
   );
 
   const updateReferenceSolution = useCallback(
@@ -293,19 +303,23 @@ const TaskFormReferenceSolutions = ({
 
   const onAddReferenceSolution = useCallback(
     () =>
-      setReferenceSolutions([
-        ...referenceSolutions,
-        {
-          // add unique synthetic id that will be removed later
-          id: Math.max(...referenceSolutions.map((s) => s.id), 0) + 1,
-          isNew: true,
-          isInitial: false,
-          title: "",
-          description: "",
-          tests: [],
-        },
-      ]),
-    [referenceSolutions, setReferenceSolutions],
+      setValue(
+        "referenceSolutions",
+        [
+          ...referenceSolutions,
+          {
+            // add unique synthetic id that will be removed later
+            id: Math.max(...referenceSolutions.map((s) => s.id), 0) + 1,
+            isNew: true,
+            isInitial: false,
+            title: "",
+            description: "",
+            tests: [],
+          },
+        ],
+        { shouldDirty: true },
+      ),
+    [referenceSolutions, setValue],
   );
 
   const shouldStopNavigation = useCallback(() => cannotNavigate.current, []);
@@ -444,10 +458,14 @@ const TaskFormReferenceSolutions = ({
                       disabled={disabled}
                       data-testid={`reference-solution-${solution.id}-title-input`}
                       onChange={(e) =>
-                        updateReferenceSolution(index, {
-                          ...referenceSolutions[index],
-                          title: e.target.value,
-                        })
+                        setValue(
+                          `referenceSolutions.${index}.title`,
+                          e.target.value,
+                          {
+                            shouldDirty: true,
+                            shouldValidate: isSubmitted,
+                          },
+                        )
                       }
                     />
                     <Field.ErrorText>
@@ -465,10 +483,14 @@ const TaskFormReferenceSolutions = ({
                       errors.referenceSolutions?.[index]?.description?.message
                     }
                     onChange={(e) =>
-                      updateReferenceSolution(index, {
-                        ...referenceSolutions[index],
-                        description: e.target.value,
-                      })
+                      setValue(
+                        `referenceSolutions.${index}.description`,
+                        e.target.value,
+                        {
+                          shouldDirty: true,
+                          shouldValidate: isSubmitted,
+                        },
+                      )
                     }
                   />
                   {!disabled && (
@@ -513,9 +535,7 @@ const TaskFormReferenceSolutions = ({
                         shouldDirty: true,
                       });
 
-                      if (isSubmitted) {
-                        trigger();
-                      }
+                      revalidate();
                     }}
                   >
                     <FontAwesomeIcon icon={faTrash} />
@@ -578,13 +598,15 @@ const TaskFormReferenceSolutions = ({
                     ...referenceSolutionFiles,
                     [showSolveTaskModalForId]: solution.file,
                   },
-                  { shouldDirty: true, shouldValidate: isSubmitted },
+                  { shouldDirty: true },
                 );
 
                 // react hook form does not detect the file change, so we need to set it manually
                 setValue("_fileChanged", true, {
                   shouldDirty: true,
                 });
+
+                revalidate();
               }}
             />
           </>

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -331,60 +331,65 @@ const TaskFormReferenceSolutions = ({
     cannotNavigate.current = isDirty;
   }, [isDirty]);
 
-  const onSubmitWrapper = useCallback(() => {
-    handleSubmit(async (data: TaskFormReferenceSolutionsValues) => {
-      try {
-        const referenceSolutions = data.referenceSolutions
-          .toSorted((a, b) => a.id - b.id)
-          .map((solution) => ({
-            ...solution,
-            id: solution.isNew ? null : solution.id,
-          }));
+  const onSubmitWrapper = useCallback(
+    (e: React.FormEvent<HTMLFormElement>) => {
+      return handleSubmit(async (data: TaskFormReferenceSolutionsValues) => {
+        try {
+          const referenceSolutions = data.referenceSolutions
+            .toSorted((a, b) => a.id - b.id)
+            .map((solution) => ({
+              ...solution,
+              id: solution.isNew ? null : solution.id,
+            }));
 
-        const referenceSolutionsFiles = Object.entries(
-          data.referenceSolutionFiles,
-        )
-          .toSorted(([a, _], [b, __]) => parseInt(a) - parseInt(b))
-          .map(([_id, file]) => file);
+          const referenceSolutionsFiles = Object.entries(
+            data.referenceSolutionFiles,
+          )
+            .toSorted(([a, _], [b, __]) => parseInt(a) - parseInt(b))
+            .map(([_id, file]) => file);
 
-        await onSubmit({
-          referenceSolutions,
-          referenceSolutionsFiles,
-        } satisfies TaskFormReferenceSolutionsSubmission);
+          await onSubmit({
+            referenceSolutions,
+            referenceSolutionsFiles,
+          } satisfies TaskFormReferenceSolutionsSubmission);
 
-        // allow navigation after the task has been saved
-        cannotNavigate.current = false;
+          // allow navigation after the task has been saved
+          cannotNavigate.current = false;
 
-        // reset the form to the updated values
-        // and mark the blob as not changed
-        // so the user can navigate without confirmation
-        reset(data);
+          // reset the form to the updated values
+          // and mark the blob as not changed
+          // so the user can navigate without confirmation
+          reset(data);
 
-        toaster.success({
-          id: `task-reference-solutions-save-success-${Date.now()}`,
-          title: intl.formatMessage(messages.saveSuccess),
-          closable: true,
-        });
-      } catch (err) {
-        console.error(`${logModule} Error saving task`, err);
-
-        if (isApiErrorWithCode(err, ErrorCode.DUPLICATE_REFERENCE_SOLUTION)) {
-          toaster.error({
-            id: `duplicate-reference-solution-${Date.now()}`,
-            title: intl.formatMessage(getErrorMessageDescriptor(err.errorCode)),
+          toaster.success({
+            id: `task-reference-solutions-save-success-${Date.now()}`,
+            title: intl.formatMessage(messages.saveSuccess),
             closable: true,
           });
-          return;
-        }
+        } catch (err) {
+          console.error(`${logModule} Error saving task`, err);
 
-        toaster.error({
-          id: "task-reference-solutions-save-error",
-          title: intl.formatMessage(messages.saveError),
-          closable: true,
-        });
-      }
-    });
-  }, [handleSubmit, onSubmit, reset, intl]);
+          if (isApiErrorWithCode(err, ErrorCode.DUPLICATE_REFERENCE_SOLUTION)) {
+            toaster.error({
+              id: `duplicate-reference-solution-${Date.now()}`,
+              title: intl.formatMessage(
+                getErrorMessageDescriptor(err.errorCode),
+              ),
+              closable: true,
+            });
+            return;
+          }
+
+          toaster.error({
+            id: "task-reference-solutions-save-error",
+            title: intl.formatMessage(messages.saveError),
+            closable: true,
+          });
+        }
+      })(e);
+    },
+    [handleSubmit, onSubmit, reset, intl],
+  );
 
   const referenceSolutionFiles: { [key: number]: Blob } = watch(
     "referenceSolutionFiles",

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -258,7 +258,7 @@ const TaskFormReferenceSolutions = ({
 
   const {
     handleSubmit,
-    formState: { errors, isDirty, isValid },
+    formState: { errors, isDirty },
     watch,
     reset,
     setValue,
@@ -324,11 +324,7 @@ const TaskFormReferenceSolutions = ({
 
   const onSubmitWrapper = useCallback(
     (e: React.FormEvent<HTMLFormElement>) => {
-      let data: TaskFormReferenceSolutionsValues;
-
-      handleSubmit((v: TaskFormReferenceSolutionsValues) => {
-        data = v;
-
+      handleSubmit(async (data: TaskFormReferenceSolutionsValues) => {
         const referenceSolutions = data.referenceSolutions
           .toSorted((a, b) => a.id - b.id)
           .map((solution) => ({
@@ -342,46 +338,42 @@ const TaskFormReferenceSolutions = ({
           .toSorted(([a, _], [b, __]) => parseInt(a) - parseInt(b))
           .map(([_id, file]) => file);
 
-        return onSubmit({
+        await onSubmit({
           referenceSolutions,
           referenceSolutionsFiles,
         } satisfies TaskFormReferenceSolutionsSubmission);
-      })(e)
-        .then(() => {
-          // allow navigation after the task has been saved
-          cannotNavigate.current = false;
 
-          // reset the form to the updated values
-          // and mark the blob as not changed
-          // so the user can navigate without confirmation
-          reset(data);
+        // allow navigation after the task has been saved
+        cannotNavigate.current = false;
 
-          toaster.success({
-            id: `task-reference-solutions-save-success-${Date.now()}`,
-            title: intl.formatMessage(messages.saveSuccess),
-            closable: true,
-          });
-        })
-        .catch((err) => {
-          console.error(`${logModule} Error saving task`, err);
+        // reset the form to the updated values
+        // and mark the blob as not changed
+        // so the user can navigate without confirmation
+        reset(data);
 
-          if (isApiErrorWithCode(err, ErrorCode.DUPLICATE_REFERENCE_SOLUTION)) {
-            toaster.error({
-              id: `duplicate-reference-solution-${Date.now()}`,
-              title: intl.formatMessage(
-                getErrorMessageDescriptor(err.errorCode),
-              ),
-              closable: true,
-            });
-            return;
-          }
-
-          toaster.error({
-            id: "task-reference-solutions-save-error",
-            title: intl.formatMessage(messages.saveError),
-            closable: true,
-          });
+        toaster.success({
+          id: `task-reference-solutions-save-success-${Date.now()}`,
+          title: intl.formatMessage(messages.saveSuccess),
+          closable: true,
         });
+      })(e).catch((err) => {
+        console.error(`${logModule} Error saving task`, err);
+
+        if (isApiErrorWithCode(err, ErrorCode.DUPLICATE_REFERENCE_SOLUTION)) {
+          toaster.error({
+            id: `duplicate-reference-solution-${Date.now()}`,
+            title: intl.formatMessage(getErrorMessageDescriptor(err.errorCode)),
+            closable: true,
+          });
+          return;
+        }
+
+        toaster.error({
+          id: "task-reference-solutions-save-error",
+          title: intl.formatMessage(messages.saveError),
+          closable: true,
+        });
+      });
     },
     [handleSubmit, onSubmit, reset, intl],
   );
@@ -594,7 +586,7 @@ const TaskFormReferenceSolutions = ({
           {shouldShowSaveButton && (
             <SubmitFormButton
               label={submitMessage}
-              disabled={!isDirty || !isValid}
+              disabled={!isDirty}
               data-testid="task-reference-solutions-form-submit"
             />
           )}

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -258,7 +258,7 @@ const TaskFormReferenceSolutions = ({
 
   const {
     handleSubmit,
-    formState: { errors, isDirty },
+    formState: { errors, isDirty, isSubmitted },
     watch,
     reset,
     setValue,
@@ -274,9 +274,10 @@ const TaskFormReferenceSolutions = ({
     (referenceSolutions: CreateReferenceSolutionDtoWithId[]) => {
       setValue("referenceSolutions", referenceSolutions, {
         shouldDirty: true,
+        shouldValidate: isSubmitted,
       });
     },
-    [setValue],
+    [setValue, isSubmitted],
   );
 
   const updateReferenceSolution = useCallback(
@@ -507,6 +508,7 @@ const TaskFormReferenceSolutions = ({
 
                       setValue("referenceSolutionFiles", newObject, {
                         shouldDirty: true,
+                        shouldValidate: isSubmitted,
                       });
                     }}
                   >
@@ -570,7 +572,7 @@ const TaskFormReferenceSolutions = ({
                     ...referenceSolutionFiles,
                     [showSolveTaskModalForId]: solution.file,
                   },
-                  { shouldDirty: true },
+                  { shouldDirty: true, shouldValidate: isSubmitted },
                 );
 
                 // react hook form does not detect the file change, so we need to set it manually

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -274,7 +274,6 @@ const TaskFormReferenceSolutions = ({
     (referenceSolutions: CreateReferenceSolutionDtoWithId[]) => {
       setValue("referenceSolutions", referenceSolutions, {
         shouldDirty: true,
-        shouldValidate: true,
       });
     },
     [setValue],
@@ -508,7 +507,6 @@ const TaskFormReferenceSolutions = ({
 
                       setValue("referenceSolutionFiles", newObject, {
                         shouldDirty: true,
-                        shouldValidate: true,
                       });
                     }}
                   >
@@ -572,13 +570,12 @@ const TaskFormReferenceSolutions = ({
                     ...referenceSolutionFiles,
                     [showSolveTaskModalForId]: solution.file,
                   },
-                  { shouldDirty: true, shouldValidate: true },
+                  { shouldDirty: true },
                 );
 
                 // react hook form does not detect the file change, so we need to set it manually
                 setValue("_fileChanged", true, {
                   shouldDirty: true,
-                  shouldValidate: true,
                 });
               }}
             />

--- a/frontend/src/components/task/TaskFormReferenceSolutions.tsx
+++ b/frontend/src/components/task/TaskFormReferenceSolutions.tsx
@@ -427,7 +427,11 @@ const TaskFormReferenceSolutions = ({
                 data-testid={`solution-${solution.id}`}
               >
                 <div>
-                  <Field.Root>
+                  <Field.Root
+                    invalid={
+                      !!errors.referenceSolutions?.[index]?.title?.message
+                    }
+                  >
                     <Field.Label
                       data-testid={`reference-solution-${solution.id}-title`}
                     >
@@ -445,28 +449,27 @@ const TaskFormReferenceSolutions = ({
                         })
                       }
                     />
+                    <Field.ErrorText>
+                      {errors.referenceSolutions?.[index]?.title?.message}
+                    </Field.ErrorText>
                   </Field.Root>
-                  <Field.Root>
-                    <Field.Label
-                      data-testid={`reference-solution-${solution.id}-description`}
-                    >
-                      {intl.formatMessage(messages.description)}
-                    </Field.Label>
-
-                    <TextArea
-                      variant="subtle"
-                      rows={5}
-                      value={solution.description}
-                      disabled={disabled}
-                      data-testid={`reference-solution-${solution.id}-description-input`}
-                      onChange={(e) =>
-                        updateReferenceSolution(index, {
-                          ...referenceSolutions[index],
-                          description: e.target.value,
-                        })
-                      }
-                    />
-                  </Field.Root>
+                  <TextArea
+                    label={messages.description}
+                    variant="subtle"
+                    rows={5}
+                    value={solution.description}
+                    disabled={disabled}
+                    data-testid={`reference-solution-${solution.id}-description-input`}
+                    errorText={
+                      errors.referenceSolutions?.[index]?.description?.message
+                    }
+                    onChange={(e) =>
+                      updateReferenceSolution(index, {
+                        ...referenceSolutions[index],
+                        description: e.target.value,
+                      })
+                    }
+                  />
                   {!disabled && (
                     <Button
                       data-testid={`edit-solution-button-${solution.id}`}


### PR DESCRIPTION
<img width="1712" height="988" alt="image" src="https://github.com/user-attachments/assets/d8a2a282-f37c-4cfb-b382-4c6be36d6cc5" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Reference Solutions with the Task form: Save is enabled when the form is edited, and validation runs on submit with clear inline errors. Addresses CRT-401.

- **Bug Fixes**
  - Save button is enabled when the form is dirty; validation runs on submit only.
  - Inline errors show under each solution’s title and description.
  - After first submit, field edits validate only that field; removing a solution or changing a file re-validates the full form to clear stale errors.
  - Fixed submission to invoke the handler returned by `handleSubmit(e)`, so Save runs validation and prevents native browser submission.
  - Clarified the file-missing message and updated `en`/`fr` strings; improved save error handling with try/catch and toasts for duplicate solutions and generic failures.

<sup>Written for commit 8c9311add76378ed9857c3134218e0b34a647174. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

