### PR TITLE
[CRT-427] System should track block changes

### DIFF
--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -213,7 +213,7 @@ class Blocks extends React.Component<Props, State> {
     string,
     { timer: ReturnType<typeof setTimeout>; flush: () => void }
   >();
-  private static readonly FIELD_CHANGE_DEBOUNCE_MS = 500;
+  private static readonly FIELD_CHANGE_DEBOUNCE_MS = 1000;
 
   constructor(props: Props) {
     super(props);

--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -10,7 +10,7 @@ import VM, {
 } from "@scratch/scratch-vm";
 
 import { connect } from "react-redux";
-import ScratchBlocks, { Flyout, Workspace } from "scratch-blocks";
+import ScratchBlocks, { Block, Flyout, Workspace } from "scratch-blocks";
 import { Action, Dispatch } from "redux";
 import log from "@scratch-submodule/packages/scratch-gui/src/lib/log.js";
 import Prompt from "@scratch-submodule/packages/scratch-gui/src/containers/prompt.jsx";
@@ -207,6 +207,12 @@ class Blocks extends React.Component<Props, State> {
   private _renderedToolboxXML?: string;
   private setToolboxRefreshEnabled?: (enabled: boolean) => void;
   private toolboxUpdateTimeout?: number;
+
+  private fieldChangeDebouncers = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout>; flush: () => void }
+  >();
+  private static readonly FIELD_CHANGE_DEBOUNCE_MS = 500;
 
   constructor(props: Props) {
     super(props);
@@ -461,6 +467,7 @@ class Blocks extends React.Component<Props, State> {
   }
 
   componentWillUnmount() {
+    this.flushPendingFieldChanges();
     this.detachVM();
     this.getWorkspace().dispose();
     clearTimeout(this.toolboxUpdateTimeout);
@@ -1149,17 +1156,69 @@ class Blocks extends React.Component<Props, State> {
       return;
     }
 
+    if (
+      eventAction === StudentActionType.BlockChange &&
+      event.element === "field" &&
+      block
+    ) {
+      this.scheduleFieldChangeTracking(event, block);
+      return;
+    }
+
+    this.trackActivity(event, eventAction, block);
+  }
+
+  private trackActivity(
+    event: WorkspaceChangeEvent,
+    action: StudentActionType,
+    block: Block | null,
+  ) {
     const json = this.props.vm.toJSON();
     const solution = new Blob([json], { type: "application/json" });
 
     handleStudentActivityTracking({
       event,
-      action: eventAction,
+      action,
       canEditTask: this.props.canEditTask,
       sendRequest: this.props.sendRequest,
       solution,
       block,
     });
+  }
+
+  private scheduleFieldChangeTracking(
+    event: WorkspaceChangeEvent,
+    block: Block,
+  ) {
+    const key = `${event.blockId}:${event.name ?? ""}`;
+    const existing = this.fieldChangeDebouncers.get(key);
+
+    if (existing) {
+      clearTimeout(existing.timer);
+    }
+
+    const flush = () => {
+      this.fieldChangeDebouncers.delete(key);
+      this.trackActivity(event, StudentActionType.BlockChange, block);
+    };
+
+    const timer = setTimeout(flush, Blocks.FIELD_CHANGE_DEBOUNCE_MS);
+
+    this.fieldChangeDebouncers.set(key, { timer, flush });
+  }
+
+  private flushPendingFieldChanges() {
+    const pending = Array.from(this.fieldChangeDebouncers.values());
+    this.fieldChangeDebouncers.clear();
+
+    for (const { timer, flush } of pending) {
+      clearTimeout(timer);
+      try {
+        flush();
+      } catch (error) {
+        console.error("Error flushing pending field change activity:", error);
+      }
+    }
   }
 
   render() {

--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -75,6 +75,7 @@ import { getCrtColorsTheme } from "../../blocks/colors";
 import { StudentActionType } from "../../types/scratch-student-activities";
 import {
   handleStudentActivityTracking,
+  isFieldChangeEvent,
   mapScratchEventTypeToStudentActionType,
 } from "../../utilities/scratch-student-activities/student-activity-tracking";
 import { handleBlockLifecycle } from "../../utilities/scratch-student-activities/scratch-block";
@@ -1112,6 +1113,10 @@ class Blocks extends React.Component<Props, State> {
       return;
     }
 
+    if (!isFieldChangeEvent(event)) {
+      this.flushPendingFieldChanges();
+    }
+
     const isBlocked = shouldPreventBlocksActions(event, {
       canEditTask: this.props.canEditTask,
       vm: this.props.vm,
@@ -1156,11 +1161,7 @@ class Blocks extends React.Component<Props, State> {
       return;
     }
 
-    if (
-      eventAction === StudentActionType.BlockChange &&
-      event.element === "field" &&
-      block
-    ) {
+    if (isFieldChangeEvent(event) && block) {
       this.scheduleFieldChangeTracking(event, block);
       return;
     }

--- a/apps/scratch/src/types/scratch-student-activities/change/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/change/index.ts
@@ -1,1 +1,1 @@
-export type { StudentChangeActivity } from "./types";
+export type { StudentBlockChangeActivity } from "./types";

--- a/apps/scratch/src/types/scratch-student-activities/change/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/change/index.ts
@@ -1,0 +1,1 @@
+export type { StudentChangeActivity } from "./types";

--- a/apps/scratch/src/types/scratch-student-activities/change/types.ts
+++ b/apps/scratch/src/types/scratch-student-activities/change/types.ts
@@ -1,6 +1,6 @@
 import { StudentAppActivity } from "../common";
 
-export interface StudentChangeActivity extends StudentAppActivity {
+export interface StudentBlockChangeActivity extends StudentAppActivity {
   group: string | null;
   element: string | null;
   name: string | null;

--- a/apps/scratch/src/types/scratch-student-activities/change/types.ts
+++ b/apps/scratch/src/types/scratch-student-activities/change/types.ts
@@ -1,0 +1,9 @@
+import { StudentAppActivity } from "../common";
+
+export interface StudentChangeActivity extends StudentAppActivity {
+  group: string | null;
+  element: string | null;
+  name: string | null;
+  oldValue: unknown;
+  newValue: unknown;
+}

--- a/apps/scratch/src/types/scratch-student-activities/common.ts
+++ b/apps/scratch/src/types/scratch-student-activities/common.ts
@@ -26,8 +26,8 @@ export enum StudentActionType {
   Move = "move",
   Delete = "delete",
   GreenFlag = "greenFlag",
-  ConfirmedChange = "confirmedChange",
-  IntermediateChange = "intermediateChange",
+  BlockChange = "blockChange",
+  IntermediateFieldChange = "intermediateFieldChange",
 }
 
 export interface BasePipelineParams {

--- a/apps/scratch/src/types/scratch-student-activities/common.ts
+++ b/apps/scratch/src/types/scratch-student-activities/common.ts
@@ -26,6 +26,7 @@ export enum StudentActionType {
   Move = "move",
   Delete = "delete",
   GreenFlag = "greenFlag",
+  ConfirmedChange = "confirmedChange",
 }
 
 export interface BasePipelineParams {

--- a/apps/scratch/src/types/scratch-student-activities/common.ts
+++ b/apps/scratch/src/types/scratch-student-activities/common.ts
@@ -27,6 +27,7 @@ export enum StudentActionType {
   Delete = "delete",
   GreenFlag = "greenFlag",
   ConfirmedChange = "confirmedChange",
+  IntermediateChange = "intermediateChange",
 }
 
 export interface BasePipelineParams {

--- a/apps/scratch/src/types/scratch-student-activities/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/index.ts
@@ -12,8 +12,8 @@ export type { StudentDeleteActivity, DeleteStudentAction } from "./delete";
 
 export type { StudentMoveActivity } from "./move";
 
-export type { StudentChangeActivity } from "./change";
+export type { StudentBlockChangeActivity } from "./change";
 
-export type { StudentIntermediateChangeActivity } from "./intermediate-change";
+export type { StudentIntermediateFieldChangeActivity } from "./intermediate-change";
 
 export { StudentActionType } from "./common";

--- a/apps/scratch/src/types/scratch-student-activities/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/index.ts
@@ -12,4 +12,6 @@ export type { StudentDeleteActivity, DeleteStudentAction } from "./delete";
 
 export type { StudentMoveActivity } from "./move";
 
+export type { StudentChangeActivity } from "./change";
+
 export { StudentActionType } from "./common";

--- a/apps/scratch/src/types/scratch-student-activities/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/index.ts
@@ -14,4 +14,6 @@ export type { StudentMoveActivity } from "./move";
 
 export type { StudentChangeActivity } from "./change";
 
+export type { StudentIntermediateChangeActivity } from "./intermediate-change";
+
 export { StudentActionType } from "./common";

--- a/apps/scratch/src/types/scratch-student-activities/intermediate-change/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/intermediate-change/index.ts
@@ -1,1 +1,1 @@
-export type { StudentIntermediateChangeActivity } from "./types";
+export type { StudentIntermediateFieldChangeActivity } from "./types";

--- a/apps/scratch/src/types/scratch-student-activities/intermediate-change/index.ts
+++ b/apps/scratch/src/types/scratch-student-activities/intermediate-change/index.ts
@@ -1,0 +1,1 @@
+export type { StudentIntermediateChangeActivity } from "./types";

--- a/apps/scratch/src/types/scratch-student-activities/intermediate-change/types.ts
+++ b/apps/scratch/src/types/scratch-student-activities/intermediate-change/types.ts
@@ -1,0 +1,8 @@
+import { StudentAppActivity } from "../common";
+
+export interface StudentIntermediateChangeActivity extends StudentAppActivity {
+  group: string | null;
+  name: string | null;
+  oldValue: unknown;
+  newValue: unknown;
+}

--- a/apps/scratch/src/types/scratch-student-activities/intermediate-change/types.ts
+++ b/apps/scratch/src/types/scratch-student-activities/intermediate-change/types.ts
@@ -1,6 +1,7 @@
 import { StudentAppActivity } from "../common";
 
-export interface StudentIntermediateChangeActivity extends StudentAppActivity {
+export interface StudentIntermediateFieldChangeActivity
+  extends StudentAppActivity {
   group: string | null;
   name: string | null;
   oldValue: unknown;

--- a/apps/scratch/src/types/scratch-workspace.ts
+++ b/apps/scratch/src/types/scratch-workspace.ts
@@ -23,4 +23,10 @@ export interface WorkspaceChangeEvent {
   oldParentId?: string | null;
   newParentId?: string | null;
   isOutside?: boolean;
+
+  group?: string;
+  element?: string;
+  name?: string;
+  oldValue?: unknown;
+  newValue?: unknown;
 }

--- a/apps/scratch/src/types/scratch-workspace.ts
+++ b/apps/scratch/src/types/scratch-workspace.ts
@@ -4,6 +4,7 @@ export interface WorkspaceChangeEvent {
   type:
     | "create"
     | "change"
+    | "block_field_intermediate_change"
     | "move"
     | "dragOutside"
     | "endDrag"

--- a/apps/scratch/src/utilities/scratch-student-activities/filters/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/filters/index.ts
@@ -2,3 +2,4 @@ export { shouldTrackCreateBlock } from "./should-track-create";
 export { shouldTrackMoveBlock } from "./should-track-move";
 export { shouldTrackDeleteBlock } from "./should-track-delete";
 export { shouldTrackChange } from "./should-track-change";
+export { shouldTrackIntermediateChange } from "./should-track-intermediate-change";

--- a/apps/scratch/src/utilities/scratch-student-activities/filters/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/filters/index.ts
@@ -1,3 +1,4 @@
 export { shouldTrackCreateBlock } from "./should-track-create";
 export { shouldTrackMoveBlock } from "./should-track-move";
 export { shouldTrackDeleteBlock } from "./should-track-delete";
+export { shouldTrackChange } from "./should-track-change";

--- a/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-change.ts
@@ -1,0 +1,20 @@
+import { StudentActionType } from "../../../types/scratch-student-activities";
+import { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
+import { isTrackableStudentAction } from "./helpers";
+
+export const shouldTrackChange = (
+  event: WorkspaceChangeEvent,
+  canEditTask: boolean | undefined,
+): boolean => {
+  if (
+    !isTrackableStudentAction(
+      StudentActionType.ConfirmedChange,
+      event,
+      canEditTask,
+    )
+  ) {
+    return false;
+  }
+
+  return event.oldValue !== event.newValue;
+};

--- a/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-change.ts
@@ -7,11 +7,7 @@ export const shouldTrackChange = (
   canEditTask: boolean | undefined,
 ): boolean => {
   if (
-    !isTrackableStudentAction(
-      StudentActionType.ConfirmedChange,
-      event,
-      canEditTask,
-    )
+    !isTrackableStudentAction(StudentActionType.BlockChange, event, canEditTask)
   ) {
     return false;
   }

--- a/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-intermediate-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-intermediate-change.ts
@@ -1,0 +1,20 @@
+import { StudentActionType } from "../../../types/scratch-student-activities";
+import { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
+import { isTrackableStudentAction } from "./helpers";
+
+export const shouldTrackIntermediateChange = (
+  event: WorkspaceChangeEvent,
+  canEditTask: boolean | undefined,
+): boolean => {
+  if (
+    !isTrackableStudentAction(
+      StudentActionType.IntermediateChange,
+      event,
+      canEditTask,
+    )
+  ) {
+    return false;
+  }
+
+  return event.oldValue !== event.newValue;
+};

--- a/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-intermediate-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/filters/should-track-intermediate-change.ts
@@ -8,7 +8,7 @@ export const shouldTrackIntermediateChange = (
 ): boolean => {
   if (
     !isTrackableStudentAction(
-      StudentActionType.IntermediateChange,
+      StudentActionType.IntermediateFieldChange,
       event,
       canEditTask,
     )

--- a/apps/scratch/src/utilities/scratch-student-activities/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/index.ts
@@ -1,3 +1,4 @@
 export { trackCreateActivity } from "./student-create";
 export { trackMoveActivity } from "./student-move";
 export { trackDeleteActivity } from "./student-delete";
+export { trackChangeActivity } from "./student-change";

--- a/apps/scratch/src/utilities/scratch-student-activities/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/index.ts
@@ -2,3 +2,4 @@ export { trackCreateActivity } from "./student-create";
 export { trackMoveActivity } from "./student-move";
 export { trackDeleteActivity } from "./student-delete";
 export { trackChangeActivity } from "./student-change";
+export { trackIntermediateChangeActivity } from "./student-intermediate-change";

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/get-change-payload.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/get-change-payload.ts
@@ -7,7 +7,7 @@ import type { StudentChangeActivity } from "../../../types/scratch-student-activ
 export const getChangePayload = (
   block: Block,
   event: WorkspaceChangeEvent,
-): StudentChangeActivity | null => {
+): StudentChangeActivity => {
   if (!hasValidBlockContext(event)) {
     throw new MissingAttributeError(event, "blockId");
   }

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/get-change-payload.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/get-change-payload.ts
@@ -1,0 +1,24 @@
+import { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
+import { hasValidBlockContext } from "../scratch-block";
+import { MissingAttributeError } from "../../../exceptions";
+import type { Block } from "scratch-blocks";
+import type { StudentChangeActivity } from "../../../types/scratch-student-activities";
+
+export const getChangePayload = (
+  block: Block,
+  event: WorkspaceChangeEvent,
+): StudentChangeActivity | null => {
+  if (!hasValidBlockContext(event)) {
+    throw new MissingAttributeError(event, "blockId");
+  }
+
+  return {
+    blockId: event.blockId,
+    blockType: block.type,
+    group: event.group ?? null,
+    element: event.element ?? null,
+    name: event.name ?? null,
+    oldValue: event.oldValue,
+    newValue: event.newValue,
+  };
+};

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/get-change-payload.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/get-change-payload.ts
@@ -2,12 +2,12 @@ import { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
 import { hasValidBlockContext } from "../scratch-block";
 import { MissingAttributeError } from "../../../exceptions";
 import type { Block } from "scratch-blocks";
-import type { StudentChangeActivity } from "../../../types/scratch-student-activities";
+import type { StudentBlockChangeActivity } from "../../../types/scratch-student-activities";
 
 export const getChangePayload = (
   block: Block,
   event: WorkspaceChangeEvent,
-): StudentChangeActivity => {
+): StudentBlockChangeActivity => {
   if (!hasValidBlockContext(event)) {
     throw new MissingAttributeError(event, "blockId");
   }

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/get-intermediate-change-payload.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/get-intermediate-change-payload.ts
@@ -1,0 +1,23 @@
+import { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
+import { hasValidBlockContext } from "../scratch-block";
+import { MissingAttributeError } from "../../../exceptions";
+import type { Block } from "scratch-blocks";
+import type { StudentIntermediateChangeActivity } from "../../../types/scratch-student-activities";
+
+export const getIntermediateChangePayload = (
+  block: Block,
+  event: WorkspaceChangeEvent,
+): StudentIntermediateChangeActivity | null => {
+  if (!hasValidBlockContext(event)) {
+    throw new MissingAttributeError(event, "blockId");
+  }
+
+  return {
+    blockId: event.blockId,
+    blockType: block.type,
+    group: event.group ?? null,
+    name: event.name ?? null,
+    oldValue: event.oldValue,
+    newValue: event.newValue,
+  };
+};

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/get-intermediate-change-payload.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/get-intermediate-change-payload.ts
@@ -2,12 +2,12 @@ import { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
 import { hasValidBlockContext } from "../scratch-block";
 import { MissingAttributeError } from "../../../exceptions";
 import type { Block } from "scratch-blocks";
-import type { StudentIntermediateChangeActivity } from "../../../types/scratch-student-activities";
+import type { StudentIntermediateFieldChangeActivity } from "../../../types/scratch-student-activities";
 
 export const getIntermediateChangePayload = (
   block: Block,
   event: WorkspaceChangeEvent,
-): StudentIntermediateChangeActivity | null => {
+): StudentIntermediateFieldChangeActivity | null => {
   if (!hasValidBlockContext(event)) {
     throw new MissingAttributeError(event, "blockId");
   }

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/index.ts
@@ -2,3 +2,4 @@ export { getCreatePayload } from "./get-create-payload";
 export { getMovePayload } from "./get-move-payload";
 export { getDeletePayload } from "./get-delete-payload";
 export { getChangePayload } from "./get-change-payload";
+export { getIntermediateChangePayload } from "./get-intermediate-change-payload";

--- a/apps/scratch/src/utilities/scratch-student-activities/payloads/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/payloads/index.ts
@@ -1,3 +1,4 @@
 export { getCreatePayload } from "./get-create-payload";
 export { getMovePayload } from "./get-move-payload";
 export { getDeletePayload } from "./get-delete-payload";
+export { getChangePayload } from "./get-change-payload";

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/index.ts
@@ -2,3 +2,4 @@ export { sendCreateActivity } from "./send-create-activity";
 export { sendMoveActivity } from "./send-move-activity";
 export { sendDeleteActivity } from "./send-delete-activity";
 export { sendGreenFlagActivity } from "./send-green-flag-activity";
+export { sendChangeActivity } from "./send-change-activity";

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/index.ts
@@ -3,3 +3,4 @@ export { sendMoveActivity } from "./send-move-activity";
 export { sendDeleteActivity } from "./send-delete-activity";
 export { sendGreenFlagActivity } from "./send-green-flag-activity";
 export { sendChangeActivity } from "./send-change-activity";
+export { sendIntermediateChangeActivity } from "./send-intermediate-change-activity";

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
@@ -1,0 +1,21 @@
+import {
+  StudentActionType,
+  type StudentChangeActivity,
+} from "../../../types/scratch-student-activities";
+import { CrtContextValue } from "../../../contexts/CrtContext";
+
+export async function sendChangeActivity(
+  data: StudentChangeActivity,
+  sendRequest: CrtContextValue["sendRequest"],
+  solution: Blob,
+): Promise<void> {
+  try {
+    await sendRequest("postStudentAppActivity", {
+      action: StudentActionType.ConfirmedChange,
+      data,
+      solution,
+    });
+  } catch (error) {
+    console.error("Error sending change activity:", error);
+  }
+}

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
@@ -1,17 +1,17 @@
 import {
   StudentActionType,
-  type StudentChangeActivity,
+  type StudentBlockChangeActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
 
 export async function sendChangeActivity(
-  data: StudentChangeActivity,
+  data: StudentBlockChangeActivity,
   sendRequest: CrtContextValue["sendRequest"],
   solution: Blob,
 ): Promise<void> {
   try {
     await sendRequest("postStudentAppActivity", {
-      action: StudentActionType.ConfirmedChange,
+      action: StudentActionType.BlockChange,
       data,
       solution,
     });

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
@@ -1,0 +1,21 @@
+import {
+  StudentActionType,
+  type StudentIntermediateChangeActivity,
+} from "../../../types/scratch-student-activities";
+import { CrtContextValue } from "../../../contexts/CrtContext";
+
+export async function sendIntermediateChangeActivity(
+  data: StudentIntermediateChangeActivity,
+  sendRequest: CrtContextValue["sendRequest"],
+  solution: Blob,
+): Promise<void> {
+  try {
+    await sendRequest("postStudentAppActivity", {
+      action: StudentActionType.IntermediateChange,
+      data,
+      solution,
+    });
+  } catch (error) {
+    console.error("Error sending intermediate change activity:", error);
+  }
+}

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
@@ -1,17 +1,17 @@
 import {
   StudentActionType,
-  type StudentIntermediateChangeActivity,
+  type StudentIntermediateFieldChangeActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
 
 export async function sendIntermediateChangeActivity(
-  data: StudentIntermediateChangeActivity,
+  data: StudentIntermediateFieldChangeActivity,
   sendRequest: CrtContextValue["sendRequest"],
   solution: Blob,
 ): Promise<void> {
   try {
     await sendRequest("postStudentAppActivity", {
-      action: StudentActionType.IntermediateChange,
+      action: StudentActionType.IntermediateFieldChange,
       data,
       solution,
     });

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -13,8 +13,19 @@ const scratchToStudentActionType: Record<string, StudentActionType> = {
   create: StudentActionType.Create,
   move: StudentActionType.Move,
   delete: StudentActionType.Delete,
-  change: StudentActionType.ConfirmedChange,
-  // block_field_intermediate_change: StudentActionType.IntermediateChange,
+  /**
+   * Note:
+   *
+   * In the Scratch version we currently have, 'change' is emitted per keystroke
+   * while editing a field, not just on commit. So it already covers the
+   * keystroke sequence, which is why intermediate tracking is left off
+   *
+   * A newer Scratch version adds 'block_field_intermediate_change' for
+   * the per-keystroke edits and makes `change` commit-only. Once we upgrade,
+   * uncomment it.
+   */
+  change: StudentActionType.BlockChange,
+  // block_field_intermediate_change: StudentActionType.IntermediateFieldChange,
 };
 
 export const mapScratchEventTypeToStudentActionType = (
@@ -86,7 +97,7 @@ export const handleStudentActivityTracking = ({
       break;
     }
 
-    case StudentActionType.ConfirmedChange: {
+    case StudentActionType.BlockChange: {
       if (!block) {
         return;
       }
@@ -102,7 +113,7 @@ export const handleStudentActivityTracking = ({
       break;
     }
 
-    // case StudentActionType.IntermediateChange: {
+    // case StudentActionType.IntermediateFieldChange: {
     //   if (!block) {
     //     return;
     //   }

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -16,9 +16,10 @@ const scratchToStudentActionType: Record<string, StudentActionType> = {
   /**
    * Note:
    *
-   * In the Scratch version we currently have, 'change' is emitted per keystroke
-   * while editing a field, not just on commit. So it already covers the
-   * keystroke sequence, which is why intermediate tracking is left off
+   * In the current scratch version (scratch-editor 11.6.0-react-18, see
+   * src/scratch-editor/package.json), 'change' is emitted per keystroke while
+   * editing a field, not just on commit. So it already covers the keystroke
+   * sequence, which is why intermediate tracking is left off.
    *
    * A newer Scratch version adds 'block_field_intermediate_change' for
    * the per-keystroke edits and makes `change` commit-only. Once we upgrade,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -1,12 +1,18 @@
 import { StudentActionType } from "../../types/scratch-student-activities";
 import { StudentActivityHandlerParams } from "../../types/scratch-student-activities";
 import { mapDeletedBlock } from "./scratch-block";
-import { trackCreateActivity, trackDeleteActivity, trackMoveActivity } from ".";
+import {
+  trackChangeActivity,
+  trackCreateActivity,
+  trackDeleteActivity,
+  trackMoveActivity,
+} from ".";
 
 const scratchToStudentActionType: Record<string, StudentActionType> = {
   create: StudentActionType.Create,
   move: StudentActionType.Move,
   delete: StudentActionType.Delete,
+  change: StudentActionType.ConfirmedChange,
 };
 
 export const mapScratchEventTypeToStudentActionType = (
@@ -68,6 +74,22 @@ export const handleStudentActivityTracking = ({
       }
 
       trackMoveActivity({
+        block,
+        sendRequest,
+        solution,
+        event,
+        canEditTask,
+      });
+
+      break;
+    }
+
+    case StudentActionType.ConfirmedChange: {
+      if (!block) {
+        return;
+      }
+
+      trackChangeActivity({
         block,
         sendRequest,
         solution,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -14,7 +14,7 @@ const scratchToStudentActionType: Record<string, StudentActionType> = {
   move: StudentActionType.Move,
   delete: StudentActionType.Delete,
   change: StudentActionType.ConfirmedChange,
-  block_field_intermediate_change: StudentActionType.IntermediateChange,
+  // block_field_intermediate_change: StudentActionType.IntermediateChange,
 };
 
 export const mapScratchEventTypeToStudentActionType = (

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -1,5 +1,6 @@
 import { StudentActionType } from "../../types/scratch-student-activities";
 import { StudentActivityHandlerParams } from "../../types/scratch-student-activities";
+import { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import { mapDeletedBlock } from "./scratch-block";
 import {
   trackChangeActivity,
@@ -32,6 +33,9 @@ const scratchToStudentActionType: Record<string, StudentActionType> = {
 export const mapScratchEventTypeToStudentActionType = (
   type: string,
 ): StudentActionType | null => scratchToStudentActionType[type] || null;
+
+export const isFieldChangeEvent = (event: WorkspaceChangeEvent): boolean =>
+  event.type === "change" && event.element === "field";
 
 export const handleStudentActivityTracking = ({
   event,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -5,6 +5,7 @@ import {
   trackChangeActivity,
   trackCreateActivity,
   trackDeleteActivity,
+  trackIntermediateChangeActivity,
   trackMoveActivity,
 } from ".";
 
@@ -13,6 +14,7 @@ const scratchToStudentActionType: Record<string, StudentActionType> = {
   move: StudentActionType.Move,
   delete: StudentActionType.Delete,
   change: StudentActionType.ConfirmedChange,
+  block_field_intermediate_change: StudentActionType.IntermediateChange,
 };
 
 export const mapScratchEventTypeToStudentActionType = (
@@ -90,6 +92,22 @@ export const handleStudentActivityTracking = ({
       }
 
       trackChangeActivity({
+        block,
+        sendRequest,
+        solution,
+        event,
+        canEditTask,
+      });
+
+      break;
+    }
+
+    case StudentActionType.IntermediateChange: {
+      if (!block) {
+        return;
+      }
+
+      trackIntermediateChangeActivity({
         block,
         sendRequest,
         solution,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -5,7 +5,7 @@ import {
   trackChangeActivity,
   trackCreateActivity,
   trackDeleteActivity,
-  trackIntermediateChangeActivity,
+  // trackIntermediateChangeActivity,
   trackMoveActivity,
 } from ".";
 
@@ -102,21 +102,21 @@ export const handleStudentActivityTracking = ({
       break;
     }
 
-    case StudentActionType.IntermediateChange: {
-      if (!block) {
-        return;
-      }
+    // case StudentActionType.IntermediateChange: {
+    //   if (!block) {
+    //     return;
+    //   }
 
-      trackIntermediateChangeActivity({
-        block,
-        sendRequest,
-        solution,
-        event,
-        canEditTask,
-      });
+    //   trackIntermediateChangeActivity({
+    //     block,
+    //     sendRequest,
+    //     solution,
+    //     event,
+    //     canEditTask,
+    //   });
 
-      break;
-    }
+    //   break;
+    // }
 
     default:
       throw new Error(`Unhandled student action type: ${action}`);

--- a/apps/scratch/src/utilities/scratch-student-activities/student-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-change.ts
@@ -1,0 +1,25 @@
+import { StudentActionContext } from "../../types/scratch-student-activities";
+import { shouldTrackChange } from "./filters/should-track-change";
+import { getChangePayload } from "./payloads";
+import { sendChangeActivity } from "./senders/send-change-activity";
+
+export const trackChangeActivity = ({
+  block,
+  sendRequest,
+  solution,
+  event,
+  canEditTask,
+}: StudentActionContext): void => {
+  if (!shouldTrackChange(event, canEditTask)) {
+    return;
+  }
+
+  const data = getChangePayload(block, event);
+
+  if (!data) {
+    console.error("Could not create payload for changed block", block, event);
+    return;
+  }
+
+  sendChangeActivity(data, sendRequest, solution);
+};

--- a/apps/scratch/src/utilities/scratch-student-activities/student-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-change.ts
@@ -16,10 +16,5 @@ export const trackChangeActivity = ({
 
   const data = getChangePayload(block, event);
 
-  if (!data) {
-    console.error("Could not create payload for changed block", block, event);
-    return;
-  }
-
   sendChangeActivity(data, sendRequest, solution);
 };

--- a/apps/scratch/src/utilities/scratch-student-activities/student-intermediate-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-intermediate-change.ts
@@ -1,0 +1,29 @@
+import { StudentActionContext } from "../../types/scratch-student-activities";
+import { shouldTrackIntermediateChange } from "./filters/should-track-intermediate-change";
+import { getIntermediateChangePayload } from "./payloads";
+import { sendIntermediateChangeActivity } from "./senders/send-intermediate-change-activity";
+
+export const trackIntermediateChangeActivity = ({
+  block,
+  sendRequest,
+  solution,
+  event,
+  canEditTask,
+}: StudentActionContext): void => {
+  if (!shouldTrackIntermediateChange(event, canEditTask)) {
+    return;
+  }
+
+  const data = getIntermediateChangePayload(block, event);
+
+  if (!data) {
+    console.error(
+      "Could not create payload for intermediate-changed block",
+      block,
+      event,
+    );
+    return;
+  }
+
+  sendIntermediateChangeActivity(data, sendRequest, solution);
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Track confirmed Scratch block field changes as student activities and debounce per-keystroke updates to reduce noise for CRT-427. Intermediate keystroke tracking is implemented but disabled until the Scratch upgrade.

- **New Features**
  - Debounce field change tracking (1s) and flush pending changes before non-field events and on unmount.
  - Added `StudentActionType`: `BlockChange`, `IntermediateFieldChange`; map Scratch `change` to `BlockChange` and leave `block_field_intermediate_change` unmapped.
  - Track only when `oldValue !== newValue`; build payload and send via `postStudentAppActivity`.
  - New types: `StudentBlockChangeActivity`, `StudentIntermediateFieldChangeActivity`; extended `WorkspaceChangeEvent` with `group`, `element`, `name`, `oldValue`, `newValue`.
  - Added filters, payload builders, and senders; only `BlockChange` wired into the handler.

- **Bug Fixes**
  - `getChangePayload` returns `StudentBlockChangeActivity` (non-null) for consistent typing.

<sup>Written for commit 7a05559a3f2e3e03b14544a806f350c99bd3142d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

