### PR TITLE
[CRT-434] Student progress is not reported consistently

### DIFF
--- a/frontend/src/components/dashboard/ProgressList.tsx
+++ b/frontend/src/components/dashboard/ProgressList.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useMemo } from "react";
+import { useMemo } from "react";
 import { defineMessages, useIntl, FormattedMessage } from "react-intl";
 import styled from "@emotion/styled";
 import { HStack, Icon, Link, Status, Text } from "@chakra-ui/react";
@@ -13,6 +13,11 @@ import { CurrentStudentAnalysis } from "@/api/collimator/models/solutions/curren
 import { ColumnType } from "@/types/tanstack-types";
 import { ProgressMessages } from "@/i18n/progress-messages";
 import { useAllSessionCurrentAnalyses } from "@/api/collimator/hooks/solutions/useAllSessionCurrentAnalyses";
+import {
+  getTaskStatus,
+  getTaskStatusColor,
+  TaskStatus,
+} from "../task-progress";
 import MultiSwrContent from "../MultiSwrContent";
 import { StudentName } from "../encryption/StudentName";
 import ChakraDataTable, { ColumnSize } from "../ChakraDataTable";
@@ -48,6 +53,7 @@ const messages = defineMessages({
 type TaskSolutions = {
   taskId: number;
   solutions: ExistingStudentSolution[];
+  currentAnalysis: CurrentStudentAnalysis | null;
 };
 
 type AnonymousStudent = {
@@ -60,14 +66,6 @@ type StudentProgress = {
   student: ClassStudent | AnonymousStudent;
   taskSolutions: TaskSolutions[];
 };
-
-enum TaskStatus {
-  notStarted,
-  incomplete,
-  complete,
-}
-
-type StatusColor = ComponentProps<typeof Status.Indicator>["backgroundColor"];
 
 const nameTemplate = (progress: StudentProgress) => (
   <Text fontWeight="semibold" fontSize="lg" margin={0}>
@@ -96,37 +94,25 @@ const TaskTemplate = ({
 }) => {
   const intl = useIntl();
 
-  const solutionToDisplay = useMemo(() => {
-    const solutions = rowData.taskSolutions.find(
-      (s) => s.taskId === taskId,
-    )?.solutions;
+  const taskSolutions = useMemo(
+    () => rowData.taskSolutions.find((s) => s.taskId === taskId),
+    [taskId, rowData],
+  );
 
-    return ExistingStudentSolution.findSolutionToDisplay(solutions);
-  }, [taskId, rowData]);
+  const solutionToDisplay = useMemo(
+    () =>
+      ExistingStudentSolution.findSolutionToDisplay(taskSolutions?.solutions),
+    [taskSolutions],
+  );
 
-  const status = useMemo(() => {
-    if (!solutionToDisplay) {
-      return TaskStatus.notStarted;
-    }
+  const currentAnalysis = taskSolutions?.currentAnalysis ?? null;
 
-    if (solutionToDisplay.tests.every((test) => test.passed)) {
-      return TaskStatus.complete;
-    }
+  const status = useMemo(
+    () => getTaskStatus(solutionToDisplay, currentAnalysis),
+    [solutionToDisplay, currentAnalysis],
+  );
 
-    return TaskStatus.incomplete;
-  }, [solutionToDisplay]);
-
-  const color = useMemo((): StatusColor => {
-    if (!solutionToDisplay) {
-      return "neutral";
-    }
-
-    if (solutionToDisplay.tests.every((test) => test.passed)) {
-      return "success";
-    }
-
-    return "error";
-  }, [solutionToDisplay]);
+  const color = useMemo(() => getTaskStatusColor(status), [status]);
 
   const statusText = useMemo(() => {
     switch (status) {
@@ -247,12 +233,20 @@ const ProgressList = ({
           (s) => s.taskId === task.id,
         )?.solutions;
 
+        const taskAnalyses = currentAnalyses?.find(
+          (a) => a.taskId === task.id,
+        )?.analyses;
+
         return {
           taskId: task.id,
           solutions:
             studentSolutions?.filter(
               (solution) => solution.studentId === student.studentId,
             ) ?? [],
+          currentAnalysis: CurrentStudentAnalysis.findAnalysisToDisplay(
+            taskAnalyses ?? [],
+            student.studentId,
+          ),
         };
       });
 
@@ -262,7 +256,7 @@ const ProgressList = ({
         taskSolutions: taskSolutions,
       } satisfies StudentProgress;
     });
-  }, [klass, session, solutions, studentIds]);
+  }, [klass, session, solutions, currentAnalyses, studentIds]);
 
   const columns: ColumnDef<StudentProgress>[] = useMemo(() => {
     const firstColumns: ColumnDef<StudentProgress>[] = [

--- a/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
+++ b/frontend/src/components/task-instance/TaskInstanceProgressList.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useMemo } from "react";
+import { useMemo } from "react";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import styled from "@emotion/styled";
 import { Button, HStack, Icon, Status } from "@chakra-ui/react";
@@ -19,6 +19,11 @@ import { isClickOnRow } from "@/utilities/table";
 import ChakraDataTable, { ColumnSize } from "../ChakraDataTable";
 import { StudentName } from "../encryption/StudentName";
 import MultiSwrContent from "../MultiSwrContent";
+import {
+  getTaskStatus,
+  getTaskStatusColor,
+  TaskStatus,
+} from "../task-progress";
 import StarSolutionButton from "../solution/StarSolutionButton";
 import UnstarPastSolutionsButton from "../solution/UnstarPastSolutionsButton";
 
@@ -68,14 +73,6 @@ type StudentProgress = {
   taskSolutions: ExistingStudentSolution[];
   currentAnalysis: CurrentStudentAnalysis | null;
 };
-
-enum TaskStatus {
-  notStarted,
-  incomplete,
-  complete,
-}
-
-type StatusColor = ComponentProps<typeof Status.Indicator>["backgroundColor"];
 
 const nameTemplate = (progress: StudentProgress) =>
   "isAnonymous" in progress.student ? (
@@ -138,31 +135,12 @@ const TaskTemplate = ({
     [rowData],
   );
 
-  const status = useMemo(() => {
-    if (!solutionToDisplay && !rowData.currentAnalysis) {
-      // if solution has an analysis then it should be displayed as in progress
-      return TaskStatus.notStarted;
-    }
+  const status = useMemo(
+    () => getTaskStatus(solutionToDisplay, rowData.currentAnalysis),
+    [solutionToDisplay, rowData.currentAnalysis],
+  );
 
-    if (solutionToDisplay && solutionToDisplay.tests.every((t) => t.passed)) {
-      return TaskStatus.complete;
-    }
-
-    return TaskStatus.incomplete;
-  }, [solutionToDisplay, rowData.currentAnalysis]);
-
-  const color = useMemo((): StatusColor => {
-    if (!solutionToDisplay && !rowData.currentAnalysis) {
-      // if solution has an analysis then it should be displayed as in progress
-      return "neutral";
-    }
-
-    if (solutionToDisplay && solutionToDisplay.tests.every((t) => t.passed)) {
-      return "success";
-    }
-
-    return "error";
-  }, [solutionToDisplay, rowData.currentAnalysis]);
+  const color = useMemo(() => getTaskStatusColor(status), [status]);
 
   const statusText = useMemo(() => {
     switch (status) {

--- a/frontend/src/components/task-progress.ts
+++ b/frontend/src/components/task-progress.ts
@@ -1,0 +1,43 @@
+import { ComponentProps } from "react";
+import { Status } from "@chakra-ui/react";
+import { ExistingStudentSolution } from "@/api/collimator/models/solutions/existing-student-solutions";
+import { CurrentStudentAnalysis } from "@/api/collimator/models/solutions/current-student-analysis";
+
+export enum TaskStatus {
+  notStarted,
+  incomplete,
+  complete,
+}
+
+export type StatusColor = ComponentProps<
+  typeof Status.Indicator
+>["backgroundColor"];
+
+export const getTaskStatus = (
+  solutionToDisplay: ExistingStudentSolution | null,
+  currentAnalysis: CurrentStudentAnalysis | null,
+): TaskStatus => {
+  if (!solutionToDisplay && !currentAnalysis) {
+    return TaskStatus.notStarted;
+  }
+
+  const tests = solutionToDisplay?.tests ?? currentAnalysis?.tests;
+
+  if (tests && tests.length >= 0 && tests.every((test) => test.passed)) {
+    return TaskStatus.complete;
+  }
+
+  return TaskStatus.incomplete;
+};
+
+export const getTaskStatusColor = (status: TaskStatus): StatusColor => {
+  switch (status) {
+    case TaskStatus.complete:
+      return "success";
+    case TaskStatus.incomplete:
+      return "error";
+    case TaskStatus.notStarted:
+    default:
+      return "neutral";
+  }
+};

--- a/frontend/src/components/task-progress.ts
+++ b/frontend/src/components/task-progress.ts
@@ -23,7 +23,7 @@ export const getTaskStatus = (
 
   const tests = solutionToDisplay?.tests ?? currentAnalysis?.tests;
 
-  if (tests && tests.length >= 0 && tests.every((test) => test.passed)) {
+  if (tests && tests.length > 0 && tests.every((test) => test.passed)) {
     return TaskStatus.complete;
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix inconsistent student progress across Dashboard and Task Instance (CRT-434) by centralizing status calculation and using current analyses to show in‑progress work. Status text and colors now match across screens.

- **Bug Fixes**
  - Use shared `getTaskStatus` to compute status from `ExistingStudentSolution` or `CurrentStudentAnalysis` (not started, incomplete, complete).
  - Populate `currentAnalysis` in Dashboard via `useAllSessionCurrentAnalyses` so in‑progress work appears.
  - Use `getTaskStatusColor` for consistent indicators.

- **Refactors**
  - Added `frontend/src/components/task-progress.ts` with `TaskStatus`, `getTaskStatus`, and `getTaskStatusColor`.
  - Removed duplicate status logic from `ProgressList.tsx` and `TaskInstanceProgressList.tsx`.

<sup>Written for commit b8488040d34ed27713a1bfee42432450fd4e9be2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

