### PR TITLE
[CRT-363] Fix Jupyter teacher-notebook leak via mode-param collision

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -349,7 +349,7 @@ export class EmbeddedPythonCallbacks {
     // instead of using window.location.reload(), because the jupyter loaded
     // with a different mode that gets reapplied on a plain reload, which overrides our custom mode.
     const url = new URL(window.location.href);
-    url.searchParams.set("mode", Mode[this.mode]);
+    url.searchParams.set("crtMode", Mode[this.mode]);
     window.location.href = url.toString();
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/mode.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/mode.ts
@@ -5,9 +5,18 @@ export enum Mode {
 }
 
 export const getModeFromUrl = (): Mode => {
-  // check if URL contains 'mode' parameter and retrieve the respective 'Mode' enum value, defaulting to 'edit'
+  // Read our own "crtMode" URL param. We must NOT use "mode": JupyterLite's
+  // `@jupyterlite/application-extension:mode-support` plugin owns that param and
+  // overwrites it with the lab shell mode ("single-document"/"multiple-document")
+  // whenever the shell mode changes — which our own `application:toggle-mode`
+  // call triggers on every load. Sharing the name let a reload read the shell
+  // mode, fall through to the default, and silently switch a student into edit
+  // mode, exposing the teacher notebook (CRT-363).
   const urlParams = new URLSearchParams(window.location.search);
-  const modeParam = urlParams.get("mode") ?? "edit";
+  const modeParam = urlParams.get("crtMode") ?? "show";
 
-  return Mode[modeParam as keyof typeof Mode] ?? Mode.edit;
+  // Default to the most restrictive mode. Edit must be requested explicitly, so
+  // a missing or unrecognized param can never expose the teacher template to a
+  // student — the frontend always sets crtMode explicitly for every flow.
+  return Mode[modeParam as keyof typeof Mode] ?? Mode.show;
 };

--- a/apps/jupyter/extensions/notebook-runner/src/mode.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/mode.ts
@@ -13,10 +13,17 @@ export const getModeFromUrl = (): Mode => {
   // mode, fall through to the default, and silently switch a student into edit
   // mode, exposing the teacher notebook (CRT-363).
   const urlParams = new URLSearchParams(window.location.search);
-  const modeParam = urlParams.get("crtMode") ?? "show";
 
   // Default to the most restrictive mode. Edit must be requested explicitly, so
   // a missing or unrecognized param can never expose the teacher template to a
   // student — the frontend always sets crtMode explicitly for every flow.
-  return Mode[modeParam as keyof typeof Mode] ?? Mode.show;
+  switch (urlParams.get("crtMode")) {
+    case "edit":
+      return Mode.edit;
+    case "solve":
+      return Mode.solve;
+    case "show":
+    default:
+      return Mode.show;
+  }
 };

--- a/docs/python/python.md
+++ b/docs/python/python.md
@@ -17,11 +17,12 @@ The `notebook-runner` extension then later retrieves the buffered messages and s
 ## Mode detection
 
 Analogous to the Scratch application, the jupyter application supports three modes.
-The three modes are detected based on the query parameter `mode`.
+The three modes are detected based on the query parameter `crtMode` (a custom
+name so it does not collide with JupyterLite's own `mode` shell-mode param).
 
-1. Edit mode through `?mode=edit` (default)
-2. Solve mode through `?mode=solve`
-3. Show mode through `?mode=show`
+1. Edit mode through `?crtMode=edit`
+2. Solve mode through `?crtMode=solve`
+3. Show mode through `?crtMode=show` (the default when the parameter is missing)
 
 ## G-AST converter
 

--- a/frontend/src/components/dashboard/CodeView.tsx
+++ b/frontend/src/components/dashboard/CodeView.tsx
@@ -4,7 +4,7 @@ import styled from "@emotion/styled";
 import { Language } from "iframe-rpc-react/src";
 import { LuExpand } from "react-icons/lu";
 import { TaskType } from "@/api/collimator/generated/models";
-import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+import { getEmbeddedAppUrl } from "@/utilities/embedded-app-url";
 import { useTaskFile } from "@/api/collimator/hooks/tasks/useTask";
 import { useSolutionFile } from "@/api/collimator/hooks/solutions/useSolution";
 import { useFileHash } from "@/hooks/useFileHash";
@@ -35,17 +35,6 @@ const CodeViewWrapper = styled(CodeViewContainer)`
     height: 100% !important;
   }
 `;
-
-const getSolutionCodeUrl = (taskType: TaskType) => {
-  switch (taskType) {
-    case TaskType.SCRATCH:
-      return `${scratchAppHostName}/show`;
-    case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?crtMode=show`;
-    default:
-      return null;
-  }
-};
 
 const CodeView = ({
   classId,
@@ -79,7 +68,10 @@ const CodeView = ({
     error: solutionFileError,
   } = useSolutionFile(classId, sessionId, taskId, solutionHash);
 
-  const iframeSrc = useMemo(() => getSolutionCodeUrl(taskType), [taskType]);
+  const iframeSrc = useMemo(
+    () => getEmbeddedAppUrl(taskType, "show"),
+    [taskType],
+  );
 
   const taskFileHash = useFileHash(taskFile);
   const solutionFileHash = useFileHash(solutionFile);

--- a/frontend/src/components/dashboard/CodeView.tsx
+++ b/frontend/src/components/dashboard/CodeView.tsx
@@ -41,7 +41,7 @@ const getSolutionCodeUrl = (taskType: TaskType) => {
     case TaskType.SCRATCH:
       return `${scratchAppHostName}/show`;
     case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?mode=show`;
+      return `${jupyterAppHostName}?crtMode=show`;
     default:
       return null;
   }

--- a/frontend/src/components/modals/EditTaskModal.tsx
+++ b/frontend/src/components/modals/EditTaskModal.tsx
@@ -1,23 +1,12 @@
 import { useIntl } from "react-intl";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { Language, Task } from "iframe-rpc-react/src";
-import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+import { getEmbeddedAppUrl } from "@/utilities/embedded-app-url";
 import { TaskType } from "@/api/collimator/generated/models";
 import { executeAsyncWithToasts } from "@/utilities/task";
 import { messages as taskMessages } from "@/i18n/task-messages";
 import { EmbeddedAppRef } from "../EmbeddedApp";
 import TaskModal from "./TaskModal";
-
-const getEditUrl = (taskType: TaskType) => {
-  switch (taskType) {
-    case TaskType.SCRATCH:
-      return `${scratchAppHostName}/edit`;
-    case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?crtMode=edit`;
-    default:
-      return null;
-  }
-};
 
 const EditTaskModal = ({
   isShown,
@@ -33,7 +22,7 @@ const EditTaskModal = ({
   initialTask?: Blob | null;
 }) => {
   const intl = useIntl();
-  const url = useMemo(() => getEditUrl(taskType), [taskType]);
+  const url = useMemo(() => getEmbeddedAppUrl(taskType, "edit"), [taskType]);
   const wasInitialized = useRef(false);
 
   const onSaveTask = useCallback(

--- a/frontend/src/components/modals/EditTaskModal.tsx
+++ b/frontend/src/components/modals/EditTaskModal.tsx
@@ -13,7 +13,7 @@ const getEditUrl = (taskType: TaskType) => {
     case TaskType.SCRATCH:
       return `${scratchAppHostName}/edit`;
     case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?mode=edit`;
+      return `${jupyterAppHostName}?crtMode=edit`;
     default:
       return null;
   }

--- a/frontend/src/components/modals/SolveTaskModal.tsx
+++ b/frontend/src/components/modals/SolveTaskModal.tsx
@@ -13,7 +13,7 @@ const getSolveUrl = (taskType: TaskType) => {
     case TaskType.SCRATCH:
       return `${scratchAppHostName}/solve`;
     case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?mode=solve`;
+      return `${jupyterAppHostName}?crtMode=solve`;
     default:
       return null;
   }

--- a/frontend/src/components/modals/SolveTaskModal.tsx
+++ b/frontend/src/components/modals/SolveTaskModal.tsx
@@ -2,22 +2,11 @@ import { useIntl } from "react-intl";
 import { useCallback, useMemo } from "react";
 import { Language, Submission } from "iframe-rpc-react/src";
 import { TaskType } from "@/api/collimator/generated/models";
-import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+import { getEmbeddedAppUrl } from "@/utilities/embedded-app-url";
 import { executeAsyncWithToasts } from "@/utilities/task";
 import { messages as taskMessages } from "@/i18n/task-messages";
 import { EmbeddedAppRef } from "../EmbeddedApp";
 import TaskModal from "./TaskModal";
-
-const getSolveUrl = (taskType: TaskType) => {
-  switch (taskType) {
-    case TaskType.SCRATCH:
-      return `${scratchAppHostName}/solve`;
-    case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?crtMode=solve`;
-    default:
-      return null;
-  }
-};
 
 const SolveTaskModal = ({
   isShown,
@@ -35,7 +24,7 @@ const SolveTaskModal = ({
   solution?: Blob | null;
 }) => {
   const intl = useIntl();
-  const url = useMemo(() => getSolveUrl(taskType), [taskType]);
+  const url = useMemo(() => getEmbeddedAppUrl(taskType, "solve"), [taskType]);
 
   const onSaveSolution = useCallback(
     async (embeddedApp: EmbeddedAppRef) => {

--- a/frontend/src/components/modals/ViewSolutionModal.tsx
+++ b/frontend/src/components/modals/ViewSolutionModal.tsx
@@ -16,7 +16,7 @@ const getViewUrl = (taskType: TaskType) => {
     case TaskType.SCRATCH:
       return `${scratchAppHostName}/solve`;
     case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?mode=solve`;
+      return `${jupyterAppHostName}?crtMode=solve`;
     default:
       return null;
   }

--- a/frontend/src/components/modals/ViewSolutionModal.tsx
+++ b/frontend/src/components/modals/ViewSolutionModal.tsx
@@ -1,7 +1,7 @@
 import { FormattedMessage, useIntl } from "react-intl";
 import React, { useCallback, useMemo } from "react";
 import { Language } from "iframe-rpc-react/src";
-import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+import { getEmbeddedAppUrl } from "@/utilities/embedded-app-url";
 import { TaskType } from "@/api/collimator/generated/models";
 import { useTaskFile } from "@/api/collimator/hooks/tasks/useTask";
 import { useSolutionFile } from "@/api/collimator/hooks/solutions/useSolution";
@@ -10,17 +10,6 @@ import { messages as taskMessages } from "@/i18n/task-messages";
 import { EmbeddedAppRef } from "../EmbeddedApp";
 import MultiSwrContent from "../MultiSwrContent";
 import TaskModal from "./TaskModal";
-
-const getViewUrl = (taskType: TaskType) => {
-  switch (taskType) {
-    case TaskType.SCRATCH:
-      return `${scratchAppHostName}/solve`;
-    case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?crtMode=solve`;
-    default:
-      return null;
-  }
-};
 
 const ViewSolutionModal = ({
   isShown,
@@ -44,7 +33,7 @@ const ViewSolutionModal = ({
   footer?: React.ReactNode;
 }) => {
   const intl = useIntl();
-  const url = useMemo(() => getViewUrl(taskType), [taskType]);
+  const url = useMemo(() => getEmbeddedAppUrl(taskType, "solve"), [taskType]);
 
   const {
     data: taskFile,

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -49,7 +49,7 @@ const getSolveUrl = (taskType: TaskType) => {
     case TaskType.SCRATCH:
       return `${scratchAppHostName}/solve`;
     case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?mode=solve`;
+      return `${jupyterAppHostName}?crtMode=solve`;
     default:
       return null;
   }

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -4,7 +4,6 @@ import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import { Language, Submission, Test, ToastType } from "iframe-rpc-react/src";
 import { Alert, Box, Breadcrumb, Text } from "@chakra-ui/react";
 import { LuListTodo, LuSignpost } from "react-icons/lu";
-import { TaskType } from "@/api/collimator/generated/models";
 import { useClassSession } from "@/api/collimator/hooks/sessions/useClassSession";
 import { useCreateSolution } from "@/api/collimator/hooks/solutions/useCreateSolution";
 import { useTask, useTaskFile } from "@/api/collimator/hooks/tasks/useTask";
@@ -13,7 +12,7 @@ import { EmbeddedAppRef } from "@/components/EmbeddedApp";
 import StudentPageLayout from "@/components/layout/StudentPageLayout";
 import MultiSwrContent from "@/components/MultiSwrContent";
 import Task from "@/components/Task";
-import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+import { getEmbeddedAppUrl } from "@/utilities/embedded-app-url";
 import { downloadBlob } from "@/utilities/download";
 import { readSingleFileFromDisk } from "@/utilities/file-from-disk";
 import { useFileHash } from "@/hooks/useFileHash";
@@ -43,17 +42,6 @@ const messages = defineMessages({
     defaultMessage: "Open Task List",
   },
 });
-
-const getSolveUrl = (taskType: TaskType) => {
-  switch (taskType) {
-    case TaskType.SCRATCH:
-      return `${scratchAppHostName}/solve`;
-    case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?crtMode=solve`;
-    default:
-      return null;
-  }
-};
 
 const SolveTaskPage = () => {
   const router = useRouter();
@@ -100,7 +88,7 @@ const SolveTaskPage = () => {
   const taskFileHash = useFileHash(taskFile);
 
   const iframeSrc = useMemo(
-    () => (task?.type ? getSolveUrl(task.type) : null),
+    () => (task?.type ? getEmbeddedAppUrl(task.type, "solve") : null),
     [task?.type],
   );
 

--- a/frontend/src/pages/task/[taskId]/view.tsx
+++ b/frontend/src/pages/task/[taskId]/view.tsx
@@ -6,7 +6,6 @@ import { Language } from "iframe-rpc-react/src";
 import TaskActions from "@/components/task/TaskActions";
 import TaskNavigation from "@/components/task/TaskNavigation";
 import { useTask, useTaskFile } from "@/api/collimator/hooks/tasks/useTask";
-import { TaskType } from "@/api/collimator/generated/models";
 import MultiSwrContent from "@/components/MultiSwrContent";
 import Header from "@/components/header/Header";
 import CrtNavigation from "@/components/CrtNavigation";
@@ -14,7 +13,7 @@ import PageHeading from "@/components/PageHeading";
 import Breadcrumbs from "@/components/Breadcrumbs";
 import EmbeddedApp, { EmbeddedAppRef } from "@/components/EmbeddedApp";
 import { useFileHash } from "@/hooks/useFileHash";
-import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+import { getEmbeddedAppUrl } from "@/utilities/embedded-app-url";
 import { executeAsyncWithToasts } from "@/utilities/task";
 import { messages as taskMessages } from "@/i18n/task-messages";
 
@@ -24,17 +23,6 @@ const messages = defineMessages({
     defaultMessage: "Task - {title}",
   },
 });
-
-const getDisplaySolveUrl = (taskType: TaskType) => {
-  switch (taskType) {
-    case TaskType.SCRATCH:
-      return `${scratchAppHostName}/solve`;
-    case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?crtMode=solve`;
-    default:
-      return null;
-  }
-};
 
 const TaskDetail = () => {
   const router = useRouter();
@@ -57,7 +45,7 @@ const TaskDetail = () => {
   } = useTaskFile(taskId);
 
   const iframeSrc = useMemo(
-    () => (task ? getDisplaySolveUrl(task.type) : null),
+    () => (task ? getEmbeddedAppUrl(task.type, "solve") : null),
     [task],
   );
 

--- a/frontend/src/pages/task/[taskId]/view.tsx
+++ b/frontend/src/pages/task/[taskId]/view.tsx
@@ -30,7 +30,7 @@ const getDisplaySolveUrl = (taskType: TaskType) => {
     case TaskType.SCRATCH:
       return `${scratchAppHostName}/solve`;
     case TaskType.JUPYTER:
-      return `${jupyterAppHostName}?mode=solve`;
+      return `${jupyterAppHostName}?crtMode=solve`;
     default:
       return null;
   }

--- a/frontend/src/utilities/embedded-app-url.ts
+++ b/frontend/src/utilities/embedded-app-url.ts
@@ -1,0 +1,24 @@
+import { TaskType } from "@/api/collimator/generated/models";
+import { jupyterAppHostName, scratchAppHostName } from "@/utilities/constants";
+
+export type EmbeddedAppMode = "edit" | "solve" | "show";
+
+/**
+ * Builds the URL embedding the application for the given task type in the
+ * given mode. Returns null for unsupported task types.
+ */
+export const getEmbeddedAppUrl = (
+  taskType: TaskType,
+  mode: EmbeddedAppMode,
+): string | null => {
+  switch (taskType) {
+    case TaskType.SCRATCH:
+      return `${scratchAppHostName}/${mode}`;
+    case TaskType.JUPYTER:
+      // "crtMode", not "mode": JupyterLite's mode-support plugin owns the
+      // "mode" URL param and overwrites it with the lab shell mode (CRT-363)
+      return `${jupyterAppHostName}?crtMode=${mode}`;
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
## Problem (CRT-363, security)

As a student in a Jupyter task, switching the UI language back and forth a few times replaces `task.ipynb` with the **teacher's notebook (solutions exposed)** and removes the autograder/student folders. [Repro video](https://jam.dev/c/24f627ba-dc72-4545-8633-a13c740013ba).

## Root cause — URL query-param namespace collision

Our extension reads the task mode from `?mode=`. But JupyterLite's `@jupyterlite/application-extension:mode-support` plugin **owns that same param** for the lab *shell* mode and rewrites it on every shell-mode change:

```js
labShell.modeChanged.connect((_, mode) => {
  url.searchParams.set("mode", mode);            // "solve" -> "single-document" -> "multiple-document"
  router.navigate(..., { skipRouting: true });
});
```

Our own `simplifyUserInterface` runs `application:toggle-mode` on every load, which fires `modeChanged` → `?mode=solve` is silently overwritten to `?mode=multiple-document`. Then **any plain reload of the iframe** (F5, "reload frame", history traversal — the extra history entries the rewrites push make Back reload at the rewritten URL) reads `multiple-document`, which `getModeFromUrl` doesn't recognize → falls through to the default `edit`. In edit mode, the frontend's re-sent `loadTask` (fired again on locale change) writes the **teacher template** into `/task.ipynb` and reveals it. The follow-up locale switch then navigates with `?mode=edit`, making it sticky — hence "3–5+ switches".

_(Full traced mechanism with file:line evidence and refuted alternatives is in the investigation notes; verified live that a load at `?mode=multiple-document` boots the extension in edit mode.)_

## Fix

1. **Rename our param `mode` → `crtMode`** — extension reader (`mode.ts`) + writer (`iframe-api.ts` locale navigation) + the six frontend Jupyter URL builders (`SolveTaskModal`, `EditTaskModal`, `ViewSolutionModal`, `CodeView`, `solve.tsx`, `view.tsx`). `mode-support` no longer touches our value, so it survives shell-mode toggles and reloads.
2. **Fail-safe default** — an absent/unknown `crtMode` now resolves to `show` (most restrictive), not `edit`. Edit must be requested explicitly, so no future param loss can ever expose the teacher template to a student. Every real flow sets `crtMode` explicitly, so teacher edit is unaffected.

Scratch is unaffected (routes by path, e.g. `/solve`, not a query param). Docs (`python.md`) updated.

## Verification

Frontend + extension `tsc --noEmit` and `eslint` clean; repo-wide sweep confirms no `mode=edit|solve|show` remains. **In-app smoke test still recommended** on a rebuilt JupyterLite: load `?crtMode=solve`, confirm it boots in solve mode and that `crtMode` survives the shell-mode toggle (unlike `mode`), and that repeated language switches no longer swap in the teacher notebook — I can run this next if you'd like.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a security bug where language switches in Jupyter tasks could replace a student’s `task.ipynb` with the teacher notebook. Resolves CRT-363 by isolating our mode param, hardening parsing, and making the default safe.

- **Bug Fixes**
  - Switched URL param from `mode` to `crtMode` and centralized embedded-app URL building with `getEmbeddedAppUrl(...)` so Jupyter URLs consistently use `crtMode` and aren’t overwritten by `@jupyterlite/application-extension:mode-support` during shell-mode changes or reloads.
  - Default on missing/unknown `crtMode` is now `show`, and parsing uses an explicit switch (not enum indexing) to reject invalid values like `"0"` or `"constructor"`, preventing teacher notebook exposure.

<sup>Written for commit b936f720a226ae071dc0255a4637e25a1717cc18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

