### PR TITLE
[CRT-389] Treat undefined block limit lookups as not allowed

### DIFF
--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -1,4 +1,5 @@
 import { WorkspaceChangeEvent } from "../types/scratch-workspace";
+import { ScratchCrtConfig } from "../types/scratch-vm-custom";
 import { countUsedBlocks } from "./block-config";
 
 export const svgNamespace = "http://www.w3.org/2000/svg";
@@ -145,6 +146,22 @@ export const shouldPreventBlocksActions = (
   return false;
 };
 
+const getAllowedBlockCount = (
+  config: ScratchCrtConfig,
+  blockType: string,
+  // negative number means unlimited, 0 or false means not allowed, undefined means not listed in config
+): number | boolean | undefined => {
+  if (blockType.startsWith("data_")) {
+    return config.allowedBlocks.variables ? -1 : 0;
+  }
+
+  if (blockType.startsWith("procedures_")) {
+    return config.allowedBlocks.customBlocks ? -1 : 0;
+  }
+
+  return config.allowedBlocks[blockType];
+};
+
 /**
  * Check if adding blocks from the flyout would exceed the limits set in the config.
  * It checks the number of blocks currently used in the workspace and the number of blocks being added, and compares it to the limits set in the config.
@@ -164,10 +181,11 @@ export const wouldExceedLimits = (
   // using the workspace count would always include the new block, this causes the flyout drags to be blocked
   const usedBlocks = countUsedBlocks(vm);
 
-  const allowed = config.allowedBlocks[block.type];
+  const allowed = getAllowedBlockCount(config, block.type);
   const count = usedBlocks[block.type];
 
-  const isPreventedEntirely = allowed === 0 || allowed === false;
+  const isPreventedEntirely =
+    allowed === undefined || allowed === 0 || allowed === false;
 
   if (isPreventedEntirely) {
     console.debug(

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -149,8 +149,8 @@ export const shouldPreventBlocksActions = (
 const getAllowedBlockCount = (
   config: ScratchCrtConfig,
   blockType: string,
-  // negative number means unlimited, 0 or false means not allowed, undefined means not listed in config
-): number | boolean | undefined => {
+  // negative number means unlimited, 0 means not allowed (including not listed in config)
+): number | boolean => {
   if (blockType.startsWith("data_")) {
     return config.allowedBlocks.variables ? -1 : 0;
   }
@@ -159,7 +159,7 @@ const getAllowedBlockCount = (
     return config.allowedBlocks.customBlocks ? -1 : 0;
   }
 
-  return config.allowedBlocks[blockType];
+  return config.allowedBlocks[blockType] || 0;
 };
 
 /**
@@ -184,8 +184,7 @@ export const wouldExceedLimits = (
   const allowed = getAllowedBlockCount(config, block.type);
   const count = usedBlocks[block.type];
 
-  const isPreventedEntirely =
-    allowed === undefined || allowed === 0 || allowed === false;
+  const isPreventedEntirely = allowed === 0;
 
   if (isPreventedEntirely) {
     console.debug(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CRT-389 by enforcing block limits on copy/paste. Blocks not listed in `allowedBlocks` are now disallowed.

- **Bug Fixes**
  - Added `getAllowedBlockCount` to normalize limits to numbers (-1 = unlimited, 0 = blocked), including `data_` and `procedures_` based on `variables`/`customBlocks` flags.
  - Updated `wouldExceedLimits` to use the helper and block when allowed is 0 (covers undefined and false), preventing pasting unlisted blocks.

<sup>Written for commit e3bace8bcf5fbe585dea8b104f1c05bf5df563d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

