### PR TITLE
[CRT-428] Handle validation failure correctly

### DIFF
--- a/frontend/src/components/task/TaskForm.tsx
+++ b/frontend/src/components/task/TaskForm.tsx
@@ -462,7 +462,7 @@ const TaskForm = ({
     (e: React.FormEvent<HTMLFormElement>) => {
       let data: TaskFormValues;
 
-      handleSubmit((v: TaskFormValues) => {
+      handleSubmit(async (v: TaskFormValues) => {
         data = v;
 
         // A null taskFile affects UI state:
@@ -478,7 +478,7 @@ const TaskForm = ({
           return Promise.reject(new NoTaskFileError());
         }
 
-        return onSubmit({
+        await onSubmit({
           title: data.title,
           description: data.description,
           type: data.type,
@@ -488,55 +488,51 @@ const TaskForm = ({
           isPublic: data.isPublic,
           clearAllReferenceSolutions: clearSolutionsOnSave,
         } satisfies TaskFormSubmission);
-      })(e)
-        .then(() => {
-          // allow navigation after the task has been saved
-          cannotNavigate.current = false;
 
-          setHasTypeChanged(false);
-          setClearSolutionsOnSave(false);
+        // allow navigation after the task has been saved
+        cannotNavigate.current = false;
 
-          // reset the form to the updated values
-          // and mark the blob as not changed
-          // so the user can navigate without confirmation
-          reset(data);
+        setHasTypeChanged(false);
+        setClearSolutionsOnSave(false);
 
-          toaster.success({
-            id: "task-save-success",
-            title: intl.formatMessage(messages.saveSuccess),
-            closable: true,
-          });
-        })
-        .catch((err) => {
-          console.error(`${logModule} Error saving task`, err);
+        // reset the form to the updated values
+        // and mark the blob as not changed
+        // so the user can navigate without confirmation
+        reset(data);
 
-          if (err instanceof NoTaskFileError) {
-            toaster.error({
-              id: "task-file-required",
-              title: intl.formatMessage(messages.taskFileRequired),
-              closable: true,
-            });
-            return;
-          }
-
-          if (err instanceof ConflictError) {
-            toaster.error({
-              id: "task-conflict-error",
-              title: intl.formatMessage(
-                getErrorMessageDescriptor(err.errorCode),
-              ),
-              closable: true,
-            });
-            onConflictError?.();
-            return;
-          }
-
-          toaster.error({
-            id: "task-save-error",
-            title: intl.formatMessage(messages.saveError),
-            closable: true,
-          });
+        toaster.success({
+          id: "task-save-success",
+          title: intl.formatMessage(messages.saveSuccess),
+          closable: true,
         });
+      })(e).catch((err) => {
+        console.error(`${logModule} Error saving task`, err);
+
+        if (err instanceof NoTaskFileError) {
+          toaster.error({
+            id: "task-file-required",
+            title: intl.formatMessage(messages.taskFileRequired),
+            closable: true,
+          });
+          return;
+        }
+
+        if (err instanceof ConflictError) {
+          toaster.error({
+            id: "task-conflict-error",
+            title: intl.formatMessage(getErrorMessageDescriptor(err.errorCode)),
+            closable: true,
+          });
+          onConflictError?.();
+          return;
+        }
+
+        toaster.error({
+          id: "task-save-error",
+          title: intl.formatMessage(messages.saveError),
+          closable: true,
+        });
+      });
     },
     [
       handleSubmit,

--- a/frontend/src/components/task/TaskForm.tsx
+++ b/frontend/src/components/task/TaskForm.tsx
@@ -475,7 +475,7 @@ const TaskForm = ({
             type: "manual",
             message: intl.formatMessage(messages.taskFileRequired),
           });
-          return Promise.reject(new NoTaskFileError());
+          throw new NoTaskFileError();
         }
 
         await onSubmit({


### PR DESCRIPTION
Closes [CRT-428](https://classroomrt.atlassian.net/browse/CRT-428)

[CRT-428]: https://classroomrt.atlassian.net/browse/CRT-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CRT-428 by showing “Task saved successfully” only after a valid submission and completed save. Also fixes async error handling to prevent false success toasts and unhandled rejections on the Create Task page.

- **Bug Fixes**
  - Await `onSubmit` in `handleSubmit`; run success toast, form reset, and navigation unlock only after a successful save. Switched validation path to `throw` and added a `catch` to handle errors cleanly.
  - Centralized error toasts for missing task file and `ConflictError`, plus a generic failure toast. No success toast or state reset on validation failure (no save, no network call), matching CRT-428.

<sup>Written for commit 29227e1f71a98650fd0b2a1a8a20ef78a89d7b46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

