### PR TITLE
[CRT-388] Refresh block limit indicator when blocks are dragged to another sprite

### DIFF
--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -13,6 +13,10 @@ export const ignoreEvent = (event: MouseEvent): void => {
 
 const pendingRejectionBlockIds = new Set<string>();
 
+// Blocks created during the current drag gesture
+// Used to detect when a block dragged onto another sprite was created in the same gesture rather
+const blocksCreatedInCurrentGesture = new Set<string>();
+
 const shouldPreventBlockCreation = (
   event: WorkspaceChangeEvent,
   vm: VMExtended,
@@ -34,6 +38,9 @@ const shouldPreventBlockCreation = (
   if (isEndDrag) {
     const blockId = event.blockId ?? "";
 
+    // the drag gesture has ended, forget any blocks created during it
+    blocksCreatedInCurrentGesture.clear();
+
     if (pendingRejectionBlockIds.has(blockId)) {
       pendingRejectionBlockIds.delete(blockId);
       workspace.undo(false);
@@ -53,8 +60,27 @@ const shouldPreventBlockCreation = (
     return false;
   }
 
-  if (!wouldExceedLimits(vm, block)) {
+  const eventBlockId = event.blockId ?? "";
+
+  const excludeBlockId =
+    isBlockDraggedToSprite && blocksCreatedInCurrentGesture.has(eventBlockId)
+      ? event.blockId
+      : undefined;
+
+  if (!wouldExceedLimits(vm, block, excludeBlockId)) {
+    if (isBlockCreated) {
+      blocksCreatedInCurrentGesture.add(eventBlockId);
+    } else if (isBlockDraggedToSprite) {
+      // the drag gesture has ended, forget any blocks created during it
+      blocksCreatedInCurrentGesture.clear();
+    }
+
     return false;
+  }
+
+  if (isBlockDraggedToSprite) {
+    // the drag gesture has ended, forget any blocks created during it
+    blocksCreatedInCurrentGesture.clear();
   }
 
   if (isBlockCreated) {
@@ -171,6 +197,8 @@ const getAllowedBlockCount = (
 export const wouldExceedLimits = (
   vm: VMExtended,
   block: ScratchBlocksExtended.Block,
+  // id of a block that is already included in the VM counts but should not be counted against the limit
+  excludeBlockId?: string,
 ): boolean => {
   const config = vm.crtConfig;
   if (!config) {
@@ -184,7 +212,11 @@ export const wouldExceedLimits = (
   const usedBlocks = countUsedBlocks(vm);
 
   const allowed = getAllowedBlockCount(config, block.type);
-  const count = usedBlocks[block.type];
+  let count = usedBlocks[block.type];
+
+  if (excludeBlockId && findBlockInRuntime(vm, excludeBlockId)) {
+    count -= 1;
+  }
 
   const isPreventedEntirely = allowed === 0;
 

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -13,9 +13,9 @@ export const ignoreEvent = (event: MouseEvent): void => {
 
 const pendingRejectionBlockIds = new Set<string>();
 
-// Blocks created during the current drag gesture
-// Used to detect when a block dragged onto another sprite was created in the same gesture rather
-const blocksCreatedInCurrentGesture = new Set<string>();
+// Block created during the current drag gesture
+// Used to detect when a block dragged onto another sprite was created in the same gesture
+let blockCreatedInCurrentGesture: string | undefined;
 
 const shouldPreventBlockCreation = (
   event: WorkspaceChangeEvent,
@@ -39,7 +39,7 @@ const shouldPreventBlockCreation = (
     const blockId = event.blockId ?? "";
 
     // the drag gesture has ended, forget any blocks created during it
-    blocksCreatedInCurrentGesture.clear();
+    blockCreatedInCurrentGesture = undefined;
 
     if (pendingRejectionBlockIds.has(blockId)) {
       pendingRejectionBlockIds.delete(blockId);
@@ -63,16 +63,16 @@ const shouldPreventBlockCreation = (
   const eventBlockId = event.blockId ?? "";
 
   const excludeBlockId =
-    isBlockDraggedToSprite && blocksCreatedInCurrentGesture.has(eventBlockId)
+    isBlockDraggedToSprite && blockCreatedInCurrentGesture === eventBlockId
       ? event.blockId
       : undefined;
 
   if (!wouldExceedLimits(vm, block, excludeBlockId)) {
     if (isBlockCreated) {
-      blocksCreatedInCurrentGesture.add(eventBlockId);
+      blockCreatedInCurrentGesture = eventBlockId;
     } else if (isBlockDraggedToSprite) {
       // the drag gesture has ended, forget any blocks created during it
-      blocksCreatedInCurrentGesture.clear();
+      blockCreatedInCurrentGesture = undefined;
     }
 
     return false;
@@ -80,7 +80,7 @@ const shouldPreventBlockCreation = (
 
   if (isBlockDraggedToSprite) {
     // the drag gesture has ended, forget any blocks created during it
-    blocksCreatedInCurrentGesture.clear();
+    blockCreatedInCurrentGesture = undefined;
   }
 
   if (isBlockCreated) {

--- a/apps/scratch/src/components/TaskConfig.tsx
+++ b/apps/scratch/src/components/TaskConfig.tsx
@@ -234,7 +234,6 @@ const TaskConfig = ({
             type="checkbox"
             onChange={(e) => {
               setAllowVariableBlocks(e.target.checked);
-              // eslint-disable-next-line react-hooks/immutability
               vm.crtConfig!.allowedBlocks.variables = e.target.checked;
             }}
           />
@@ -250,7 +249,6 @@ const TaskConfig = ({
             type="checkbox"
             onChange={(e) => {
               setAllowCustomProcedureBlocks(e.target.checked);
-              // eslint-disable-next-line react-hooks/immutability
               vm.crtConfig!.allowedBlocks.customBlocks = e.target.checked;
             }}
           />
@@ -266,7 +264,6 @@ const TaskConfig = ({
             type="checkbox"
             onChange={(e) => {
               setEnableStageInteractions(e.target.checked);
-              // eslint-disable-next-line react-hooks/immutability
               vm.crtConfig!.enableStageInteractions = e.target.checked;
             }}
           />

--- a/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Blocks.tsx
@@ -52,13 +52,9 @@ import {
 import { StageDisplaySize } from "@scratch-submodule/packages/scratch-gui/src/lib/screen-utils";
 import VMScratchBlocks from "@scratch-submodule/packages/scratch-gui/src/lib/blocks";
 import makeToolboxXML from "../../blocks/make-toolbox-xml";
-import {
-  addBlockConfigButtons,
-  updateSingleBlockConfigButton,
-} from "../../blocks/block-config";
+import { addBlockConfigButtons } from "../../blocks/block-config";
 import BlockConfig from "../../components/block-config/BlockConfig";
 import { UpdateBlockToolboxEvent } from "../../events/update-block-toolbox";
-import { filterNonNull } from "../../utilities/filter-non-null";
 import {
   addFreezeButtonsToStack,
   freezeTaskBlocks,
@@ -1140,8 +1136,6 @@ class Blocks extends React.Component<Props, State> {
       vm: this.props.vm,
       canEditTask: this.props.canEditTask,
       blocks: this.blocks,
-      filterNonNull,
-      updateSingleBlockConfigButton,
     });
 
     if (isBlocked) {

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -49,7 +49,15 @@ export const handleBlockLifecycle = ({
           return;
         }
 
-        refreshBlockConfigButtonsFromXml(vm, event.xml, blocks, canEditTask);
+        // Get the xml representing the block change
+        const xml = getXmlFromEvent(event, undefined);
+
+        if (!xml) {
+          // No xml found, cannot proceed
+          return;
+        }
+
+        refreshBlockConfigButtonsFromXml(vm, xml, blocks, canEditTask);
       }
       break;
   }
@@ -89,6 +97,8 @@ const getXmlFromEvent = (
     case "delete":
       return event.oldXml;
 
+    case "endDrag":
+      return event.xml;
     default:
       console.error(`${logModule} Could not find xml in event`, event);
       return xmlElement;

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -72,7 +72,7 @@ const refreshBlockConfigButtonsFromXml = (
   // Create a new element to be able to use querySelectorAll on it, otherwise
   // Only the children are matched against the selector
   const el = document.createElement("div");
-  el.appendChild(xml);
+  el.appendChild(xml.cloneNode(true));
 
   const opcodes = [...el.querySelectorAll("block[type]")]
     .map((element) => element.getAttribute("type"))

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -1,6 +1,7 @@
 import VM from "@scratch/scratch-vm";
 import { filterNonNull } from "../../filter-non-null";
 import { logBaseModule } from "../log-module";
+import { updateSingleBlockConfigButton } from "../../../blocks/block-config";
 import type { WorkspaceChangeEvent } from "../../../types/scratch-workspace";
 
 const logModule = `${logBaseModule}[scratch-block/lifecycle]`;
@@ -10,13 +11,6 @@ interface BlockLifecycleParams {
   vm: VM;
   canEditTask: boolean | undefined;
   blocks: HTMLElement;
-  filterNonNull: typeof filterNonNull;
-  updateSingleBlockConfigButton: (
-    vm: VM,
-    blocks: HTMLElement,
-    opcode: string,
-    canEditTask: boolean | undefined,
-  ) => void;
 }
 
 export const handleBlockLifecycle = ({
@@ -24,8 +18,6 @@ export const handleBlockLifecycle = ({
   vm,
   canEditTask,
   blocks,
-  filterNonNull,
-  updateSingleBlockConfigButton,
 }: BlockLifecycleParams): void => {
   switch (event.type) {
     case "create":
@@ -39,19 +31,7 @@ export const handleBlockLifecycle = ({
           return;
         }
 
-        // Create a new element to be able to use querySelectorAll on it, otherwise
-        // Only the children are matched against the selector
-        const el = document.createElement("div");
-        el.appendChild(xml);
-
-        const opcodes = [...el.querySelectorAll("block[type]")]
-          .map((element) => element.getAttribute("type"))
-          .filter(filterNonNull);
-
-        // Update the block config button for the blocks
-        for (const opcode of opcodes) {
-          updateSingleBlockConfigButton(vm, blocks, opcode, canEditTask);
-        }
+        refreshBlockConfigButtonsFromXml(vm, xml, blocks, canEditTask);
 
         // Cleanup any freeze state associated with deleted blocks
         cleanupDeletedBlockFreezeState(vm, event, canEditTask);
@@ -69,22 +49,30 @@ export const handleBlockLifecycle = ({
           return;
         }
 
-        // Clone: the dragged block's xml element may still be referenced by
-        // scratch-blocks, so it must not be re-parented like create/delete xml
-        const el = document.createElement("div");
-        el.appendChild(event.xml.cloneNode(true));
-
-        const opcodes = [...el.querySelectorAll("block[type]")]
-          .map((element) => element.getAttribute("type"))
-          .filter(filterNonNull);
-
-        setTimeout(() => {
-          for (const opcode of opcodes) {
-            updateSingleBlockConfigButton(vm, blocks, opcode, canEditTask);
-          }
-        });
+        refreshBlockConfigButtonsFromXml(vm, event.xml, blocks, canEditTask);
       }
       break;
+  }
+};
+
+const refreshBlockConfigButtonsFromXml = (
+  vm: VM,
+  xml: Element,
+  blocks: HTMLElement,
+  canEditTask: boolean | undefined,
+): void => {
+  // Create a new element to be able to use querySelectorAll on it, otherwise
+  // Only the children are matched against the selector
+  const el = document.createElement("div");
+  el.appendChild(xml);
+
+  const opcodes = [...el.querySelectorAll("block[type]")]
+    .map((element) => element.getAttribute("type"))
+    .filter(filterNonNull);
+
+  // Update the block config button for the blocks
+  for (const opcode of opcodes) {
+    updateSingleBlockConfigButton(vm, blocks, opcode, canEditTask);
   }
 };
 

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -57,6 +57,34 @@ export const handleBlockLifecycle = ({
         cleanupDeletedBlockFreezeState(vm, event, canEditTask);
       }
       break;
+
+    case "endDrag":
+      {
+        // When a block is dragged onto another sprite, the VM copies it into
+        // that target after this event is processed (BLOCK_DRAG_END ->
+        // shareBlocksToTarget resolves in a promise callback), so no
+        // create/delete event fires on the active workspace. Defer the
+        // counter refresh until the copy is registered in the runtime.
+        if (!event.isOutside || !event.xml) {
+          return;
+        }
+
+        // Clone: the dragged block's xml element may still be referenced by
+        // scratch-blocks, so it must not be re-parented like create/delete xml
+        const el = document.createElement("div");
+        el.appendChild(event.xml.cloneNode(true));
+
+        const opcodes = [...el.querySelectorAll("block[type]")]
+          .map((element) => element.getAttribute("type"))
+          .filter(filterNonNull);
+
+        setTimeout(() => {
+          for (const opcode of opcodes) {
+            updateSingleBlockConfigButton(vm, blocks, opcode, canEditTask);
+          }
+        });
+      }
+      break;
   }
 };
 

--- a/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/scratch-block/lifecycle.ts
@@ -74,6 +74,8 @@ const refreshBlockConfigButtonsFromXml = (
   for (const opcode of opcodes) {
     updateSingleBlockConfigButton(vm, blocks, opcode, canEditTask);
   }
+
+  el.remove();
 };
 
 const getXmlFromEvent = (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refreshes the block limit indicator when blocks are dragged onto another sprite so counts stay accurate and the limit UI updates as expected (CRT-388).

- Bug Fixes
  - Listens for endDrag and defers the refresh until the VM copies the block to the target, covering cases without create/delete events.
  - Prevents false limit hits by tracking the block created in the current drag and excluding its id from limit checks when dropping to another sprite; clears this tracking at endDrag and after cross-sprite drops.
  - Parses opcodes from cloned event XML to update buttons, removes the temporary helper element, and only runs when dropped outside and XML exists.

- Refactors
  - Extracted `refreshBlockConfigButtonsFromXml`, imported `updateSingleBlockConfigButton` directly, removed leftover lifecycle params/call sites, and deleted outdated ESLint disable comments.

<sup>Written for commit db4aa7e036bd8e95e7382d09a4bb63de12c58abf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



