### PR TITLE
[CRT-430] Standardise filename across exports

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -186,7 +186,7 @@ export class EmbeddedPythonCallbacks {
 
       return {
         file: taskBlob,
-        filename: "task.zip",
+        filename: "ClassMosaicExportedJupyterTask.zip",
       };
     } catch (e) {
       console.error(

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -46,6 +46,7 @@ import { hasStatus } from "./utils";
 import {
   ExportTask,
   ExportTaskResult,
+  JUPYTER_TASK_EXPORT_FILENAME,
 } from "./iframe-rpc/src/methods/export-task";
 import { toCrtLocale, toJupyterLocale } from "./languages";
 
@@ -186,7 +187,7 @@ export class EmbeddedPythonCallbacks {
 
       return {
         file: taskBlob,
-        filename: "ClassMosaicExportedJupyterTask.zip",
+        filename: JUPYTER_TASK_EXPORT_FILENAME,
       };
     } catch (e) {
       console.error(

--- a/apps/scratch/src/hooks/useEmbeddedScratch.ts
+++ b/apps/scratch/src/hooks/useEmbeddedScratch.ts
@@ -37,7 +37,10 @@ import {
   saveCrtProject,
 } from "../vm/save-crt-project";
 import { Assertion } from "../types/scratch-vm-custom";
-import { ExportTaskResult } from "../../../../libraries/iframe-rpc/src/methods/export-task";
+import {
+  ExportTaskResult,
+  SCRATCH_TASK_EXPORT_FILENAME,
+} from "../../../../libraries/iframe-rpc/src/methods/export-task";
 import { stopBufferingIframeMessages } from "../utilities/iframe-message-buffer";
 
 export const scratchIdentifierSeparator = "$";
@@ -338,7 +341,7 @@ export class EmbeddedScratchCallbacks {
 
       return {
         file: task,
-        filename: "ClassMosaicExportedScratchTask.sb3",
+        filename: SCRATCH_TASK_EXPORT_FILENAME,
       };
     } catch (e) {
       console.error(`Failed to export task:`, e);

--- a/apps/scratch/src/hooks/useEmbeddedScratch.ts
+++ b/apps/scratch/src/hooks/useEmbeddedScratch.ts
@@ -338,7 +338,7 @@ export class EmbeddedScratchCallbacks {
 
       return {
         file: task,
-        filename: "task.sb3",
+        filename: "ClassMosaicExportedScratchTask.sb3",
       };
     } catch (e) {
       console.error(`Failed to export task:`, e);

--- a/frontend/src/components/task/TaskActions.tsx
+++ b/frontend/src/components/task/TaskActions.tsx
@@ -2,6 +2,10 @@ import { defineMessages, useIntl } from "react-intl";
 import { LuDownload, LuTrash } from "react-icons/lu";
 import { useState } from "react";
 import { useRouter } from "next/router";
+import {
+  JUPYTER_TASK_EXPORT_FILENAME,
+  SCRATCH_TASK_EXPORT_FILENAME,
+} from "iframe-rpc-react/src";
 import { useDeleteTask } from "@/api/collimator/hooks/tasks/useDeleteTask";
 import { getErrorMessageDescriptor } from "@/errors/errorMessages";
 import { ButtonMessages } from "@/i18n/button-messages";
@@ -72,9 +76,9 @@ const TaskActions = ({
   const getTaskExportFilename = (taskType: TaskType): string => {
     switch (taskType) {
       case TaskType.SCRATCH:
-        return "ClassMosaicExportedScratchTask.sb3";
+        return SCRATCH_TASK_EXPORT_FILENAME;
       case TaskType.JUPYTER:
-        return "ClassMosaicExportedJupyterTask.zip";
+        return JUPYTER_TASK_EXPORT_FILENAME;
     }
   };
 

--- a/libraries/iframe-rpc/src/methods/export-task.ts
+++ b/libraries/iframe-rpc/src/methods/export-task.ts
@@ -1,6 +1,11 @@
 import { IframeRpcMethod } from "../remote-procedure-call";
 import { RpcCaller } from "../rpc-caller";
 
+export const SCRATCH_TASK_EXPORT_FILENAME =
+  "ClassMosaicExportedScratchTask.sb3";
+export const JUPYTER_TASK_EXPORT_FILENAME =
+  "ClassMosaicExportedJupyterTask.zip";
+
 export interface ExportTaskResult {
   file: Blob;
   filename: string;

--- a/libraries/iframe-rpc/src/methods/index.ts
+++ b/libraries/iframe-rpc/src/methods/index.ts
@@ -29,6 +29,10 @@ export { ToastType } from "./post-message";
 export type { SetLocale } from "./set-locale";
 export type { ImportTask } from "./import-task";
 export type { PostStudentAppActivity } from "./post-student-activity";
+export {
+  SCRATCH_TASK_EXPORT_FILENAME,
+  JUPYTER_TASK_EXPORT_FILENAME,
+} from "./export-task";
 
 type Methods =
   | GetHeight


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized export filenames for Jupyter and Scratch and centralized them as shared constants so the actions dropdown and exporters stay in sync, resolving CRT-430. Added `SCRATCH_TASK_EXPORT_FILENAME` and `JUPYTER_TASK_EXPORT_FILENAME` in `libraries/iframe-rpc` and reused them in exporters and `iframe-rpc-react`.

- **Bug Fixes**
  - Jupyter export filename: ClassMosaicExportedJupyterTask.zip (was task.zip)
  - Scratch export filename: ClassMosaicExportedScratchTask.sb3 (was task.sb3)

- **Migration**
  - Update any scripts or tests that depended on the old filenames.

<sup>Written for commit 8d8716a036d63506464165ff41fe163c4a89aa8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

