### PR TITLE
[CRT-379] Restore happened at counter to student activity index

### DIFF
--- a/backend/prisma/migrations/20260629153413_restore_happened_at_counter_in_student_activity_unique_constraint/migration.sql
+++ b/backend/prisma/migrations/20260629153413_restore_happened_at_counter_in_student_activity_unique_constraint/migration.sql
@@ -1,0 +1,11 @@
+-- The 20260318 migration that added the "deletedAt IS NULL" partial condition to
+-- the StudentActivity unique index accidentally dropped "happenedAtCounter" from
+-- the column list, reverting 20260316. 
+
+-- Restore happenedAtCounter to the index
+
+DROP INDEX "StudentActivity_studentId_type_happenedAt_key";
+
+CREATE UNIQUE INDEX "StudentActivity_studentId_type_happenedAt_key"
+  ON "StudentActivity"("studentId", "type", "happenedAt", "happenedAtCounter")
+  WHERE "deletedAt" IS NULL;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore happenedAtCounter to the StudentActivity unique index (studentId, type, happenedAt, happenedAtCounter) with the partial condition deletedAt IS NULL. Fixes CRT-379 by preventing false unique violations in `prisma.studentActivity.create()` when multiple activities share the same happenedAt.

<sup>Written for commit d3cc925b07172e7489f2b7491facbd9f7f984778. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

