### PR TITLE
[CRT-308] Localize professor title and HEP profile link in Impressum

### DIFF
--- a/frontend/content/compiled-locales/en.json
+++ b/frontend/content/compiled-locales/en.json
@@ -3413,6 +3413,12 @@
       "value": "General Information"
     }
   ],
+  "impressum.hepProfileLink": [
+    {
+      "type": 0,
+      "value": "HEP profile"
+    }
+  ],
   "impressum.hosting": [
     {
       "type": 0,
@@ -3423,6 +3429,12 @@
     {
       "type": 0,
       "value": "Amazon Web Services, Inc. - Zurich Region"
+    }
+  ],
+  "impressum.professorAbbreviation": [
+    {
+      "type": 0,
+      "value": "Prof."
     }
   ],
   "impressum.projectSponsor": [

--- a/frontend/content/compiled-locales/fr.json
+++ b/frontend/content/compiled-locales/fr.json
@@ -3877,6 +3877,12 @@
       "value": "Informations générales"
     }
   ],
+  "impressum.hepProfileLink": [
+    {
+      "type": 0,
+      "value": "Profil HEP"
+    }
+  ],
   "impressum.hosting": [
     {
       "type": 0,
@@ -3887,6 +3893,12 @@
     {
       "type": 0,
       "value": "Amazon Web Services, Inc. - Région Zurich"
+    }
+  ],
+  "impressum.professorAbbreviation": [
+    {
+      "type": 0,
+      "value": "Pr."
     }
   ],
   "impressum.projectSponsor": [

--- a/frontend/content/locales/en.json
+++ b/frontend/content/locales/en.json
@@ -1610,11 +1610,17 @@
   "impressum.generalInformation": {
     "message": "General Information"
   },
+  "impressum.hepProfileLink": {
+    "message": "HEP profile"
+  },
   "impressum.hosting": {
     "message": "Hosting"
   },
   "impressum.hostingProvider": {
     "message": "Amazon Web Services, Inc. - Zurich Region"
+  },
+  "impressum.professorAbbreviation": {
+    "message": "Prof."
   },
   "impressum.projectSponsor": {
     "message": "Project Sponsor"

--- a/frontend/content/locales/fr.json
+++ b/frontend/content/locales/fr.json
@@ -1850,11 +1850,17 @@
   "impressum.generalInformation": {
     "message": "Informations générales"
   },
+  "impressum.hepProfileLink": {
+    "message": "Profil HEP"
+  },
   "impressum.hosting": {
     "message": "Hébergement"
   },
   "impressum.hostingProvider": {
     "message": "Amazon Web Services, Inc. - Région Zurich"
+  },
+  "impressum.professorAbbreviation": {
+    "message": "Pr."
   },
   "impressum.projectSponsor": {
     "message": "Direction de projet"

--- a/frontend/src/pages/impressum.tsx
+++ b/frontend/src/pages/impressum.tsx
@@ -69,13 +69,22 @@ const Impressum = () => {
           />
         </Heading>
         <Box>
-          <Text fontWeight="bold">Pr. Engin Bumbacher</Text>
+          <Text fontWeight="bold">
+            <FormattedMessage
+              id={"impressum.professorAbbreviation"}
+              defaultMessage="Prof."
+            />{" "}
+            Engin Bumbacher
+          </Text>
           <Text>
             <Link
               variant="underline"
               href="https://www.hepl.ch/annuaire/engin.bumbacher"
             >
-              HEP profile
+              <FormattedMessage
+                id={"impressum.hepProfileLink"}
+                defaultMessage="HEP profile"
+              />
             </Link>
           </Text>
         </Box>


### PR DESCRIPTION
## CRT-308

The Impressum "Project Sponsor" section had two hardcoded (untranslated) strings: the **"HEP profile"** link and the **"Pr."** academic title. Both are now externalized as `react-intl` messages.

### Changes
- `impressum.professorAbbreviation` — EN **"Prof."**, FR **"Pr."**. French uses *Pr.* as the abbreviation for *Professeur*; English uses *Prof.* (the previous global `Pr.` was effectively the French form applied to every locale).
- `impressum.hepProfileLink` — EN **"HEP profile"**, FR **"Profil HEP"**.
- Keys added to `content/locales/{en,fr}.json` and `content/compiled-locales/{en,fr}.json`.

### Decisions to review
- English default kept as lowercase **"HEP profile"** (matches the original); the Jira text capitalizes it — trivial to change if preferred.
- FR link wording **"Profil HEP"** — confirm.

### Verification
- `eslint --fix src/pages/impressum.tsx` → clean (exit 0), prettier-formatted.
- All four locale JSON files parse OK.
- Compiled-locale entries inserted **surgically** rather than via `yarn i18n:compile`, because a full recompile surfaced **pre-existing drift** (compiled catalogs are stale vs. source: deleted `CopyLessonModal.*` keys, reordered `TaskInstanceProgressList` columns, reworded `TaskInstanceReferenceSolutions`, plus a formatjs empty-array formatting change). That drift is intentionally **not** bundled here.
- Not run locally: full `next build` / typecheck — left to CI.

> ⚠️ Draft, opened autonomously for review. Separate finding worth its own PR: the committed `compiled-locales` are out of sync with their source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the Project Sponsor section in Impressum by translating the professor title and the “HEP profile” link. Addresses CRT-308 (“HEP Profile” is not translated).

- **Bug Fixes**
  - Externalized to `react-intl`: `impressum.professorAbbreviation` (EN "Prof.", FR "Pr.") and `impressum.hepProfileLink` (EN "HEP profile", FR "Profil HEP").
  - Updated `frontend/src/pages/impressum.tsx` to use `FormattedMessage`; added keys to `content/locales/{en,fr}.json` and compiled catalogs.

<sup>Written for commit 6cca2df026f5d41cb7580748d7c4741ddf9df4c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

