### PR TITLE
Add missing namespaces to app logs

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
@@ -8,6 +8,8 @@ import {
 import { AppCrtIframeApi } from "../iframe-rpc/src";
 import { sendTaskSolution } from "./send-task-solution";
 
+const logModule = "[Jupyter][Auto Save]";
+
 export type ExecutionScheduledCallback = Parameters<
   typeof NotebookActions.executionScheduled.connect
 >[0];
@@ -112,7 +114,10 @@ export class TaskAutoSaver {
       try {
         await saver.saveNotebook(panel, model);
       } catch (error) {
-        console.error(`Failed to save notebook ${model.toString()}:`, error);
+        console.error(
+          `${logModule} Failed to save notebook ${model.toString()}:`,
+          error,
+        );
       }
     });
   }
@@ -152,7 +157,7 @@ export class TaskAutoSaver {
       await panel.context.save();
       await this.postCurrentSolution(panel);
     } catch (error) {
-      console.error(`Save failed:`, error);
+      console.error(`${logModule} Save failed:`, error);
     }
   }
 
@@ -166,7 +171,7 @@ export class TaskAutoSaver {
 
       await sendTaskSolution(solution, this.sendRequest);
     } catch (error) {
-      console.warn("Failed to post solution to parent:", error);
+      console.warn(`${logModule} Failed to post solution to parent:`, error);
     }
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
@@ -8,7 +8,7 @@ import {
 import { AppCrtIframeApi } from "../iframe-rpc/src";
 import { sendTaskSolution } from "./send-task-solution";
 
-const logModule = "[Jupyter][Auto Save]";
+const logModule = "[Jupyter][auto-save/task-auto-saver]";
 
 export type ExecutionScheduledCallback = Parameters<
   typeof NotebookActions.executionScheduled.connect

--- a/apps/jupyter/extensions/notebook-runner/src/command.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/command.ts
@@ -5,7 +5,7 @@ import { Contents, ContentsManager } from "@jupyterlab/services";
 import { NotebookRunnerState } from "./notebook-runner-state";
 import { executePythonInKernel, writeJsonToVirtualFilesystem } from "./utils";
 
-const logModule = "[Jupyter][Command]";
+const logModule = "[Jupyter][command]";
 
 export const runAssignCommand = "notebook-runner:run-assign";
 export const runGradingCommand = "notebook-runner:run-grading";

--- a/apps/jupyter/extensions/notebook-runner/src/command.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/command.ts
@@ -5,6 +5,8 @@ import { Contents, ContentsManager } from "@jupyterlab/services";
 import { NotebookRunnerState } from "./notebook-runner-state";
 import { executePythonInKernel, writeJsonToVirtualFilesystem } from "./utils";
 
+const logModule = "[Jupyter][Command]";
+
 export const runAssignCommand = "notebook-runner:run-assign";
 export const runGradingCommand = "notebook-runner:run-grading";
 export const runAllCellsCommand = "notebook-runner:run-all-cells";
@@ -22,7 +24,7 @@ export const executeRunNotebookCommand = async (
   notebookPath: string,
   binaryResultsPath: string,
 ): Promise<void> => {
-  console.debug("Opening notebook at path:", notebookPath);
+  console.debug(`${logModule} Opening notebook at path:`, notebookPath);
 
   state.allowNextNotebookInParallel = true;
   const newNotebookPanel = documentManager.open(
@@ -53,10 +55,12 @@ export const executeRunNotebookCommand = async (
 
   // Connect to existing kernel if available
   const otterKernel = await state.getOtterKernel();
-  console.debug("Reusing existing otter kernel:", otterKernel);
+  console.debug(`${logModule} Reusing existing otter kernel:`, otterKernel);
 
   // copying the notebook to the virtual filesystem on the kernel in the same location
-  console.debug("Copying notebook to virtual filesystem before running");
+  console.debug(
+    `${logModule} Copying notebook to virtual filesystem before running`,
+  );
   let notebook: Contents.IModel | null = null;
   try {
     notebook = await contentsManager.get(notebookPath, { content: true });
@@ -79,7 +83,7 @@ export const executeRunNotebookCommand = async (
 
   // get parent directory of the notebook
   const parentDir = notebookPath.split("/").slice(0, -1).join("/");
-  console.debug("Change working directory to ", parentDir);
+  console.debug(`${logModule} Change working directory to `, parentDir);
 
   await executePythonInKernel({
     kernel: otterKernel,
@@ -94,7 +98,7 @@ nb.init_grading_mode("./tests")
 
   // Run all cells silently
   console.debug(
-    "Running all cells in the new notebook:",
+    `${logModule} Running all cells in the new notebook:`,
     newNotebookPanel.title.label,
   );
 
@@ -103,7 +107,9 @@ nb.init_grading_mode("./tests")
     newNotebookPanel.context.sessionContext,
   );
 
-  console.debug("All cells executed in the new notebook. Now running tests...");
+  console.debug(
+    `${logModule} All cells executed in the new notebook. Now running tests...`,
+  );
 
   await executePythonInKernel({
     kernel: otterKernel,
@@ -122,15 +128,15 @@ with open("${binaryResultsPath}", "wb") as f:
     `,
   });
 
-  console.debug("Tests executed, saving notebook...");
+  console.debug(`${logModule} Tests executed, saving notebook...`);
 
   await newNotebookPanel.context.save();
 
-  console.debug("Notebook saved. Closing notebook...");
+  console.debug(`${logModule} Notebook saved. Closing notebook...`);
 
   const waitUntilClosed = new Promise<void>((resolve) => {
     newNotebookPanel.disposed.connect(() => {
-      console.debug("Closed notebook that was run");
+      console.debug(`${logModule} Closed notebook that was run`);
       resolve();
     });
   });
@@ -140,5 +146,5 @@ with open("${binaryResultsPath}", "wb") as f:
   // wait until the widget is closed
   await waitUntilClosed;
 
-  console.debug("Notebook closed.");
+  console.debug(`${logModule} Notebook closed.`);
 };

--- a/apps/jupyter/extensions/notebook-runner/src/commands/assign.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/assign.ts
@@ -9,6 +9,8 @@ import { CannotReadNotebookException } from "../errors/otter-errors";
 import { DEBUG_NOTEBOOK_RUNNER } from "../constants";
 import { copyRequiredFoldersToKernel, handleOtterCommandError } from "./helper";
 
+const logModule = "[Jupyter][Assign]";
+
 export const registerAssignCommand = (
   state: NotebookRunnerState,
   app: JupyterFrontEnd,
@@ -20,7 +22,7 @@ export const registerAssignCommand = (
     isVisible: () => DEBUG_NOTEBOOK_RUNNER,
     execute: async () => {
       try {
-        console.debug("Saving all open notebooks...");
+        console.debug(`${logModule} Saving all open notebooks...`);
         const widgets = app.shell.widgets("main");
 
         const savePromises: Promise<void>[] = [];
@@ -32,10 +34,12 @@ export const registerAssignCommand = (
         }
         await Promise.all(savePromises);
 
-        console.debug(`Waiting for otter session kernel to be available`);
+        console.debug(
+          `${logModule} Waiting for otter session kernel to be available`,
+        );
         const kernel = await state.getOtterKernel();
 
-        console.debug(`Generating student task and autograder...`);
+        console.debug(`${logModule} Generating student task and autograder...`);
 
         // read notebook template
         let template: Contents.IModel | null = null;
@@ -46,7 +50,7 @@ export const registerAssignCommand = (
           );
         } catch (error) {
           console.debug(
-            `Cannot read notebook: ${EmbeddedPythonCallbacks.taskTemplateLocation}`,
+            `${logModule} Cannot read notebook: ${EmbeddedPythonCallbacks.taskTemplateLocation}`,
             error,
           );
           throw new CannotReadNotebookException(
@@ -75,7 +79,7 @@ assign(
           `,
         });
 
-        console.debug("Retrieving generated files...");
+        console.debug(`${logModule} Retrieving generated files...`);
 
         await executePythonInKernel({
           kernel,
@@ -92,7 +96,7 @@ def first_file_with_extension(directory, extension):
         });
 
         console.debug(
-          "Looking for first file with extension .zip in /autograder",
+          `${logModule} Looking for first file with extension .zip in /autograder`,
         );
 
         // there should now be an 'autograder' directory containing a zip file with a random name
@@ -109,7 +113,7 @@ shutil.move(
       `,
         });
 
-        console.debug("Retrieving autograder...");
+        console.debug(`${logModule} Retrieving autograder...`);
 
         await app.serviceManager.contents.save("/autograder", {
           type: "directory",
@@ -135,7 +139,7 @@ shutil.move(
           },
         );
 
-        console.debug("Retrieving student notebook...");
+        console.debug(`${logModule} Retrieving student notebook...`);
 
         // and a 'student' directory containing a jupyter notebook.
         const studentNotebook =

--- a/apps/jupyter/extensions/notebook-runner/src/commands/assign.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/assign.ts
@@ -9,7 +9,7 @@ import { CannotReadNotebookException } from "../errors/otter-errors";
 import { DEBUG_NOTEBOOK_RUNNER } from "../constants";
 import { copyRequiredFoldersToKernel, handleOtterCommandError } from "./helper";
 
-const logModule = "[Jupyter][Assign]";
+const logModule = "[Jupyter][commands/assign]";
 
 export const registerAssignCommand = (
   state: NotebookRunnerState,

--- a/apps/jupyter/extensions/notebook-runner/src/commands/grade.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/grade.ts
@@ -18,7 +18,7 @@ import {
   kernelPaths,
 } from "./helper";
 
-const logModule = "[Jupyter][Grade]";
+const logModule = "[Jupyter][commands/grade]";
 
 const createOnNewNotebookListener =
   (app: JupyterFrontEnd, state: NotebookRunnerState) =>

--- a/apps/jupyter/extensions/notebook-runner/src/commands/grade.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/grade.ts
@@ -18,6 +18,8 @@ import {
   kernelPaths,
 } from "./helper";
 
+const logModule = "[Jupyter][Grade]";
+
 const createOnNewNotebookListener =
   (app: JupyterFrontEnd, state: NotebookRunnerState) =>
   async (
@@ -30,7 +32,7 @@ const createOnNewNotebookListener =
 
       for (const widget of widgets) {
         if (widget instanceof NotebookPanel && widget !== notebookPanel) {
-          console.debug("Closing notebook: ", widget);
+          console.debug(`${logModule} Closing notebook: `, widget);
           await widget.context.save();
           await widget.sessionContext.shutdown();
           widget.close();
@@ -52,7 +54,7 @@ export const registerGradeCommand = (
     isVisible: () => DEBUG_NOTEBOOK_RUNNER,
     execute: async (): Promise<OtterGradingResults> => {
       try {
-        console.debug("Saving all open notebooks...");
+        console.debug(`${logModule} Saving all open notebooks...`);
         const widgets = app.shell.widgets("main");
 
         const savePromises: Promise<void>[] = [];
@@ -64,10 +66,12 @@ export const registerGradeCommand = (
         }
         await Promise.all(savePromises);
 
-        console.debug(`Waiting for otter session kernel to be available`);
+        console.debug(
+          `${logModule} Waiting for otter session kernel to be available`,
+        );
         const kernel = await state.getOtterKernel();
 
-        console.debug(`Transferring autograder for grading...`);
+        console.debug(`${logModule} Transferring autograder for grading...`);
 
         let autograder: Contents.IModel | null = null;
         try {
@@ -85,7 +89,9 @@ export const registerGradeCommand = (
           autograder.content,
         );
 
-        console.debug(`Unpack tests from autograder.zip to student/`);
+        console.debug(
+          `${logModule} Unpack tests from autograder.zip to student/`,
+        );
 
         await executePythonInKernel({
           kernel,
@@ -101,7 +107,9 @@ with zipfile.ZipFile(autograder_path, 'r') as zip_ref:
 `,
         });
 
-        console.debug(`Executing notebook before submitting it for grading`);
+        console.debug(
+          `${logModule} Executing notebook before submitting it for grading`,
+        );
 
         await executeRunNotebookCommand(
           app,
@@ -127,7 +135,7 @@ with zipfile.ZipFile(autograder_path, 'r') as zip_ref:
         }
 
         console.debug(
-          `Transfering executed notebook to virtual filesystem to '${EmbeddedPythonCallbacks.studentTaskLocation}'`,
+          `${logModule} Transfering executed notebook to virtual filesystem to '${EmbeddedPythonCallbacks.studentTaskLocation}'`,
         );
 
         await writeJsonToVirtualFilesystem(
@@ -137,7 +145,7 @@ with zipfile.ZipFile(autograder_path, 'r') as zip_ref:
         );
 
         console.debug(
-          "Running notebook with autograder: ",
+          `${logModule} Running notebook with autograder: `,
           EmbeddedPythonCallbacks.autograderLocation,
         );
 
@@ -161,10 +169,10 @@ run(
         try {
           await run;
         } catch (error) {
-          console.error("Error running notebook:", error);
+          console.error(`${logModule} Error running notebook:`, error);
         }
 
-        console.debug("Retrieving results...");
+        console.debug(`${logModule} Retrieving results...`);
 
         const results =
           await state.readJsonFromVirtualFilesystem<OtterGradingResults>(
@@ -172,7 +180,7 @@ run(
             "/results.json",
           );
 
-        console.debug("Grading results:", results);
+        console.debug(`${logModule} Grading results:`, results);
 
         return results;
       } catch (error) {

--- a/apps/jupyter/extensions/notebook-runner/src/commands/helper.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/helper.ts
@@ -12,7 +12,7 @@ import {
   CannotReadNotebookException,
 } from "../errors/otter-errors";
 
-const logModule = "[Jupyter][Command Helper]";
+const logModule = "[Jupyter][commands/helper]";
 
 export const kernelPaths = {
   data: "/data",

--- a/apps/jupyter/extensions/notebook-runner/src/commands/helper.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/helper.ts
@@ -12,6 +12,8 @@ import {
   CannotReadNotebookException,
 } from "../errors/otter-errors";
 
+const logModule = "[Jupyter][Command Helper]";
+
 export const kernelPaths = {
   data: "/data",
   src: "/src",
@@ -67,7 +69,7 @@ const copyFolderToKernelIfExists = async (
   } catch (error) {
     if (error instanceof DirectoryNotFoundError) {
       console.warn(
-        `Warning: ${error.message}. Continuing without copying ${sourcePath} folder.`,
+        `${logModule} Warning: ${error.message}. Continuing without copying ${sourcePath} folder.`,
       );
     } else {
       throw error; // Re-throw if it's a different error
@@ -87,7 +89,7 @@ const copyFolderToKernel = async (
     folder = await contents.get(sourcePath, { content: true });
   } catch (e) {
     console.debug(
-      `Error accessing ${sourcePath}:`,
+      `${logModule} Error accessing ${sourcePath}:`,
       e,
       ". Treating as not found.",
     );

--- a/apps/jupyter/extensions/notebook-runner/src/commands/run-all-cells.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/run-all-cells.ts
@@ -8,7 +8,7 @@ import { messages } from "../i18n/messages";
 import { formatMessage } from "../i18n/intl";
 import { AppCrtIframeApi, ToastType } from "../iframe-rpc/src";
 
-const logModule = "[Jupyter][Run All Cells]";
+const logModule = "[Jupyter][commands/run-all-cells]";
 
 export const registerRunAllCellsCommand = (
   state: NotebookRunnerState,

--- a/apps/jupyter/extensions/notebook-runner/src/commands/run-all-cells.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/commands/run-all-cells.ts
@@ -8,6 +8,8 @@ import { messages } from "../i18n/messages";
 import { formatMessage } from "../i18n/intl";
 import { AppCrtIframeApi, ToastType } from "../iframe-rpc/src";
 
+const logModule = "[Jupyter][Run All Cells]";
+
 export const registerRunAllCellsCommand = (
   state: NotebookRunnerState,
   app: JupyterFrontEnd,
@@ -20,18 +22,21 @@ export const registerRunAllCellsCommand = (
       const currentNotebook = notebookTracker.currentWidget;
 
       if (currentNotebook === null) {
-        console.warn("No active notebook to run cells in.");
+        console.warn(`${logModule} No active notebook to run cells in.`);
         return;
       }
 
       console.debug(
-        "awaiting for packages to be ready before running cells...",
+        `${logModule} awaiting for packages to be ready before running cells...`,
       );
 
       try {
         await waitForPackagesReady();
       } catch (error) {
-        console.error("Cannot run cells, package installation failed:", error);
+        console.error(
+          `${logModule} Cannot run cells, package installation failed:`,
+          error,
+        );
 
         await sendMessage(
           formatMessage(messages.packageInstallationFailedTitle),
@@ -39,19 +44,22 @@ export const registerRunAllCellsCommand = (
           ToastType.Error,
           sendRequest,
         ).catch((messageError) => {
-          console.error("Failed to show error notification:", messageError);
+          console.error(
+            `${logModule} Failed to show error notification:`,
+            messageError,
+          );
         });
 
         return;
       }
 
-      console.debug("packages are ready, running cells...");
+      console.debug(`${logModule} packages are ready, running cells...`);
 
       await NotebookActions.runAll(
         currentNotebook.content,
         currentNotebook.context.sessionContext,
       );
-      console.debug("finished running cells");
+      console.debug(`${logModule} finished running cells`);
     },
   });
 };

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -49,7 +49,7 @@ import {
 } from "./iframe-rpc/src/methods/export-task";
 import { toCrtLocale, toJupyterLocale } from "./languages";
 
-const logModule = "[Jupyter][Embedded]";
+const logModule = "[Jupyter][iframe-api]";
 
 const initIframeApi = (handleRequest: AppHandleRequestMap): AppCrtIframeApi => {
   const crtPlatform = new AppCrtIframeApi({

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -49,7 +49,7 @@ import {
 } from "./iframe-rpc/src/methods/export-task";
 import { toCrtLocale, toJupyterLocale } from "./languages";
 
-const logModule = "[Embedded Jupyter]";
+const logModule = "[Jupyter][Embedded]";
 
 const initIframeApi = (handleRequest: AppHandleRequestMap): AppCrtIframeApi => {
   const crtPlatform = new AppCrtIframeApi({

--- a/apps/jupyter/extensions/notebook-runner/src/index.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/index.ts
@@ -25,6 +25,8 @@ import { messages } from "./i18n/messages";
 import { formatMessage, setIntlLocale } from "./i18n/intl";
 import { toCrtLocale } from "./languages";
 
+const logModule = "[Jupyter][Notebook Runner]";
+
 enableSentry();
 
 /**
@@ -58,7 +60,9 @@ const plugin: JupyterFrontEndPlugin<void> = {
     factory: IFileBrowserFactory,
     settingRegistry: ISettingRegistry,
   ) => {
-    console.debug("JupyterLab extension notebook-runner is activated!");
+    console.debug(
+      `${logModule} JupyterLab extension notebook-runner is activated!`,
+    );
 
     // The default file browser instance
     const fileBrowser = factory.tracker.find(
@@ -66,7 +70,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     );
 
     if (!fileBrowser) {
-      console.warn("No default file browser found");
+      console.warn(`${logModule} No default file browser found`);
       return;
     }
 
@@ -91,14 +95,20 @@ const plugin: JupyterFrontEndPlugin<void> = {
         setIntlLocale(toCrtLocale(rawLocale));
       }
     } catch (error) {
-      console.error("Failed to read locale for notebook-runner i18n:", error);
+      console.error(
+        `${logModule} Failed to read locale for notebook-runner i18n:`,
+        error,
+      );
       await sendMessage(
         formatMessage(messages.localeReadFailedTitle),
         formatMessage(messages.localeReadFailedBody),
         ToastType.Error,
         platform.sendRequest.bind(platform),
       ).catch((error) => {
-        console.error("Failed to show locale read error notification", error);
+        console.error(
+          `${logModule} Failed to show locale read error notification`,
+          error,
+        );
       });
     }
 
@@ -148,7 +158,10 @@ const plugin: JupyterFrontEndPlugin<void> = {
         loadingStateManager,
       );
     } catch (error) {
-      console.error("Failed to initialize package installation flow:", error);
+      console.error(
+        `${logModule} Failed to initialize package installation flow:`,
+        error,
+      );
 
       await sendMessage(
         formatMessage(messages.initFailedTitle),
@@ -157,7 +170,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         platform.sendRequest.bind(platform),
       ).catch((messageError) => {
         console.error(
-          "Failed to show initialization error notification:",
+          `${logModule} Failed to show initialization error notification:`,
           messageError,
         );
       });

--- a/apps/jupyter/extensions/notebook-runner/src/index.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/index.ts
@@ -25,7 +25,7 @@ import { messages } from "./i18n/messages";
 import { formatMessage, setIntlLocale } from "./i18n/intl";
 import { toCrtLocale } from "./languages";
 
-const logModule = "[Jupyter][Notebook Runner]";
+const logModule = "[Jupyter][index]";
 
 enableSentry();
 

--- a/apps/jupyter/extensions/notebook-runner/src/loading-state.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/loading-state.ts
@@ -6,7 +6,7 @@ import { sendMessage } from "./send-message";
 import { messages } from "./i18n/messages";
 import { formatMessage } from "./i18n/intl";
 
-const logModule = "[Jupyter][Loading State]";
+const logModule = "[Jupyter][loading-state]";
 
 const executionToolbarButtons = new Set(["run", "advance"]);
 const alwaysDisabledToolbarButtons = new Set([

--- a/apps/jupyter/extensions/notebook-runner/src/loading-state.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/loading-state.ts
@@ -6,6 +6,8 @@ import { sendMessage } from "./send-message";
 import { messages } from "./i18n/messages";
 import { formatMessage } from "./i18n/intl";
 
+const logModule = "[Jupyter][Loading State]";
+
 const executionToolbarButtons = new Set(["run", "advance"]);
 const alwaysDisabledToolbarButtons = new Set([
   "restart",
@@ -74,7 +76,10 @@ export class LoadingStateManager {
       type,
       this.sendRequest,
     ).catch((error) => {
-      console.error(`Failed to show "${title.id}" notification:`, error);
+      console.error(
+        `${logModule} Failed to show "${title.id}" notification:`,
+        error,
+      );
     });
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/notebook-runner-state.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/notebook-runner-state.ts
@@ -15,7 +15,7 @@ import {
 } from "./utils";
 import { installNbConvert, installOtter } from "./packages";
 
-const logModule = "[Jupyter][Runner State]";
+const logModule = "[Jupyter][notebook-runner-state]";
 
 /**
  * A listener that is called when a comm message is received from the kernel.

--- a/apps/jupyter/extensions/notebook-runner/src/notebook-runner-state.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/notebook-runner-state.ts
@@ -15,6 +15,8 @@ import {
 } from "./utils";
 import { installNbConvert, installOtter } from "./packages";
 
+const logModule = "[Jupyter][Runner State]";
+
 /**
  * A listener that is called when a comm message is received from the kernel.
  */
@@ -74,7 +76,7 @@ export class NotebookRunnerState {
     try {
       const serviceManager = this.app.serviceManager;
 
-      console.debug("Initializing Otter session context...");
+      console.debug(`${logModule} Initializing Otter session context...`);
       sessionContext = new SessionContext({
         sessionManager: serviceManager.sessions,
         specsManager: serviceManager.kernelspecs,
@@ -88,14 +90,14 @@ export class NotebookRunnerState {
       });
 
       // Initialize the session
-      console.debug("Initializing otter context...");
+      console.debug(`${logModule} Initializing otter context...`);
       await sessionContext.initialize();
 
-      console.debug("Adding kernel listeners to otter context...");
+      console.debug(`${logModule} Adding kernel listeners to otter context...`);
 
       await setupKernel(sessionContext, async (kernel) => {
         console.debug(
-          "Kernel is ready:",
+          `${logModule} Kernel is ready:`,
           kernel.name,
           "attaching listeners...",
         );
@@ -103,7 +105,7 @@ export class NotebookRunnerState {
         await this.prepareOtterKernel(kernel);
       });
 
-      console.debug("Otter context initialized:", sessionContext);
+      console.debug(`${logModule} Otter context initialized:`, sessionContext);
 
       this._resolveOtterSessionContext(sessionContext);
 
@@ -120,7 +122,11 @@ export class NotebookRunnerState {
         await isDisposed;
       }
 
-      console.error("Error initializing otter context:", e, ". Restarting...");
+      console.error(
+        `${logModule} Error initializing otter context:`,
+        e,
+        ". Restarting...",
+      );
       return this.init();
     }
   }
@@ -150,9 +156,9 @@ export class NotebookRunnerState {
   }
 
   private async prepareOtterKernel(kernel: IKernelConnection): Promise<void> {
-    console.debug("Preparing Otter kernel:", kernel.name);
+    console.debug(`${logModule} Preparing Otter kernel:`, kernel.name);
 
-    console.debug("Importing basic libraries...");
+    console.debug(`${logModule} Importing basic libraries...`);
     await executePythonInKernel({
       kernel,
       code: `
@@ -164,7 +170,7 @@ from ipykernel.comm import Comm
     await installOtter(kernel);
     await installNbConvert(kernel);
 
-    console.debug("Importing Otter Grader...");
+    console.debug(`${logModule} Importing Otter Grader...`);
     await executePythonInKernel({
       kernel,
       code: `
@@ -174,7 +180,7 @@ from otter.run import main as run
       disposeOnDone: true,
     });
 
-    console.debug("Otter Grader is ready to be used!", kernel);
+    console.debug(`${logModule} Otter Grader is ready to be used!`, kernel);
     setKernelIsPrepared(kernel);
   }
 
@@ -189,14 +195,14 @@ from otter.run import main as run
 
     while (!sessionContext.session?.kernel) {
       console.debug(
-        "No kernel available in otter session context, restarting the kernel...",
+        `${logModule} No kernel available in otter session context, restarting the kernel...`,
         sessionContext.session,
       );
       await sessionContext.startKernel();
     }
 
     console.debug(
-      "Kernel is available in otter session, waiting for it to be prepared:",
+      `${logModule} Kernel is available in otter session, waiting for it to be prepared:`,
       sessionContext.session.kernel,
     );
     await waitForKernelToBePrepared(sessionContext.session.kernel);

--- a/apps/jupyter/extensions/notebook-runner/src/packages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/packages.ts
@@ -11,6 +11,8 @@ import {
 import { EmbeddedPythonCallbacks } from "./iframe-api";
 import { LoadingStateManager } from "./loading-state";
 
+const logModule = "[Jupyter][Packages]";
+
 /**
  * resolver for `_packagesReady`. it is called once the student-task notebook's
  * kernel has finished installing packages and copying the notebook content
@@ -46,26 +48,26 @@ const autoInstallPackages =
       if (KernelMessage.isStatusMsg(msg)) {
         // ignore status messages
       } else if (KernelMessage.isStreamMsg(msg)) {
-        console.debug(`[${kernel.id}]`, msg.content.text);
+        console.debug(`${logModule} [${kernel.id}]`, msg.content.text);
       } else if (KernelMessage.isExecuteInputMsg(msg)) {
         console.debug(
-          `[${kernel.id}] Executing code (${msg.content.execution_count}):\n`,
+          `${logModule} [${kernel.id}] Executing code (${msg.content.execution_count}):\n`,
           msg.content.code,
         );
       } else if (KernelMessage.isExecuteResultMsg(msg)) {
         console.debug(
-          `[${kernel.id}] Finished executing code (${msg.content.execution_count}):`,
+          `${logModule} [${kernel.id}] Finished executing code (${msg.content.execution_count}):`,
           msg.content.data,
         );
       } else {
-        console.debug(`[${kernel.id}] IOPub message:`, msg);
+        console.debug(`${logModule} [${kernel.id}] IOPub message:`, msg);
       }
     });
 
     try {
-      console.debug("Installing packages...", kernel.id);
+      console.debug(`${logModule} Installing packages...`, kernel.id);
       await installOtter(kernel);
-      console.debug("Finished installing packages", kernel.id);
+      console.debug(`${logModule} Finished installing packages`, kernel.id);
 
       const isStudentNotebook =
         // JupyterLite seems to sometimes use a leading slash and sometimes not, hence
@@ -75,7 +77,7 @@ const autoInstallPackages =
 
       if (isStudentNotebook) {
         console.debug(
-          "Opened student notebook - copying notebook to the virtual filesystem to make tests available.",
+          `${logModule} Opened student notebook - copying notebook to the virtual filesystem to make tests available.`,
         );
 
         let notebook: Contents.IModel | null = null;
@@ -88,7 +90,7 @@ const autoInstallPackages =
         }
 
         console.debug(
-          `Finished reading notebook content, writing to virtual filesystem and changing working directory to ${studentWorkingDirectory}...`,
+          `${logModule} Finished reading notebook content, writing to virtual filesystem and changing working directory to ${studentWorkingDirectory}...`,
           kernel.id,
         );
 
@@ -99,7 +101,7 @@ const autoInstallPackages =
           studentWorkingDirectory,
         );
         console.debug(
-          `Finished copying notebook to the virtual filesystem and changing working directory to ${studentWorkingDirectory}`,
+          `${logModule} Finished copying notebook to the virtual filesystem and changing working directory to ${studentWorkingDirectory}`,
           kernel.id,
         );
       }
@@ -118,7 +120,11 @@ const trackSession = (
 ): Promise<void> => {
   // start the kernel so the install runs in the background, instead of waiting for something else to trigger it.
   sessionContext.initialize().catch((error) => {
-    console.error("Failed to initialize session for", notebookPath, error);
+    console.error(
+      `${logModule} Failed to initialize session for`,
+      notebookPath,
+      error,
+    );
   });
 
   return setupKernel(
@@ -153,13 +159,13 @@ export const installPackagesWithLoadingState = async (
   await loadingStateManager.startLoading();
 
   preInstallPackages(app, contentsManager, notebookTracker).catch((error) => {
-    console.error("preInstallPackages failed:", error);
+    console.error(`${logModule} preInstallPackages failed:`, error);
   });
 
   waitForPackagesReady()
     .then(() => loadingStateManager.finishLoading(true))
     .catch((error) => {
-      console.error("Error waiting for packages to be ready:", error);
+      console.error(`${logModule} Error waiting for packages to be ready:`, error);
       return loadingStateManager.finishLoading(false);
     });
 };
@@ -167,7 +173,7 @@ export const installPackagesWithLoadingState = async (
 export const installOtter = async (
   kernel: IKernelConnection,
 ): Promise<void> => {
-  console.debug("Installing Otter Grader...");
+  console.debug(`${logModule} Installing Otter Grader...`);
   await executePythonInKernel({
     kernel,
     code: `
@@ -182,7 +188,7 @@ await micropip.install("/jupyter/pypi/otter_grader-6.1.3-py3-none-any.whl")
 export const installNbConvert = async (
   kernel: IKernelConnection,
 ): Promise<void> => {
-  console.debug("Installing nbconvert...");
+  console.debug(`${logModule} Installing nbconvert...`);
   await executePythonInKernel({
     kernel,
     // Micropip by default installs all dependencies including tornado which is not mandatory,
@@ -198,7 +204,7 @@ await micropip.install("jupyter_client", deps=False)
     disposeOnDone: true,
   });
 
-  console.debug("Installing remaining dependencies...");
+  console.debug(`${logModule} Installing remaining dependencies...`);
   await executePythonInKernel({
     kernel,
     code: `
@@ -225,7 +231,7 @@ await micropip.install([
     disposeOnDone: true,
   });
 
-  console.debug("Creating nbclient mock...");
+  console.debug(`${logModule} Creating nbclient mock...`);
   await executePythonInKernel(
     // make nbclient.exceptions available, copied from https://gist.github.com/bollwyvl/6b3cb4c46b1764c6d9ae1e5831f86d7a#file-nbconvert-in-jupyterlite-ipynb
     {
@@ -245,7 +251,7 @@ sys.modules["nbclient.exceptions"] = nbclient_exceptions
     },
   );
 
-  console.debug("Patching nbclient for JupyterLite...");
+  console.debug(`${logModule} Patching nbclient for JupyterLite...`);
   await executePythonInKernel({
     kernel,
     // make nbconvert.preprocessors available without importing execute, copied from https://gist.github.com/bollwyvl/6b3cb4c46b1764c6d9ae1e5831f86d7a#file-nbconvert-in-jupyterlite-ipynb

--- a/apps/jupyter/extensions/notebook-runner/src/packages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/packages.ts
@@ -11,7 +11,7 @@ import {
 import { EmbeddedPythonCallbacks } from "./iframe-api";
 import { LoadingStateManager } from "./loading-state";
 
-const logModule = "[Jupyter][Packages]";
+const logModule = "[Jupyter][packages]";
 
 /**
  * resolver for `_packagesReady`. it is called once the student-task notebook's
@@ -165,7 +165,10 @@ export const installPackagesWithLoadingState = async (
   waitForPackagesReady()
     .then(() => loadingStateManager.finishLoading(true))
     .catch((error) => {
-      console.error(`${logModule} Error waiting for packages to be ready:`, error);
+      console.error(
+        `${logModule} Error waiting for packages to be ready:`,
+        error,
+      );
       return loadingStateManager.finishLoading(false);
     });
 };

--- a/apps/jupyter/extensions/notebook-runner/src/utils.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/utils.ts
@@ -5,6 +5,8 @@ import { IExecuteReplyMsg } from "@jupyterlab/services/lib/kernel/messages";
 import { FileNotFoundError } from "./errors/task-errors";
 import { AssignNotebookFormatException } from "./errors/otter-errors";
 
+const logModule = "[Jupyter][Utils]";
+
 const isPreparedKey = "__isPrepared";
 const preparedKey = "__prepared";
 const preparedResolveKey = "__preparedResolve";
@@ -106,7 +108,7 @@ export const setupKernel = async (
   sessionContext: ISessionContext,
   setup: (kernel: IKernelConnection) => Promise<void>,
 ): Promise<void> => {
-  console.debug("Waiting for session context to be ready...");
+  console.debug(`${logModule} Waiting for session context to be ready...`);
   await sessionContext.ready;
 
   let kernel = sessionContext.session?.kernel;
@@ -141,7 +143,9 @@ export const setupKernel = async (
   ): Promise<void> => {
     let kernel = change.newValue;
     if (kernel === null) {
-      console.warn("Kernel is not available in session context, restarting...");
+      console.warn(
+        `${logModule} Kernel is not available in session context, restarting...`,
+      );
 
       try {
         sessionCtx.kernelChanged.disconnect(restartListener);
@@ -150,7 +154,7 @@ export const setupKernel = async (
           name: "python",
         });
       } catch (error) {
-        console.error("Error restarting kernel:", error);
+        console.error(`${logModule} Error restarting kernel:`, error);
         return;
       } finally {
         sessionCtx.kernelChanged.connect(restartListener);
@@ -166,7 +170,7 @@ export const setupKernel = async (
       }
     }
 
-    console.debug("Kernel changed:", kernel.name);
+    console.debug(`${logModule} Kernel changed:`, kernel.name);
     await kernel.info;
 
     return setup(kernel);

--- a/apps/jupyter/extensions/notebook-runner/src/utils.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/utils.ts
@@ -5,7 +5,7 @@ import { IExecuteReplyMsg } from "@jupyterlab/services/lib/kernel/messages";
 import { FileNotFoundError } from "./errors/task-errors";
 import { AssignNotebookFormatException } from "./errors/otter-errors";
 
-const logModule = "[Jupyter][Utils]";
+const logModule = "[Jupyter][utils]";
 
 const isPreparedKey = "__isPrepared";
 const preparedKey = "__prepared";

--- a/apps/scratch/src/blocks/block-config.ts
+++ b/apps/scratch/src/blocks/block-config.ts
@@ -4,6 +4,8 @@ import { isBlockInFlyoutCanvas } from "../utilities/scratch-selectors";
 import { ScratchCrtConfig } from "../types/scratch-vm-custom";
 import { ignoreEvent, svgNamespace } from "./helpers";
 
+const logModule = "[Scratch][Block Config]";
+
 const buttonHeight = 20;
 const buttonWidth = 60;
 
@@ -109,7 +111,7 @@ const updateBlockConfigButton = (
 
   if (typeof allowedCount === "boolean") {
     console.error(
-      `Trying to limit the number of visible blocks for ${blockId} which is not configured for this`,
+      `${logModule} Trying to limit the number of visible blocks for ${blockId} which is not configured for this`,
     );
     return;
   }

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -1,6 +1,8 @@
 import { WorkspaceChangeEvent } from "../types/scratch-workspace";
 import { countUsedBlocks } from "./block-config";
 
+const logModule = "[Scratch][Block Helpers]";
+
 export const svgNamespace = "http://www.w3.org/2000/svg";
 
 export const ignoreEvent = (event: MouseEvent): void => {
@@ -155,7 +157,7 @@ export const wouldExceedLimits = (
 ): boolean => {
   const config = vm.crtConfig;
   if (!config) {
-    console.debug("No config found, not blocking any blocks");
+    console.debug(`${logModule} No config found, not blocking any blocks`);
     return false;
   }
 
@@ -171,7 +173,7 @@ export const wouldExceedLimits = (
 
   if (isPreventedEntirely) {
     console.debug(
-      `Block ${block.type} is not allowed, blocking addition of blocks`,
+      `${logModule} Block ${block.type} is not allowed, blocking addition of blocks`,
     );
     return true;
   }
@@ -184,7 +186,7 @@ export const wouldExceedLimits = (
   // we use >= to prevent going over the limit by one.
   if (hasLimit && count >= allowed) {
     console.debug(
-      `Block limit reached for ${block.type}: ${count} >= ${allowed}`,
+      `${logModule} Block limit reached for ${block.type}: ${count} >= ${allowed}`,
     );
     return true;
   }

--- a/apps/scratch/src/components/TaskConfig.tsx
+++ b/apps/scratch/src/components/TaskConfig.tsx
@@ -21,6 +21,8 @@ import { ScratchCrtConfig } from "../types/scratch-vm-custom";
 import { defaultMaximumExecutionTimeInMs } from "../utilities/constants";
 import Modal from "./modal/Modal";
 
+const logModule = "[Scratch][Task Config]";
+
 const Label = styled.label`
   display: flex !important;
 
@@ -73,7 +75,7 @@ const TaskConfig = ({
       const config = vm.crtConfig;
 
       if (!config) {
-        console.error("No task config found");
+        console.error(`${logModule} No task config found`);
         return;
       }
 
@@ -100,7 +102,7 @@ const TaskConfig = ({
 
   useEffect(() => {
     if (!vm.crtConfig) {
-      console.error("No task config found");
+      console.error(`${logModule} No task config found`);
       return;
     }
 
@@ -179,7 +181,7 @@ const TaskConfig = ({
 
   const onCancel = useCallback(() => {
     if (!configSnapshot.current || !vm.crtConfig) {
-      console.error("No config snapshot or task config found");
+      console.error(`${logModule} No config snapshot or task config found`);
       hideModal();
       return;
     }

--- a/apps/scratch/src/components/block-config/BlockConfig.tsx
+++ b/apps/scratch/src/components/block-config/BlockConfig.tsx
@@ -6,6 +6,8 @@ import { ModifyBlockConfigEvent } from "../../events/modify-block-config";
 import { UpdateBlockToolboxEvent } from "../../events/update-block-toolbox";
 import Modal from "../modal/Modal";
 
+const logModule = "[Scratch][Block Config]";
+
 const cannotBeUsed = 0;
 const infiniteUses = -1;
 
@@ -26,7 +28,7 @@ const BlockConfig = ({ vm }: { vm: VM }) => {
 
       if (typeof currentConfig === "boolean") {
         console.error(
-          `Trying to limit the number of blocks for ${e.blockId} which is not configured for this`,
+          `${logModule} Trying to limit the number of blocks for ${e.blockId} which is not configured for this`,
         );
         return;
       }
@@ -67,12 +69,12 @@ const BlockConfig = ({ vm }: { vm: VM }) => {
       const config = vm.crtConfig;
 
       if (!config) {
-        console.error("No task config found");
+        console.error(`${logModule} No task config found`);
         return;
       }
 
       if (!blockId) {
-        console.error("Block ID not found", blockId);
+        console.error(`${logModule} Block ID not found`, blockId);
         return;
       }
 

--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -85,6 +85,8 @@ import ExtensionLibrary from "./ExtensionLibrary";
 import type { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import type { CrtContextValue } from "../../contexts/CrtContext";
 
+const logModule = "[Scratch][Blocks]";
+
 const addFunctionListener = (
   object: unknown,
   property: string,
@@ -1217,7 +1219,10 @@ class Blocks extends React.Component<Props, State> {
       try {
         flush();
       } catch (error) {
-        console.error("Error flushing pending field change activity:", error);
+        console.error(
+          `${logModule} Error flushing pending field change activity:`,
+          error,
+        );
       }
     }
   }

--- a/apps/scratch/src/containers/customized-scratch-containers/Gui.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Gui.tsx
@@ -39,6 +39,8 @@ import HashParserHOC from "../../components/customized-scratch-components/HashPa
 import { ScratchCrtConfig } from "../../types/scratch-vm-custom";
 import AppStateHOC from "./AppStateHOC";
 
+const logModule = "[Scratch][Gui]";
+
 const GUIComponentTyped = GUIComponent as unknown as React.ComponentType<
   React.ComponentProps<typeof GUIComponent> & {
     children?: React.ReactNode;
@@ -211,7 +213,7 @@ class GUI extends React.Component<Props> {
         }
       })
       .catch((err) => {
-        console.error(err);
+        console.error(logModule, err);
       });
   }
 

--- a/apps/scratch/src/extensions/assertions/index.ts
+++ b/apps/scratch/src/extensions/assertions/index.ts
@@ -18,6 +18,8 @@ import {
 import testIconWhite from "./test-icon-white.svg";
 import testIconBlack from "./test-icon-black.svg";
 
+const logModule = "[Scratch][Assertions]";
+
 const messages = defineMessages({
   categoryName: {
     id: "crt.extensions.assertions.categoryName",
@@ -357,7 +359,7 @@ class AssertionExtension {
         this.runtime.emit("BLOCK_GLOW_ON", { id: assertion.blockId });
       } catch (error) {
         console.error(
-          `Assertion block with id ${assertion.blockId} not found for target ${assertion.targetId}.`,
+          `${logModule} Assertion block with id ${assertion.blockId} not found for target ${assertion.targetId}.`,
           "Original error:",
           error,
         );
@@ -371,7 +373,7 @@ class AssertionExtension {
         this.runtime.emit("BLOCK_GLOW_OFF", { id: assertion.blockId });
       } catch (error) {
         console.error(
-          `Assertion block with id ${assertion.blockId} not found for target ${assertion.targetId}`,
+          `${logModule} Assertion block with id ${assertion.blockId} not found for target ${assertion.targetId}`,
           "Original error:",
           error,
         );

--- a/apps/scratch/src/hooks/useEmbeddedScratch.ts
+++ b/apps/scratch/src/hooks/useEmbeddedScratch.ts
@@ -42,7 +42,7 @@ import { stopBufferingIframeMessages } from "../utilities/iframe-message-buffer"
 
 export const scratchIdentifierSeparator = "$";
 
-const logModule = "[Embedded Scratch]";
+const logModule = "[Scratch][Embedded]";
 
 const messages = defineMessages({
   cannotLoadProject: {
@@ -341,7 +341,7 @@ export class EmbeddedScratchCallbacks {
         filename: "task.sb3",
       };
     } catch (e) {
-      console.error(`Failed to export task:`, e);
+      console.error(`${logModule} Failed to export task:`, e);
 
       throw new CannotExportProjectError(this.getErrorMessage(e));
     }

--- a/apps/scratch/src/utilities/scratch-student-activities/log-module.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/log-module.ts
@@ -1,0 +1,1 @@
+export const logModule = "[Scratch][Student Activity]";

--- a/apps/scratch/src/utilities/scratch-student-activities/log-module.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/log-module.ts
@@ -1,1 +1,1 @@
-export const logModule = "[Scratch][Student Activity]";
+export const logBaseModule = "[Scratch][Student Activity]";

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -1,7 +1,9 @@
 import VM from "@scratch/scratch-vm";
 import { filterNonNull } from "../../filter-non-null";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
 import type { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
+
+const logModule = `${logBaseModule}[scratch-block/lifecycle]`;
 
 interface BlockLifecycleParams {
   event: WorkspaceChangeEvent;

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -1,5 +1,6 @@
 import VM from "@scratch/scratch-vm";
 import { filterNonNull } from "../../filter-non-null";
+import { logModule } from "../log-module";
 import type { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
 
 interface BlockLifecycleParams {
@@ -69,7 +70,7 @@ const getXmlFromEvent = (
       return event.oldXml;
 
     default:
-      console.error("Could not find xml in event", event);
+      console.error(`${logModule} Could not find xml in event`, event);
       return xmlElement;
   }
 };

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
@@ -3,6 +3,7 @@ import {
   type StudentBlockChangeActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
+import { logModule } from "../log-module";
 
 export async function sendChangeActivity(
   data: StudentBlockChangeActivity,
@@ -16,6 +17,6 @@ export async function sendChangeActivity(
       solution,
     });
   } catch (error) {
-    console.error("Error sending change activity:", error);
+    console.error(`${logModule} Error sending change activity:`, error);
   }
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-change-activity.ts
@@ -3,7 +3,9 @@ import {
   type StudentBlockChangeActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-change-activity]`;
 
 export async function sendChangeActivity(
   data: StudentBlockChangeActivity,

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-create-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-create-activity.ts
@@ -3,6 +3,7 @@ import {
   type StudentCreateActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
+import { logModule } from "../log-module";
 
 export async function sendCreateActivity(
   data: StudentCreateActivity,
@@ -16,6 +17,6 @@ export async function sendCreateActivity(
       solution,
     });
   } catch (error) {
-    console.error("Error sending create activity:", error);
+    console.error(`${logModule} Error sending create activity:`, error);
   }
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-create-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-create-activity.ts
@@ -3,7 +3,9 @@ import {
   type StudentCreateActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-create-activity]`;
 
 export async function sendCreateActivity(
   data: StudentCreateActivity,

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-delete-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-delete-activity.ts
@@ -3,7 +3,9 @@ import {
   StudentActionType,
   type StudentDeleteActivity,
 } from "../../../types/scratch-student-activities";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-delete-activity]`;
 
 export async function sendDeleteActivity(
   data: StudentDeleteActivity,

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-delete-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-delete-activity.ts
@@ -3,6 +3,7 @@ import {
   StudentActionType,
   type StudentDeleteActivity,
 } from "../../../types/scratch-student-activities";
+import { logModule } from "../log-module";
 
 export async function sendDeleteActivity(
   data: StudentDeleteActivity,
@@ -16,6 +17,6 @@ export async function sendDeleteActivity(
       solution,
     });
   } catch (error) {
-    console.error("Error sending delete activity:", error);
+    console.error(`${logModule} Error sending delete activity:`, error);
   }
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-green-flag-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-green-flag-activity.ts
@@ -1,6 +1,8 @@
 import { StudentActionType } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-green-flag-activity]`;
 
 export async function sendGreenFlagActivity(
   sendRequest: CrtContextValue["sendRequest"],

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-green-flag-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-green-flag-activity.ts
@@ -1,5 +1,6 @@
 import { StudentActionType } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
+import { logModule } from "../log-module";
 
 export async function sendGreenFlagActivity(
   sendRequest: CrtContextValue["sendRequest"],
@@ -12,6 +13,6 @@ export async function sendGreenFlagActivity(
       solution,
     });
   } catch (error) {
-    console.error("Error sending green flag activity:", error);
+    console.error(`${logModule} Error sending green flag activity:`, error);
   }
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
@@ -3,6 +3,7 @@ import {
   type StudentIntermediateFieldChangeActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
+import { logModule } from "../log-module";
 
 export async function sendIntermediateChangeActivity(
   data: StudentIntermediateFieldChangeActivity,
@@ -16,6 +17,9 @@ export async function sendIntermediateChangeActivity(
       solution,
     });
   } catch (error) {
-    console.error("Error sending intermediate change activity:", error);
+    console.error(
+      `${logModule} Error sending intermediate change activity:`,
+      error,
+    );
   }
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-intermediate-change-activity.ts
@@ -3,7 +3,9 @@ import {
   type StudentIntermediateFieldChangeActivity,
 } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-intermediate-change-activity]`;
 
 export async function sendIntermediateChangeActivity(
   data: StudentIntermediateFieldChangeActivity,

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-move-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-move-activity.ts
@@ -1,7 +1,9 @@
 import { StudentActionType } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
 import { StudentMoveActivity } from "../../../types/scratch-student-activities/move";
-import { logModule } from "../log-module";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-move-activity]`;
 
 export async function sendMoveActivity(
   data: StudentMoveActivity,

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-move-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-move-activity.ts
@@ -1,6 +1,7 @@
 import { StudentActionType } from "../../../types/scratch-student-activities";
 import { CrtContextValue } from "../../../contexts/CrtContext";
 import { StudentMoveActivity } from "../../../types/scratch-student-activities/move";
+import { logModule } from "../log-module";
 
 export async function sendMoveActivity(
   data: StudentMoveActivity,
@@ -14,6 +15,6 @@ export async function sendMoveActivity(
       solution,
     });
   } catch (error) {
-    console.error("Error sending move activity:", error);
+    console.error(`${logModule} Error sending move activity:`, error);
   }
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -2,7 +2,7 @@ import { StudentActionType } from "../../types/scratch-student-activities";
 import { StudentActivityHandlerParams } from "../../types/scratch-student-activities";
 import { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import { mapDeletedBlock } from "./scratch-block";
-import { logModule } from "./log-module";
+import { logBaseModule } from "./log-module";
 import {
   trackChangeActivity,
   trackCreateActivity,
@@ -10,6 +10,8 @@ import {
   // trackIntermediateChangeActivity,
   trackMoveActivity,
 } from ".";
+
+const logModule = `${logBaseModule}[student-activity-tracking]`;
 
 const scratchToStudentActionType: Record<string, StudentActionType> = {
   create: StudentActionType.Create,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-activity-tracking.ts
@@ -2,6 +2,7 @@ import { StudentActionType } from "../../types/scratch-student-activities";
 import { StudentActivityHandlerParams } from "../../types/scratch-student-activities";
 import { WorkspaceChangeEvent } from "../../types/scratch-workspace";
 import { mapDeletedBlock } from "./scratch-block";
+import { logModule } from "./log-module";
 import {
   trackChangeActivity,
   trackCreateActivity,
@@ -48,14 +49,14 @@ export const handleStudentActivityTracking = ({
   switch (action) {
     case StudentActionType.Delete: {
       if (!event.oldXml) {
-        console.error("Could not find xml in event", event);
+        console.error(`${logModule} Could not find xml in event`, event);
         return;
       }
 
       const block = mapDeletedBlock(event.oldXml);
 
       if (!block) {
-        console.error("Could not retrieve deleted block");
+        console.error(`${logModule} Could not retrieve deleted block`);
         return;
       }
 

--- a/apps/scratch/src/utilities/scratch-student-activities/student-create.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-create.ts
@@ -2,7 +2,9 @@ import { StudentActionContext } from "../../types/scratch-student-activities";
 import { shouldTrackCreateBlock } from "./filters/should-track-create";
 import { getCreatePayload } from "./payloads";
 import { sendCreateActivity } from "./senders/send-create-activity";
-import { logModule } from "./log-module";
+import { logBaseModule } from "./log-module";
+
+const logModule = `${logBaseModule}[student-create]`;
 
 export const trackCreateActivity = ({
   block,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-create.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-create.ts
@@ -2,6 +2,7 @@ import { StudentActionContext } from "../../types/scratch-student-activities";
 import { shouldTrackCreateBlock } from "./filters/should-track-create";
 import { getCreatePayload } from "./payloads";
 import { sendCreateActivity } from "./senders/send-create-activity";
+import { logModule } from "./log-module";
 
 export const trackCreateActivity = ({
   block,
@@ -17,7 +18,11 @@ export const trackCreateActivity = ({
   const data = getCreatePayload(block, event);
 
   if (!data) {
-    console.error("Could not create payload for created block", block, event);
+    console.error(
+      `${logModule} Could not create payload for created block`,
+      block,
+      event,
+    );
     return;
   }
 

--- a/apps/scratch/src/utilities/scratch-student-activities/student-delete.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-delete.ts
@@ -2,7 +2,9 @@ import { DeleteStudentAction } from "../../types/scratch-student-activities";
 import { shouldTrackDeleteBlock } from "./filters/should-track-delete";
 import { getDeletePayload } from "./payloads";
 import { sendDeleteActivity } from "./senders/send-delete-activity";
-import { logModule } from "./log-module";
+import { logBaseModule } from "./log-module";
+
+const logModule = `${logBaseModule}[student-delete]`;
 
 export const trackDeleteActivity = ({
   block,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-delete.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-delete.ts
@@ -2,6 +2,7 @@ import { DeleteStudentAction } from "../../types/scratch-student-activities";
 import { shouldTrackDeleteBlock } from "./filters/should-track-delete";
 import { getDeletePayload } from "./payloads";
 import { sendDeleteActivity } from "./senders/send-delete-activity";
+import { logModule } from "./log-module";
 
 export const trackDeleteActivity = ({
   block,
@@ -18,7 +19,11 @@ export const trackDeleteActivity = ({
   const data = getDeletePayload(block, event);
 
   if (!data) {
-    console.error("Could not create payload for deleted block", block, event);
+    console.error(
+      `${logModule} Could not create payload for deleted block`,
+      block,
+      event,
+    );
     return;
   }
 

--- a/apps/scratch/src/utilities/scratch-student-activities/student-intermediate-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-intermediate-change.ts
@@ -2,7 +2,9 @@ import { StudentActionContext } from "../../types/scratch-student-activities";
 import { shouldTrackIntermediateChange } from "./filters/should-track-intermediate-change";
 import { getIntermediateChangePayload } from "./payloads";
 import { sendIntermediateChangeActivity } from "./senders/send-intermediate-change-activity";
-import { logModule } from "./log-module";
+import { logBaseModule } from "./log-module";
+
+const logModule = `${logBaseModule}[student-intermediate-change]`;
 
 export const trackIntermediateChangeActivity = ({
   block,

--- a/apps/scratch/src/utilities/scratch-student-activities/student-intermediate-change.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-intermediate-change.ts
@@ -2,6 +2,7 @@ import { StudentActionContext } from "../../types/scratch-student-activities";
 import { shouldTrackIntermediateChange } from "./filters/should-track-intermediate-change";
 import { getIntermediateChangePayload } from "./payloads";
 import { sendIntermediateChangeActivity } from "./senders/send-intermediate-change-activity";
+import { logModule } from "./log-module";
 
 export const trackIntermediateChangeActivity = ({
   block,
@@ -18,7 +19,7 @@ export const trackIntermediateChangeActivity = ({
 
   if (!data) {
     console.error(
-      "Could not create payload for intermediate-changed block",
+      `${logModule} Could not create payload for intermediate-changed block`,
       block,
       event,
     );

--- a/apps/scratch/src/utilities/scratch-student-activities/student-move.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-move.ts
@@ -2,6 +2,7 @@ import { StudentActionContext } from "../../types/scratch-student-activities";
 import { shouldTrackMoveBlock } from "./filters/should-track-move";
 import { getMovePayload } from "./payloads";
 import { sendMoveActivity } from "./senders/send-move-activity";
+import { logModule } from "./log-module";
 
 export const trackMoveActivity = ({
   block,
@@ -18,7 +19,11 @@ export const trackMoveActivity = ({
   const data = getMovePayload(block, event);
 
   if (!data) {
-    console.error("Could not create payload for moved block", block, event);
+    console.error(
+      `${logModule} Could not create payload for moved block`,
+      block,
+      event,
+    );
     return;
   }
 

--- a/apps/scratch/src/utilities/scratch-student-activities/student-move.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/student-move.ts
@@ -2,7 +2,9 @@ import { StudentActionContext } from "../../types/scratch-student-activities";
 import { shouldTrackMoveBlock } from "./filters/should-track-move";
 import { getMovePayload } from "./payloads";
 import { sendMoveActivity } from "./senders/send-move-activity";
-import { logModule } from "./log-module";
+import { logBaseModule } from "./log-module";
+
+const logModule = `${logBaseModule}[student-move]`;
 
 export const trackMoveActivity = ({
   block,

--- a/apps/scratch/src/vm/load-crt-project.ts
+++ b/apps/scratch/src/vm/load-crt-project.ts
@@ -14,6 +14,8 @@ import {
 
 import { defaultCrtConfig } from "./default-crt-config";
 
+const logModule = "[Scratch][Load CRT Project]";
+
 let nextProject: ArrayBuffer | undefined = undefined;
 let isLoading = false;
 
@@ -67,7 +69,7 @@ const loadZip = async (input: ArrayBuffer): Promise<JSZip> => {
   try {
     await zip.loadAsync(input);
   } catch (e) {
-    console.error("Error loading ZIP file:", e);
+    console.error(`${logModule} Error loading ZIP file:`, e);
 
     throw new InvalidZipError();
   }
@@ -92,7 +94,7 @@ const parseProjectJson = async (zip: JSZip): Promise<ScratchProject> => {
   try {
     project = await projectFile.async("text").then((text) => JSON.parse(text));
   } catch (e) {
-    console.log("Error parsing project.json:", e);
+    console.log(`${logModule} Error parsing project.json:`, e);
     throw new InvalidProjectJsonError();
   }
 
@@ -133,7 +135,7 @@ const loadCrtConfig = async (vm: VM, zip: JSZip): Promise<void> => {
     try {
       config = await configFile.async("text").then((text) => JSON.parse(text));
     } catch (e) {
-      console.error("Error parsing crt.json:", e);
+      console.error(`${logModule} Error parsing crt.json:`, e);
       throw new CrtConfigParseError();
     }
 
@@ -182,7 +184,7 @@ export const loadCrtProject = async (
       throw e;
     }
 
-    console.error("Error loading project in VM:", e);
+    console.error(`${logModule} Error loading project in VM:`, e);
     throw new VmLoadError();
   } finally {
     isLoading = false;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized console log namespaces across Jupyter Notebook Runner and Scratch using file-path–based tags to make logs easier to filter and trace. Supports CRT-427 by making student block-change logs precise, with no runtime changes.

- **Refactors**
  - Adopted file-path–based `logModule` prefixes across autosave, commands (assign/grade/run-all), packages, state, utils, VM loader, GUI/Blocks, and iframe APIs (e.g., “[Jupyter][commands/grade]”, “[Scratch][blocks/helpers]”, “[Jupyter][iframe-api]”).
  - Introduced shared `logBaseModule` for Scratch student activity and composed per-file namespaces in lifecycle and `send-*` modules.
  - Standardized error/warn/debug wording; normalized embedded labels to “[Jupyter][iframe-api]” and “[Scratch][Embedded]”.

<sup>Written for commit ff5a1b24190404416ddc8ace6979a9d804beb2aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

