### PR TITLE
[CRT-438] Freeze Jupyter task editor read-only during save

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/content/compiled-locales/en.json
+++ b/apps/jupyter/extensions/notebook-runner/src/content/compiled-locales/en.json
@@ -47,6 +47,12 @@
       "value": "Package Installation Failed"
     }
   ],
+  "crt.notebookRunner.savingTask": [
+    {
+      "type": 0,
+      "value": "Saving the task and generating the student version..."
+    }
+  ],
   "crt.notebookRunner.taskReadyBody": [
     {
       "type": 0,

--- a/apps/jupyter/extensions/notebook-runner/src/content/compiled-locales/fr.json
+++ b/apps/jupyter/extensions/notebook-runner/src/content/compiled-locales/fr.json
@@ -47,6 +47,12 @@
       "value": "Échec de l'installation des paquets"
     }
   ],
+  "crt.notebookRunner.savingTask": [
+    {
+      "type": 0,
+      "value": "Enregistrement de l'activité et génération de la version pour les élèves..."
+    }
+  ],
   "crt.notebookRunner.taskReadyBody": [
     {
       "type": 0,

--- a/apps/jupyter/extensions/notebook-runner/src/content/locales/en.json
+++ b/apps/jupyter/extensions/notebook-runner/src/content/locales/en.json
@@ -23,6 +23,9 @@
   "crt.notebookRunner.packageInstallationFailedTitle": {
     "message": "Package Installation Failed"
   },
+  "crt.notebookRunner.savingTask": {
+    "message": "Saving the task and generating the student version..."
+  },
   "crt.notebookRunner.taskReadyBody": {
     "message": "All packages installed successfully. Code execution is now enabled."
   },

--- a/apps/jupyter/extensions/notebook-runner/src/content/locales/fr.json
+++ b/apps/jupyter/extensions/notebook-runner/src/content/locales/fr.json
@@ -23,6 +23,9 @@
   "crt.notebookRunner.packageInstallationFailedTitle": {
     "message": "Échec de l'installation des paquets"
   },
+  "crt.notebookRunner.savingTask": {
+    "message": "Enregistrement de l'activité et génération de la version pour les élèves..."
+  },
   "crt.notebookRunner.taskReadyBody": {
     "message": "Tous les paquets ont été installés avec succès. L'exécution du code est désormais activée."
   },

--- a/apps/jupyter/extensions/notebook-runner/src/i18n/messages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/i18n/messages.ts
@@ -46,6 +46,10 @@ export const messages = defineMessages({
     defaultMessage:
       "Cannot run cells because package installation failed. Please reload the page and try again.",
   },
+  savingTask: {
+    id: "crt.notebookRunner.savingTask",
+    defaultMessage: "Saving the task and generating the student version...",
+  },
   localeReadFailedTitle: {
     id: "crt.notebookRunner.localeReadFailedTitle",
     defaultMessage: "Translation Failed",

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -20,8 +20,6 @@ import { stopBufferingIframeMessages } from "./iframe-message-buffer";
 import { OtterGradingResults } from "./grading-results";
 import { runAssignCommand, runGradingCommand } from "./command";
 import { blockUserInterface } from "./ui-blocker";
-import { messages } from "./i18n/messages";
-import { formatMessage } from "./i18n/intl";
 import { Mode } from "./mode";
 import {
   CrtInternalTask,
@@ -133,10 +131,7 @@ export class EmbeddedPythonCallbacks {
     // notebook is generated up front (from the assign pipeline) while the
     // teacher template is read at the end, so an edit in between would land only
     // in the teacher template and make the two diverge.
-    const unblockUserInterface = blockUserInterface(
-      this.app,
-      formatMessage(messages.savingTask),
-    );
+    const unblockUserInterface = blockUserInterface(this.app);
 
     try {
       // generate student task and autograder

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -20,6 +20,8 @@ import { stopBufferingIframeMessages } from "./iframe-message-buffer";
 import { OtterGradingResults } from "./grading-results";
 import { runAssignCommand, runGradingCommand } from "./command";
 import { blockUserInterface } from "./ui-blocker";
+import { messages } from "./i18n/messages";
+import { formatMessage } from "./i18n/intl";
 import { Mode } from "./mode";
 import {
   CrtInternalTask,
@@ -131,7 +133,10 @@ export class EmbeddedPythonCallbacks {
     // notebook is generated up front (from the assign pipeline) while the
     // teacher template is read at the end, so an edit in between would land only
     // in the teacher template and make the two diverge.
-    const unblockUserInterface = blockUserInterface(this.app);
+    const unblockUserInterface = blockUserInterface(
+      this.app,
+      formatMessage(messages.savingTask),
+    );
 
     try {
       // generate student task and autograder

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -1,6 +1,7 @@
 import { JupyterFrontEnd } from "@jupyterlab/application";
 import { IDocumentManager } from "@jupyterlab/docmanager";
 import { FileBrowser } from "@jupyterlab/filebrowser";
+import { NotebookPanel } from "@jupyterlab/notebook";
 
 import { ISettingRegistry } from "@jupyterlab/settingregistry";
 import { DEFAULT_SCROLL_HEIGHT } from "./constants";
@@ -126,6 +127,27 @@ export class EmbeddedPythonCallbacks {
       : EmbeddedPythonCallbacks.studentTaskLocation;
 
   async getTask(request: GetTask["request"]): Promise<Task> {
+    // CRT-438: freeze the task-template editor read-only for the duration of the
+    // save. The student notebook is generated up front (from the assign pipeline)
+    // while the teacher template is read at the end (after the grade pipeline
+    // re-saves the still-live editor), so a keystroke in between would land only
+    // in the teacher template and make the two diverge. Per-cell `readOnly` is an
+    // editor-level flag: it locks each cell's editor (blocks typing) but is not
+    // persisted into the saved notebook and does not block the programmatic
+    // context.save() calls inside assign/grade (unlike the notebook model's
+    // read-only flag, which would).
+    const notebookPanel = this.documentManager.findWidget(
+      EmbeddedPythonCallbacks.taskTemplateLocation,
+    ) as NotebookPanel | undefined;
+
+    const frozenCells = notebookPanel
+      ? Array.from(notebookPanel.content.widgets)
+      : [];
+    const previousReadOnly = frozenCells.map((cell) => cell.readOnly);
+    frozenCells.forEach((cell) => {
+      cell.readOnly = true;
+    });
+
     try {
       // generate student task and autograder
       await this.app.commands.execute(runAssignCommand);
@@ -165,6 +187,13 @@ export class EmbeddedPythonCallbacks {
       const errorMessage = e instanceof Error ? e.message : String(e);
 
       throw new GetTaskError(errorMessage);
+    } finally {
+      // Re-enable editing (matters on the error path, where the modal stays open).
+      frozenCells.forEach((cell, index) => {
+        if (!cell.isDisposed) {
+          cell.readOnly = previousReadOnly[index];
+        }
+      });
     }
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -127,13 +127,10 @@ export class EmbeddedPythonCallbacks {
       : EmbeddedPythonCallbacks.studentTaskLocation;
 
   async getTask(request: GetTask["request"]): Promise<Task> {
-    // CRT-438: block the whole UI while the save/export pipeline runs. The
-    // student notebook is generated up front (from the assign pipeline) while
-    // the teacher template is read at the end (after the grade pipeline re-saves
-    // the still-live editor), so an edit in between would land only in the
-    // teacher template and make the two diverge. `inert` stops all user input
-    // without touching the notebook, unlike per-cell `readOnly`, which persists
-    // `editable: false` into the saved .ipynb and locks it permanently.
+    // Block the whole UI while the save/export pipeline runs. The student
+    // notebook is generated up front (from the assign pipeline) while the
+    // teacher template is read at the end, so an edit in between would land only
+    // in the teacher template and make the two diverge.
     const unblockUserInterface = blockUserInterface(this.app);
 
     try {

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -1,7 +1,6 @@
 import { JupyterFrontEnd } from "@jupyterlab/application";
 import { IDocumentManager } from "@jupyterlab/docmanager";
 import { FileBrowser } from "@jupyterlab/filebrowser";
-import { NotebookPanel } from "@jupyterlab/notebook";
 
 import { ISettingRegistry } from "@jupyterlab/settingregistry";
 import { DEFAULT_SCROLL_HEIGHT } from "./constants";
@@ -20,6 +19,7 @@ import {
 import { stopBufferingIframeMessages } from "./iframe-message-buffer";
 import { OtterGradingResults } from "./grading-results";
 import { runAssignCommand, runGradingCommand } from "./command";
+import { blockUserInterface } from "./ui-blocker";
 import { Mode } from "./mode";
 import {
   CrtInternalTask,
@@ -127,26 +127,14 @@ export class EmbeddedPythonCallbacks {
       : EmbeddedPythonCallbacks.studentTaskLocation;
 
   async getTask(request: GetTask["request"]): Promise<Task> {
-    // CRT-438: freeze the task-template editor read-only for the duration of the
-    // save. The student notebook is generated up front (from the assign pipeline)
-    // while the teacher template is read at the end (after the grade pipeline
-    // re-saves the still-live editor), so a keystroke in between would land only
-    // in the teacher template and make the two diverge. Per-cell `readOnly` is an
-    // editor-level flag: it locks each cell's editor (blocks typing) but is not
-    // persisted into the saved notebook and does not block the programmatic
-    // context.save() calls inside assign/grade (unlike the notebook model's
-    // read-only flag, which would).
-    const notebookPanel = this.documentManager.findWidget(
-      EmbeddedPythonCallbacks.taskTemplateLocation,
-    ) as NotebookPanel | undefined;
-
-    const frozenCells = notebookPanel
-      ? Array.from(notebookPanel.content.widgets)
-      : [];
-    const previousReadOnly = frozenCells.map((cell) => cell.readOnly);
-    frozenCells.forEach((cell) => {
-      cell.readOnly = true;
-    });
+    // CRT-438: block the whole UI while the save/export pipeline runs. The
+    // student notebook is generated up front (from the assign pipeline) while
+    // the teacher template is read at the end (after the grade pipeline re-saves
+    // the still-live editor), so an edit in between would land only in the
+    // teacher template and make the two diverge. `inert` stops all user input
+    // without touching the notebook, unlike per-cell `readOnly`, which persists
+    // `editable: false` into the saved .ipynb and locks it permanently.
+    const unblockUserInterface = blockUserInterface(this.app);
 
     try {
       // generate student task and autograder
@@ -188,12 +176,7 @@ export class EmbeddedPythonCallbacks {
 
       throw new GetTaskError(errorMessage);
     } finally {
-      // Re-enable editing (matters on the error path, where the modal stays open).
-      frozenCells.forEach((cell, index) => {
-        if (!cell.isDisposed) {
-          cell.readOnly = previousReadOnly[index];
-        }
-      });
+      unblockUserInterface();
     }
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
@@ -1,5 +1,7 @@
 import { JupyterFrontEnd } from "@jupyterlab/application";
 import { Spinner } from "@jupyterlab/apputils";
+import { messages } from "./i18n/messages";
+import { formatMessage } from "./i18n/intl";
 
 const OVERLAY_ID = "notebook-runner-ui-blocker";
 
@@ -8,22 +10,12 @@ const OVERLAY_ID = "notebook-runner-ui-blocker";
  * spinner overlay for the duration of a long operation such as the getTask
  * save/export pipeline. Returns a cleanup function that restores interactivity.
  *
- * We block the whole shell rather than toggling per-cell `readOnly`: the
- * `Cell.readOnly` setter writes `editable: false` into the cell metadata, which
- * is persisted into the saved .ipynb and would permanently lock the notebook
- * for both the teacher and the students (CRT-438).
- *
  * `inert` disables user pointer, keyboard and focus for the subtree while
  * leaving programmatic work — command execution, kernel messaging and
  * `context.save()` — unaffected. It is set on the shell node only, so error
  * dialogs (which attach to `document.body`) remain dismissible.
- *
- * An optional (already localized) message is shown below the spinner.
  */
-export const blockUserInterface = (
-  app: JupyterFrontEnd,
-  message?: string,
-): (() => void) => {
+export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
   const shellNode = app.shell.node;
   const previousInert = shellNode.inert;
   shellNode.inert = true;
@@ -39,24 +31,22 @@ export const blockUserInterface = (
   );
   overlay.appendChild(spinner.node);
 
-  if (message) {
-    const label = document.createElement("div");
-    label.textContent = message;
-    label.style.cssText = [
-      "position:absolute",
-      "top:calc(50% + 3.5rem)",
-      "left:50%",
-      "transform:translateX(-50%)",
-      "z-index:11",
-      "max-width:32rem",
-      "padding:0 1rem",
-      "text-align:center",
-      "color:var(--jp-ui-font-color1)",
-      "font-family:var(--jp-ui-font-family)",
-      "font-size:var(--jp-ui-font-size1)",
-    ].join(";");
-    overlay.appendChild(label);
-  }
+  const label = document.createElement("div");
+  label.textContent = formatMessage(messages.savingTask);
+  label.style.cssText = [
+    "position:absolute",
+    "top:calc(50% + 3.5rem)",
+    "left:50%",
+    "transform:translateX(-50%)",
+    "z-index:11",
+    "max-width:32rem",
+    "padding:0 1rem",
+    "text-align:center",
+    "color:var(--jp-ui-font-color1)",
+    "font-family:var(--jp-ui-font-family)",
+    "font-size:var(--jp-ui-font-size1)",
+  ].join(";");
+  overlay.appendChild(label);
 
   document.body.appendChild(overlay);
 

--- a/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
@@ -1,4 +1,5 @@
 import { JupyterFrontEnd } from "@jupyterlab/application";
+import { Spinner } from "@jupyterlab/apputils";
 
 const OVERLAY_ID = "notebook-runner-ui-blocker";
 
@@ -22,6 +23,8 @@ export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
   const previousInert = shellNode.inert;
   shellNode.inert = true;
 
+  const spinner = new Spinner();
+
   const overlay = document.createElement("div");
   overlay.id = OVERLAY_ID;
   overlay.style.cssText = [
@@ -34,14 +37,7 @@ export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
     "background:rgba(255,255,255,0.6)",
     "cursor:wait",
   ].join(";");
-
-  // jp-Spinner / jp-SpinnerContent styles ship with @jupyterlab/apputils.
-  const spinner = document.createElement("div");
-  spinner.className = "jp-Spinner";
-  const spinnerContent = document.createElement("div");
-  spinnerContent.className = "jp-SpinnerContent";
-  spinner.appendChild(spinnerContent);
-  overlay.appendChild(spinner);
+  overlay.appendChild(spinner.node);
 
   document.body.appendChild(overlay);
 
@@ -52,6 +48,7 @@ export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
     }
     cleanedUp = true;
     shellNode.inert = previousInert;
+    spinner.dispose();
     overlay.remove();
   };
 };

--- a/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
@@ -17,8 +17,13 @@ const OVERLAY_ID = "notebook-runner-ui-blocker";
  * leaving programmatic work — command execution, kernel messaging and
  * `context.save()` — unaffected. It is set on the shell node only, so error
  * dialogs (which attach to `document.body`) remain dismissible.
+ *
+ * An optional (already localized) message is shown below the spinner.
  */
-export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
+export const blockUserInterface = (
+  app: JupyterFrontEnd,
+  message?: string,
+): (() => void) => {
   const shellNode = app.shell.node;
   const previousInert = shellNode.inert;
   shellNode.inert = true;
@@ -27,17 +32,31 @@ export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
 
   const overlay = document.createElement("div");
   overlay.id = OVERLAY_ID;
-  overlay.style.cssText = [
-    "position:fixed",
-    "inset:0",
-    "z-index:10000",
-    "display:flex",
-    "align-items:center",
-    "justify-content:center",
-    "background:rgba(255,255,255,0.6)",
-    "cursor:wait",
-  ].join(";");
+  // The Spinner fills the overlay with an opaque, centered, theme-coloured
+  // loading screen; the message is layered above it, just below the spinner.
+  overlay.style.cssText = ["position:fixed", "inset:0", "z-index:10000"].join(
+    ";",
+  );
   overlay.appendChild(spinner.node);
+
+  if (message) {
+    const label = document.createElement("div");
+    label.textContent = message;
+    label.style.cssText = [
+      "position:absolute",
+      "top:calc(50% + 3.5rem)",
+      "left:50%",
+      "transform:translateX(-50%)",
+      "z-index:11",
+      "max-width:32rem",
+      "padding:0 1rem",
+      "text-align:center",
+      "color:var(--jp-ui-font-color1)",
+      "font-family:var(--jp-ui-font-family)",
+      "font-size:var(--jp-ui-font-size1)",
+    ].join(";");
+    overlay.appendChild(label);
+  }
 
   document.body.appendChild(overlay);
 

--- a/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
@@ -1,0 +1,57 @@
+import { JupyterFrontEnd } from "@jupyterlab/application";
+
+const OVERLAY_ID = "notebook-runner-ui-blocker";
+
+/**
+ * Make the whole JupyterLite UI inert (no typing, clicking or focus) and show a
+ * spinner overlay for the duration of a long operation such as the getTask
+ * save/export pipeline. Returns a cleanup function that restores interactivity.
+ *
+ * We block the whole shell rather than toggling per-cell `readOnly`: the
+ * `Cell.readOnly` setter writes `editable: false` into the cell metadata, which
+ * is persisted into the saved .ipynb and would permanently lock the notebook
+ * for both the teacher and the students (CRT-438).
+ *
+ * `inert` disables user pointer, keyboard and focus for the subtree while
+ * leaving programmatic work — command execution, kernel messaging and
+ * `context.save()` — unaffected. It is set on the shell node only, so error
+ * dialogs (which attach to `document.body`) remain dismissible.
+ */
+export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
+  const shellNode = app.shell.node;
+  const previousInert = shellNode.inert;
+  shellNode.inert = true;
+
+  const overlay = document.createElement("div");
+  overlay.id = OVERLAY_ID;
+  overlay.style.cssText = [
+    "position:fixed",
+    "inset:0",
+    "z-index:10000",
+    "display:flex",
+    "align-items:center",
+    "justify-content:center",
+    "background:rgba(255,255,255,0.6)",
+    "cursor:wait",
+  ].join(";");
+
+  // jp-Spinner / jp-SpinnerContent styles ship with @jupyterlab/apputils.
+  const spinner = document.createElement("div");
+  spinner.className = "jp-Spinner";
+  const spinnerContent = document.createElement("div");
+  spinnerContent.className = "jp-SpinnerContent";
+  spinner.appendChild(spinnerContent);
+  overlay.appendChild(spinner);
+
+  document.body.appendChild(overlay);
+
+  let cleanedUp = false;
+  return (): void => {
+    if (cleanedUp) {
+      return;
+    }
+    cleanedUp = true;
+    shellNode.inert = previousInert;
+    overlay.remove();
+  };
+};

--- a/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/ui-blocker.ts
@@ -55,6 +55,7 @@ export const blockUserInterface = (app: JupyterFrontEnd): (() => void) => {
     if (cleanedUp) {
       return;
     }
+
     cleanedUp = true;
     shellNode.inert = previousInert;
     spinner.dispose();


### PR DESCRIPTION
## Problem (CRT-438)

While a teacher runs the task save/export pipeline (`getTask`), the notebook must not be edited: the student copy is generated up front by the assign pipeline, but the teacher template is read at the end, so an edit in between lands only in the template and desyncs the two.

### Why the first approach was wrong (reported broken)

The initial version set `cell.readOnly = true` on every cell. In JupyterLab 4.4 the `Notebook` widget sets `syncEditable = true` on its cells, so the `readOnly` setter writes **`editable: false` into the cell metadata**, which is serialized into the saved `.ipynb`. The pipeline saves the notebook while frozen, so `editable: false` got baked into **both** the teacher template and the generated student copy — students could no longer type, and reopening the task still showed the cells locked.

## Fix

Block the **whole shell** for the duration of `getTask` instead of touching any cell:

- `app.shell.node.inert = true` — disables user pointer, keyboard and focus across the JupyterLab UI, while leaving programmatic work (command execution, kernel messaging, `context.save()`) unaffected. No model/metadata is touched, so nothing is persisted.
- a fixed-position spinner overlay (`jp-Spinner`) for visual feedback.
- both torn down in `finally` (idempotent cleanup), so the error path can't strand the UI.

`inert` is scoped to the shell node, so the otter error dialogs (`showErrorMessage`, which attach to `document.body` and are fire-and-forget) remain visible and dismissible.

New helper: `src/ui-blocker.ts`. `getTask` reverts to its original body wrapped in `blockUserInterface(this.app)` / `unblock()`.

## ⚠️ Data note

Any task **saved while the old `readOnly` approach was deployed** has `editable: false` baked into its notebook cells and will stay locked until re-saved with this fix. If any such tasks exist, they need a re-save (or a one-off metadata strip on import).

## Verification

Extension `eslint` + `tsc --noEmit` clean (0 errors). Needs an in-app check on a rebuilt JupyterLite: run a task save → confirm the UI is fully inert with a spinner during the pipeline, editable again afterward, and that the saved student/teacher notebooks are **not** read-only on reload.