### PR TITLE
Fix flaky Scratch app-tests (assertion-mode timing)

### DIFF
--- a/apps/scratch/playwright.config.ts
+++ b/apps/scratch/playwright.config.ts
@@ -4,6 +4,15 @@ const config: PlaywrightTestConfig = {
   // ignore the scratch submodules
   testIgnore: "**src/scratch-editor/**/*",
 
+  // Assertion state is produced by a two-phase Scratch-VM cycle (project run ->
+  // after-run assertion hats -> ASSERTIONS_CHECKED) and then rendered by React.
+  // On the heavy app-tests CI job that chain occasionally takes longer than
+  // Playwright's 5s default, which made assertion-state expectations flaky. Give
+  // web-first assertions more headroom, and retry once (as the e2e suite does)
+  // so a lone transient hiccup doesn't fail the whole job.
+  expect: { timeout: 15 * 1000 },
+  retries: 1,
+
   projects: [
     {
       name: "Desktop",


### PR DESCRIPTION
## Problem

The `app-tests` job intermittently fails on `apps/scratch` `Edit.spec.tsx:461 "can disable assertion mode"` (and its sibling assertion-mode tests) — e.g. [run 29746052511](https://github.com/crt25/collimator/actions/runs/29746052511/job/88364173920):

```
1) [Desktop] › src/__tests__/Edit.spec.tsx:461:7 › /edit › can disable assertion mode
   Error: expect(locator).toHaveText(expected) failed
   Locator:  getByTestId('assertion-state').getByTestId('passed')
   Expected: "1"   Received: "0"   Timeout: 5000ms
     14 × locator resolved to <span data-testid="passed">0</span>
```

## Root cause

Assertion state (`passed`/`total`) is produced by a **two-phase Scratch-VM cycle**, then rendered by React:

1. green flag → project run → `PROJECT_RUN_STOP`
2. the assertions extension sees after-run assertion hats and calls `startHats(...whenTaskFinishedRunning)` — a *second* mini-run
3. its `PROJECT_RUN_STOP` → `onProjectAssertionsRan()` → emits `ASSERTIONS_CHECKED`
4. `useAssertionsState` updates React state → the `passed`/`total` spans re-render

On the heavy `app-tests` runner (which builds backend + frontend + scratch + jupyter in the same job) that chain occasionally takes longer than Playwright's **5 s default `expect` timeout**, so the span is still showing the previous run's `"0"` when the assertion times out. Because the test is *flaky, not consistently red*, the mechanism works — it's a timing shortfall, not a logic bug. And the scratch config sets **no retries** (unlike the e2e suite's `retries: 1`), so a single transient miss fails the whole job.

## Fix

`apps/scratch/playwright.config.ts` — two config lines:

```ts
expect: { timeout: 15 * 1000 },  // headroom for the two-phase VM assertion cycle
retries: 1,                      // match the e2e suite; absorb lone transient misses
```

Web-first assertions auto-retry up to the timeout, so fast runs are unaffected — this only raises the ceiling. No test logic changed; it also covers the identical assertion pattern in `Solve.spec.tsx`.

## Verification

Reasoned from the assertion mechanism; **CI is the check** (no scratch `node_modules` locally, and the flake is load-dependent, so it can't be reproduced here). The change is type-safe config only.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix flaky Scratch app-tests by giving assertion checks more time and one retry. Updates Playwright config so assertion-state waits for the full two-phase Scratch VM cycle; no test logic changed.

- **Bug Fixes**
  - In `apps/scratch/playwright.config.ts`, set `expect: { timeout: 15000 }`.
  - Set `retries: 1` to match the e2e suite and absorb transient timing.

<sup>Written for commit 92c3ad3ed629aa1a9aa29cea81393d59372d2d8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

