### PR TITLE
[CRT-357] Fix misleading rename-error message for the task file

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -107,12 +107,17 @@ const throwOnRestrictedFileOperation = (fileBrowser: FileBrowser): void => {
     }
 
     if (protectedFiles.includes(oldName)) {
+      if (oldName === newName) {
+        // moving a protected file to another directory (name unchanged)
+        throw new ProtectedFileMoveError(oldName);
+      }
+
       // renaming a protected file away from its required name
       throw new ProtectedFileRenameError(oldName);
     }
 
     if (protectedFiles.includes(newName)) {
-      // renaming another file to a reserved name
+      // renaming or moving another file to a reserved name
       throw new ProtectedFileError(newName);
     }
 
@@ -223,5 +228,18 @@ class ProtectedFileRenameError extends Error {
 
   constructor(fileName: string) {
     super(`Only the file name ${fileName} is allowed.`);
+  }
+}
+
+class ProtectedFileMoveError extends Error {
+  // Ensure that the error object is compatible with the format expected by JupyterLite.
+  // See https://github.com/jupyterlab/jupyterlab/blob/35e1551dbd31104d76834848ce3c620a82921839/packages/docmanager/src/dialogs.ts#L210.
+  public readonly response = {
+    status: 400,
+    statusText: "Bad Request",
+  };
+
+  constructor(fileName: string) {
+    super(`The file name ${fileName} can't be moved.`);
   }
 }

--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -106,10 +106,14 @@ const throwOnRestrictedFileOperation = (fileBrowser: FileBrowser): void => {
       throw new HiddenFolderError(newName);
     }
 
-    if (protectedFiles.includes(oldName) || protectedFiles.includes(newName)) {
-      throw new ProtectedFileError(
-        protectedFiles.includes(oldName) ? oldName : newName,
-      );
+    if (protectedFiles.includes(oldName)) {
+      // renaming a protected file away from its required name
+      throw new ProtectedFileRenameError(oldName);
+    }
+
+    if (protectedFiles.includes(newName)) {
+      // renaming another file to a reserved name
+      throw new ProtectedFileError(newName);
     }
 
     return originalRename(oldPath, newPath);
@@ -206,5 +210,18 @@ class ProtectedFileError extends Error {
 
   constructor(fileName: string) {
     super(`The file name ${fileName} is not allowed.`);
+  }
+}
+
+class ProtectedFileRenameError extends Error {
+  // Ensure that the error object is compatible with the format expected by JupyterLite.
+  // See https://github.com/jupyterlab/jupyterlab/blob/35e1551dbd31104d76834848ce3c620a82921839/packages/docmanager/src/dialogs.ts#L210.
+  public readonly response = {
+    status: 400,
+    statusText: "Bad Request",
+  };
+
+  constructor(fileName: string) {
+    super(`Only the file name ${fileName} is allowed.`);
   }
 }

--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -240,6 +240,6 @@ class ProtectedFileMoveError extends Error {
   };
 
   constructor(fileName: string) {
-    super(`The file name ${fileName} can't be moved.`);
+    super(`The file ${fileName} can't be moved.`);
   }
 }


### PR DESCRIPTION
## Problem (CRT-357)

When a student tries to rename `task.ipynb`, the error modal says:

> **Rename Error**
> The file name task.ipynb is not allowed.

That's backwards — `task.ipynb` is the *only* allowed name, and the student's chosen name isn't mentioned at all.

## Fix

`throwOnRestrictedFileOperation` conflated two distinct cases in one error. Split them:

| Action | Message |
|---|---|
| Renaming `task.ipynb` → anything | **"Only the file name task.ipynb is allowed."** (new `ProtectedFileRenameError`) |
| Renaming another file → `task.ipynb`, or uploading a `task.ipynb` | "The file name task.ipynb is not allowed." (unchanged — correct in these cases) |

Both error classes keep the `response: { status: 400 }` shape JupyterLite's rename dialog expects, so the modal plumbing is untouched. Messages stay unlocalized, matching the sibling `HiddenFolderError`/`ProtectedFileError`.

**Verification:** extension `eslint` + `tsc --noEmit` clean on the changed file. Needs a rebuilt JupyterLite for an in-app check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misleading messages for protected task file actions in `JupyterLite`. Addresses CRT-357 by clarifying rename vs move: only `task.ipynb` is allowed as the name, and the file can't be moved.

- **Bug Fixes**
  - Renaming `task.ipynb` shows "Only the file name task.ipynb is allowed."; moving it shows "The file task.ipynb can't be moved." (both via new errors returning `{ status: 400 }`).
  - Renaming or moving another file to `task.ipynb` (or uploading one) still shows "The file name task.ipynb is not allowed."

<sup>Written for commit 300a2a08b8bdfa8bce2fd6a55d7e6e9c3fb07dd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

