### PR TITLE
[CRT-399] Auto-select the Pyodide kernel instead of prompting

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/eslint.config.mjs
+++ b/apps/jupyter/extensions/notebook-runner/eslint.config.mjs
@@ -51,6 +51,16 @@ export default defineConfig([
     rules: {
       "no-unused-vars": "off",
 
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "CallExpression > MemberExpression.callee[property.name='openOrReveal']",
+          message:
+            "Use openTaskNotebook() instead — it awaits kernelspecs.ready so JupyterLab auto-selects the Pyodide kernel instead of prompting the user.",
+        },
+      ],
+
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -140,17 +140,21 @@ export class EmbeddedPythonCallbacks {
     const kernelSpecs = this.app.serviceManager.kernelspecs;
     await kernelSpecs.ready;
 
-    const hasSpec = (): boolean =>
-      !!kernelSpecs.specs &&
-      Object.keys(kernelSpecs.specs.kernelspecs).length > 0;
+    const hasSpec = (specs = kernelSpecs.specs): boolean =>
+      !!specs && Object.keys(specs.kernelspecs).length > 0;
 
     if (hasSpec()) {
       return;
     }
 
     await new Promise<void>((resolve) => {
-      function onChange(): void {
-        if (hasSpec()) {
+      // specsChanged emits the freshly fetched specs, so use the emitted
+      // payload instead of re-reading the manager's mutable specs property
+      function onChange(
+        _sender: unknown,
+        specs: typeof kernelSpecs.specs,
+      ): void {
+        if (hasSpec(specs)) {
           clearTimeout(timeout);
           kernelSpecs.specsChanged.disconnect(onChange);
           resolve();

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -125,6 +125,43 @@ export class EmbeddedPythonCallbacks {
       ? EmbeddedPythonCallbacks.taskTemplateLocation
       : EmbeddedPythonCallbacks.studentTaskLocation;
 
+  /**
+   * Resolves once at least one kernelspec (the Pyodide kernel) is registered.
+   */
+  private async waitForKernelSpecs(): Promise<void> {
+    const kernelSpecs = this.app.serviceManager.kernelspecs;
+    await kernelSpecs.ready;
+
+    const hasSpec = (): boolean =>
+      !!kernelSpecs.specs &&
+      Object.keys(kernelSpecs.specs.kernelspecs).length > 0;
+
+    if (hasSpec()) {
+      return;
+    }
+
+    await new Promise<void>((resolve) => {
+      const onChange = (): void => {
+        if (hasSpec()) {
+          kernelSpecs.specsChanged.disconnect(onChange);
+          resolve();
+        }
+      };
+      kernelSpecs.specsChanged.connect(onChange);
+    });
+  }
+
+  /**
+   * Open the visible task notebook only after a kernel is available, so
+   * JupyterLab auto-selects the Pyodide kernel instead of prompting the user to
+   * pick one (CRT-399). The kernel-select dialog otherwise appears whenever the
+   * notebook opens before the Pyodide kernelspec has been registered.
+   */
+  private async openTaskNotebook(path: string): Promise<void> {
+    await this.waitForKernelSpecs();
+    this.documentManager.openOrReveal(path);
+  }
+
   async getTask(request: GetTask["request"]): Promise<Task> {
     try {
       // generate student task and autograder
@@ -204,7 +241,7 @@ export class EmbeddedPythonCallbacks {
       await this.setJupyterLocale(request.params.language);
 
       if (!isLoadTaskWithTask(request.params)) {
-        this.documentManager.openOrReveal(this.notebookToOpen);
+        await this.openTaskNotebook(this.notebookToOpen);
         return undefined;
       }
 
@@ -300,7 +337,7 @@ export class EmbeddedPythonCallbacks {
         request.params.submission,
       );
 
-      this.documentManager.openOrReveal(this.notebookToOpen);
+      await this.openTaskNotebook(this.notebookToOpen);
     } catch (e) {
       console.error(`${logModule} Project load failure: ${e}`);
 
@@ -312,7 +349,7 @@ export class EmbeddedPythonCallbacks {
 
   async setLocale(request: SetLocale["request"]): Promise<undefined> {
     await this.setJupyterLocale(request.params);
-    this.documentManager.openOrReveal(this.notebookToOpen);
+    await this.openTaskNotebook(this.notebookToOpen);
     return undefined;
   }
 
@@ -624,7 +661,7 @@ export class EmbeddedPythonCallbacks {
       );
     }
 
-    this.documentManager.openOrReveal(this.notebookToOpen);
+    await this.openTaskNotebook(this.notebookToOpen);
   }
 
   private async writeGenericNotebookTask(
@@ -655,9 +692,7 @@ export class EmbeddedPythonCallbacks {
       task.gradingSrc,
     );
 
-    this.documentManager.openOrReveal(
-      EmbeddedPythonCallbacks.taskTemplateLocation,
-    );
+    await this.openTaskNotebook(EmbeddedPythonCallbacks.taskTemplateLocation);
   }
 
   private async getAllFolderContents(): Promise<{

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -154,11 +154,11 @@ export class EmbeddedPythonCallbacks {
   /**
    * Open the visible task notebook only after a kernel is available, so
    * JupyterLab auto-selects the Pyodide kernel instead of prompting the user to
-   * pick one (CRT-399). The kernel-select dialog otherwise appears whenever the
-   * notebook opens before the Pyodide kernelspec has been registered.
+   * pick one.
    */
   private async openTaskNotebook(path: string): Promise<void> {
     await this.waitForKernelSpecs();
+    // eslint-disable-next-line no-restricted-syntax -- this wrapper is the one sanctioned call site
     this.documentManager.openOrReveal(path);
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -102,6 +102,10 @@ export class EmbeddedPythonCallbacks {
   public static readonly gradingSrcLocation: string = "/grading_src";
   public static readonly pluginId = "@jupyterlab/translation-extension:plugin";
 
+  // kernelspec registration happens during startup (local JS, no downloads),
+  // so this is generous; it only matters when the kernel extension is broken
+  private static readonly kernelSpecWaitTimeoutMs = 15_000;
+
   private readonly beforeReloadCallbacks: Array<() => Promise<void>> = [];
 
   constructor(
@@ -126,7 +130,11 @@ export class EmbeddedPythonCallbacks {
       : EmbeddedPythonCallbacks.studentTaskLocation;
 
   /**
-   * Resolves once at least one kernelspec (the Pyodide kernel) is registered.
+   * Resolves once at least one kernelspec (the Pyodide kernel) is registered,
+   * or after a bounded wait. The wait is bounded so that a broken kernel
+   * extension degrades to the pre-existing behavior (the notebook opens and
+   * JupyterLab may prompt for a kernel) instead of hanging the task-opening
+   * RPC — and with it the embedded app — forever.
    */
   private async waitForKernelSpecs(): Promise<void> {
     const kernelSpecs = this.app.serviceManager.kernelspecs;
@@ -141,12 +149,22 @@ export class EmbeddedPythonCallbacks {
     }
 
     await new Promise<void>((resolve) => {
-      const onChange = (): void => {
+      function onChange(): void {
         if (hasSpec()) {
+          clearTimeout(timeout);
           kernelSpecs.specsChanged.disconnect(onChange);
           resolve();
         }
-      };
+      }
+
+      const timeout = setTimeout(() => {
+        kernelSpecs.specsChanged.disconnect(onChange);
+        console.warn(
+          `${logModule} No kernelspec registered after ${EmbeddedPythonCallbacks.kernelSpecWaitTimeoutMs}ms; opening the notebook anyway (the kernel selection dialog may appear)`,
+        );
+        resolve();
+      }, EmbeddedPythonCallbacks.kernelSpecWaitTimeoutMs);
+
       kernelSpecs.specsChanged.connect(onChange);
     });
   }

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -170,6 +170,16 @@ export class EmbeddedPythonCallbacks {
       }, EmbeddedPythonCallbacks.kernelSpecWaitTimeoutMs);
 
       kernelSpecs.specsChanged.connect(onChange);
+
+      // Re-check after connecting so that a spec registered between the check
+      // above and the connect cannot be missed. This makes the wait correct by
+      // inspection instead of relying on the surrounding block staying free of
+      // awaits between the check and the connect.
+      if (hasSpec()) {
+        clearTimeout(timeout);
+        kernelSpecs.specsChanged.disconnect(onChange);
+        resolve();
+      }
     });
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/index.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/index.ts
@@ -112,13 +112,6 @@ const plugin: JupyterFrontEndPlugin<void> = {
       });
     }
 
-    notebookTracker.widgetAdded.connect((_, panel) => {
-      panel.sessionContext.kernelPreference = {
-        ...panel.sessionContext.kernelPreference,
-        autoStartDefault: true,
-      };
-    });
-
     if (mode === Mode.solve) {
       const taskAutoSaver = TaskAutoSaver.trackNotebook(
         notebookTracker,


### PR DESCRIPTION
## CRT-399 — Auto-select the Pyodide kernel instead of prompting

Opening a task notebook popped a **"Select the kernel"** dialog for task creators (it should auto-select Python (Pyodide) silently).

### Root cause — a kernelspec-readiness race
The visible task notebook opens (and its `sessionContext` resolves a kernel) **before the Pyodide kernelspec is registered**. `SessionContext.getDefaultKernel` then sees `specs === null`, so `startKernel()` returns `true` and JupyterLab falls back to the kernel-select dialog. Once the specs load, the single Python-language kernel resolves automatically — so the bug is purely ordering.

### Fix
`await app.serviceManager.kernelspecs.ready` (+ a non-empty `specsChanged` guard) **before** opening the visible notebook — all five `openOrReveal` sites in `iframe-api.ts` now route through a small `openTaskNotebook()` helper. This lets `getDefaultKernel` deterministically resolve the single Pyodide kernel with no prompt, and fixes the same race for the student/solve open too.

Also removed the pre-existing `notebookTracker.widgetAdded` `autoStartDefault: true` hook — it **cannot** fix this (the `!specs` branch short-circuits before `autoStartDefault` is read, and `NotebookPanel.setConfig` re-applies the setting's `false` default anyway), so it was dead and misleading.

### Verification
- Extension `tsc --noEmit`: **zero errors from the change** (remaining errors are the pre-existing uninitialized `./iframe-rpc` submodule, on `main` too); the `kernelspecs.ready/.specs/.specsChanged` APIs typecheck.
- ⚠️ **Not verified in the running app** (needs the built JupyterLite/pyodide). Please confirm: `?mode=edit` opening `task.ipynb` shows **no** kernel dialog and auto-selects Python (Pyodide); same in `?mode=solve`.
- Confidence HIGH on mechanism + fix; the exact race window is the one part worth an in-app sanity check.

> ⚠️ Draft, opened autonomously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-selects the Python (Pyodide) kernel by waiting for kernelspecs before opening task notebooks, removing the “Select the kernel” prompt in edit and solve modes and fixing CRT-399. The wait is bounded to 15s with a safe fallback, and a lint rule prevents regressions.

- **Bug Fixes**
  - Added `waitForKernelSpecs()` that awaits `serviceManager.kernelspecs.ready`, listens to `specsChanged` and checks the emitted specs payload, re-checks immediately after connecting, and on a 15s timeout opens the notebook anyway (dialog may appear).
  - Routed all notebook opens through `openTaskNotebook()`; lint-banned direct `documentManager.openOrReveal` calls.
  - Removed the `notebookTracker.widgetAdded` `autoStartDefault` hook, which didn’t affect the missing-specs case.

<sup>Written for commit cec5d928e999d59aa2a7d403c01b9aeb5bb1e5ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

