### PR TITLE
[CRT-400] Fix reference-solutions save button wording

### DIFF
--- a/frontend/content/compiled-locales/en.json
+++ b/frontend/content/compiled-locales/en.json
@@ -2620,7 +2620,7 @@
   "TaskReferenceSolutions.submit": [
     {
       "type": 0,
-      "value": "Save Reference Solution(s)"
+      "value": "Save Reference Solutions"
     }
   ],
   "TaskReferenceSolutions.title": [

--- a/frontend/content/compiled-locales/fr.json
+++ b/frontend/content/compiled-locales/fr.json
@@ -3083,7 +3083,7 @@
   "TaskReferenceSolutions.submit": [
     {
       "type": 0,
-      "value": "Enregistrer les/la solution(s) de référence"
+      "value": "Enregistrer les solutions de référence"
     }
   ],
   "TaskReferenceSolutions.title": [

--- a/frontend/content/locales/en.json
+++ b/frontend/content/locales/en.json
@@ -1233,7 +1233,7 @@
     "message": "View only"
   },
   "TaskReferenceSolutions.submit": {
-    "message": "Save Reference Solution(s)"
+    "message": "Save Reference Solutions"
   },
   "TaskReferenceSolutions.title": {
     "message": "Edit Reference Solution - {title}"

--- a/frontend/content/locales/fr.json
+++ b/frontend/content/locales/fr.json
@@ -1473,7 +1473,7 @@
     "message": "Consultation uniquement"
   },
   "TaskReferenceSolutions.submit": {
-    "message": "Enregistrer les/la solution(s) de référence"
+    "message": "Enregistrer les solutions de référence"
   },
   "TaskReferenceSolutions.title": {
     "message": "Modifier l'activité - {title}"

--- a/frontend/src/pages/task/[taskId]/reference-solutions.tsx
+++ b/frontend/src/pages/task/[taskId]/reference-solutions.tsx
@@ -28,7 +28,7 @@ const messages = defineMessages({
   },
   submit: {
     id: "TaskReferenceSolutions.submit",
-    defaultMessage: "Save Reference Solution(s)",
+    defaultMessage: "Save Reference Solutions",
   },
   referenceReadOnlyTitle: {
     id: "TaskReferenceSolutions.referenceReadOnlyTitle",


### PR DESCRIPTION
## CRT-400 — Fix reference-solutions save button wording

The "Save" button on `/task/{id}/reference-solutions` hedged singular/plural:
- EN: "Save Reference Solution(s)"
- FR: "Enregistrer les/la solution(s) de référence"

The page always manages the collection of reference solutions, so both now use the plain plural:
- EN: **"Save Reference Solutions"**
- FR: **"Enregistrer les solutions de référence"** (the exact fix from the ticket)

Changed the source `defaultMessage` (`reference-solutions.tsx`) so the English survives i18n extraction, plus the source + compiled locale catalogs for both languages.

> The ticket specified the French; I also fixed the identical `(s)` hedge in the English button text (the ticket title says "text and translation"). Trivial to revert the EN half if you only wanted FR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Save button on /task/{id}/reference-solutions to use a clear plural, removing “(s)”. EN: “Save Reference Solutions”; FR: “Enregistrer les solutions de référence” (CRT-400).

- **Bug Fixes**
  - Updated defaultMessage in frontend/src/pages/task/[taskId]/reference-solutions.tsx.
  - Synced locale catalogs in frontend/content/locales/{en,fr}.json and compiled-locales.

<sup>Written for commit 20a5da251c7937014bc9119466b3fb15c2a8de6e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

