### PR TITLE
[CRT-437] Hide Clear Browser Data from the Jupyter UI

### DIFF
--- a/apps/jupyter/jupyter-lite.json
+++ b/apps/jupyter/jupyter-lite.json
@@ -8,7 +8,8 @@
     "workspacesStorageDrivers": ["memoryStorageDriver"],
     "settingsStorageDrivers": ["localStorageWrapper"],
     "disabledExtensions": [
-      "@jupyterlite/application-extension:service-worker-manager"
+      "@jupyterlite/application-extension:service-worker-manager",
+      "@jupyterlite/application-extension:clear-browser-data"
     ]
   }
 }


### PR DESCRIPTION
## CRT-437 — Hide "Clear Browser Data" (security)

In **solve mode** a student could right-click → **"Clear Browser Data"** (or run it from the **command palette**, which is enabled in solve mode). Clearing wipes local storage and reloads, which resets the solve-mode UI hardening and **exposes the teacher's `task.ipynb`**.

### Fix
Disable the dedicated JupyterLite plugin `@jupyterlite/application-extension:clear-browser-data` in `apps/jupyter/jupyter-lite.json`'s `disabledExtensions`. That removes the command from **every** vector at once — context menu, Help menu, command palette, and the command id itself — so it can't be reached by any route. The plugin `provides` nothing → no dependency breakage (matches the existing `service-worker-manager` entry).

### Trade-off
`disabledExtensions` is global, so the item is also gone in edit/show mode. Acceptable: contents are memory-backed (little "browser data" to clear), and a menu-/mode-scoped removal couldn't also strip the palette entry — the actual live security vector.

### Verification
- JSON validated.
- ⚠️ Needs a rebuild (`task build` from `apps/jupyter/`) + manual check: in `?mode=solve`, "Clear Browser Data" absent from right-click, command palette, and Help menu; no console error about a missing plugin.

> ⚠️ Draft, opened autonomously. Security fix — please confirm in a built app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disabled the JupyterLite “Clear Browser Data” command to prevent solve‑mode users from wiping storage and exposing the teacher’s `task.ipynb`. Addresses CRT-437 by adding `@jupyterlite/application-extension:clear-browser-data` to `disabledExtensions` in `apps/jupyter/jupyter-lite.json`, removing it from context menus, Help, and the command palette (global across modes); requires rebuilding the Jupyter app.

<sup>Written for commit c4756d1b9ee5785c19c25cbad27a0418f899d42a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

