### PR TITLE
[CRT-353] Allow admins to copy session links from the session page

### DIFF
--- a/frontend/src/components/session/SessionActions.tsx
+++ b/frontend/src/components/session/SessionActions.tsx
@@ -6,7 +6,10 @@ import { Link } from "@chakra-ui/react";
 import { ButtonMessages } from "@/i18n/button-messages";
 import { SessionShareMessages } from "@/i18n/session-share-messages";
 import { useDeleteClassSession } from "@/api/collimator/hooks/sessions/useDeleteClassSession";
-import { AuthenticationContext } from "@/contexts/AuthenticationContext";
+import {
+  AuthenticationContext,
+  canShareSession,
+} from "@/contexts/AuthenticationContext";
 import { ExistingClassExtended } from "@/api/collimator/models/classes/existing-class-extended";
 import { ShareModal } from "@/components/modals/ShareModal";
 import { ExistingSessionExtended } from "@/api/collimator/models/sessions/existing-session-extended";
@@ -41,9 +44,7 @@ const SessionActions = ({
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
   const [sessionLink, setSessionLink] = useState("");
 
-  const canGetSessionLink =
-    "userId" in authenticationContext &&
-    klass.teacher.id === authenticationContext.userId;
+  const canGetSessionLink = canShareSession(authenticationContext, klass);
 
   const handleDeleteConfirm = async () => {
     try {

--- a/frontend/src/components/session/SessionList.tsx
+++ b/frontend/src/components/session/SessionList.tsx
@@ -8,16 +8,13 @@ import { MdAdd, MdContentCopy } from "react-icons/md";
 import { useAllClassSessions } from "@/api/collimator/hooks/sessions/useAllClassSessions";
 import { ExistingSession } from "@/api/collimator/models/sessions/existing-session";
 import {
-  AuthenticationContextType,
-  AdminOrTeacherAuthenticated,
-  isFullyAuthenticated,
   AuthenticationContext,
+  canShareSession,
 } from "@/contexts/AuthenticationContext";
 import { useClass } from "@/api/collimator/hooks/classes/useClass";
 import { SessionShareMessages } from "@/i18n/session-share-messages";
 import { isClickOnRow } from "@/utilities/table";
 import { ColumnType } from "@/types/tanstack-types";
-import { UserRole } from "@/types/user/user-role";
 import MultiSwrContent from "../MultiSwrContent";
 import Button from "../Button";
 import ChakraDataTable, { ColumnSize } from "../ChakraDataTable";
@@ -132,21 +129,7 @@ const SessionList = ({ classId }: { classId: number }) => {
         return null;
       }
 
-      const isAdminOrTeacher = (
-        context: AuthenticationContextType,
-      ): context is AdminOrTeacherAuthenticated =>
-        isFullyAuthenticated(context) &&
-        (context.role === UserRole.teacher || context.role === UserRole.admin);
-
-      const isAdminOrClassTeacher = (
-        context: AuthenticationContextType,
-        klass: { teacher: { id: number } },
-      ): context is AdminOrTeacherAuthenticated =>
-        isAdminOrTeacher(context) &&
-        (context.role === UserRole.admin ||
-          klass.teacher.id === context.userId);
-
-      return isAdminOrClassTeacher(authenticationContext, klass) ? (
+      return canShareSession(authenticationContext, klass) ? (
         <Button
           onClick={async () => {
             const fingerprint =

--- a/frontend/src/contexts/AuthenticationContext.tsx
+++ b/frontend/src/contexts/AuthenticationContext.tsx
@@ -156,8 +156,7 @@ export const isAdminOrTeacher = (
 /**
  * Whether the authenticated user may share/copy the join link of a session
  * belonging to the given class: admins may share any class's sessions, teachers
- * only their own. Centralized here so the session list, the session detail
- * actions and the progress page stay in sync (see CRT-353).
+ * only their own.
  */
 export const canShareSession = (
   authContext: AuthenticationContextType,

--- a/frontend/src/contexts/AuthenticationContext.tsx
+++ b/frontend/src/contexts/AuthenticationContext.tsx
@@ -146,6 +146,27 @@ export const isFullyAuthenticated = (
   authContext.version === latestAuthenticationContextVersion &&
   authContext.authenticationToken !== undefined;
 
+export const isAdminOrTeacher = (
+  authContext: AuthenticationContextType,
+): authContext is AdminOrTeacherAuthenticated =>
+  isFullyAuthenticated(authContext) &&
+  (authContext.role === UserRole.teacher ||
+    authContext.role === UserRole.admin);
+
+/**
+ * Whether the authenticated user may share/copy the join link of a session
+ * belonging to the given class: admins may share any class's sessions, teachers
+ * only their own. Centralized here so the session list, the session detail
+ * actions and the progress page stay in sync (see CRT-353).
+ */
+export const canShareSession = (
+  authContext: AuthenticationContextType,
+  klass: { teacher: { id: number } },
+): authContext is AdminOrTeacherAuthenticated =>
+  isAdminOrTeacher(authContext) &&
+  (authContext.role === UserRole.admin ||
+    klass.teacher.id === authContext.userId);
+
 export const authenticationContextDefaultValue: AuthenticationContextType = {
   version: latestAuthenticationContextVersion,
   idToken: undefined,

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/progress/index.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/progress/index.tsx
@@ -16,7 +16,10 @@ import PageHeading from "@/components/PageHeading";
 import SessionActions from "@/components/session/SessionActions";
 import { ShareModal } from "@/components/modals/ShareModal";
 import { SessionShareMessages } from "@/i18n/session-share-messages";
-import { AuthenticationContext } from "@/contexts/AuthenticationContext";
+import {
+  AuthenticationContext,
+  canShareSession,
+} from "@/contexts/AuthenticationContext";
 import Button from "@/components/Button";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
@@ -61,9 +64,7 @@ const SessionProgress = () => {
   } = useClassSession(classId, sessionId);
 
   const canGetSessionLink =
-    klass &&
-    "userId" in authenticationContext &&
-    klass.teacher.id === authenticationContext.userId;
+    !!klass && canShareSession(authenticationContext, klass);
 
   const handleShareClick = useCallback(async () => {
     if (session && canGetSessionLink) {


### PR DESCRIPTION
## CRT-353

Admins could copy a session's join link from the **session list** but not from the **session detail** ("Actions ▸ Copy Lesson Link" dropdown), nor from the **progress page's** share button. The copy action was gated to the owning teacher only.

### Root cause
The "can share this session" check was **duplicated in three places and had drifted**:
- `SessionList.tsx` — allowed admins ✅ (the working "list" path)
- `SessionActions.tsx` (detail dropdown) — owning teacher only ❌
- `progress/index.tsx` (share button) — owning teacher only ❌

### Fix
Extract one `canShareSession(context, klass)` type-guard into `AuthenticationContext.tsx` (admins may share any class's sessions; teachers only their own) and use it in all three sites. Fixes both broken spots and removes the duplication that caused the drift.

**Link generation is unchanged** — the join link still embeds the *current user's* key fingerprint, exactly as the list already did. (Whether an admin-shared link should embed the teacher's key instead is a separate, pre-existing question that also affects the list — out of scope here.)

### Verification
- `tsc --noEmit` (after `chakra:update`): **0 errors in the changed files**; type-guard narrowing (`.keyPair`/`.userId`) resolves at all three call sites and inside the async closures.
- `eslint --fix` on all four files → clean (exit 0).
- No component tests exist for these — a focused unit test for `canShareSession` (admin ✓ / owning teacher ✓ / other teacher ✗ / student ✗ / unauthenticated ✗) is a recommended hardening follow-up.
- Pre-existing, unrelated tsc noise NOT touched: 32 Chakra custom-`variant` errors (resolved by the build's `chakra:update` typegen) and 2 `email`-on-Student-mock errors in `contexts/__tests__/mock-contexts.ts`.

> ⚠️ Draft, opened autonomously. Security-relevant (permission boundary) — please sanity-check the "admins may share any session" intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CRT-353 by allowing admins to copy session join links from the session detail and progress pages, consistent with the session list. Centralizes the share-permission check to prevent drift.

- **Bug Fixes**
  - Added `canShareSession(context, klass)` in `AuthenticationContext.tsx` (admins can share any session; teachers only their own).
  - Updated `SessionActions`, `SessionList`, and the progress page to use the new check.
  - Removed duplicated role checks.
  - Link generation is unchanged; it still uses the current user's key fingerprint.

- **Refactors**
  - Cleaned up the `canShareSession` comment (removed internal note); no behavior change.

<sup>Written for commit 347e305e975d1cd78cc4f66513007c1ab9eb5832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

