### PR TITLE
[CRT-397] Fix Jupyter locale change losing work + student-path content error

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -170,15 +170,11 @@ const isTaskFile = (path: string): boolean =>
   path === "/task.ipynb" || path === "task.ipynb";
 
 /**
- * The student never edits the teacher template directly: opening `task.ipynb`
- * transparently opens their own `/student/task.ipynb`. That copy is (re)written
- * asynchronously after a reload (e.g. a language change wipes the memory-backed
- * contents and the frontend re-sends the submission), so opening it too early
- * throws "could not find content" (CRT-397). We therefore open it only if it
- * already exists; if it does not, the open is DROPPED — there is no waiting or
- * retrying here. That is safe because the restore flow (loadSubmission) issues
- * its own open after writing the file, and we must never fall back to opening
- * the template itself.
+ * Entry point to open the student notebook, only if it's available.
+ * In case of failure, we let the restore flow (loadSubmission) issue
+ * its own open after writing the file.
+ * Without this, quick locale change could lead to failure when
+ * opening the notebook, or worse, opening the wrong task.
  */
 const redirectTaskFileOpensToStudentVersion = (
   documentManager: IDocumentManager,
@@ -199,9 +195,6 @@ const redirectTaskFileOpensToStudentVersion = (
       .then(
         () => open(studentTaskPath, widgetName, kernel, options),
         (error) => {
-          // Only contents.get() rejections land here: the student copy has not
-          // been restored yet, so this open is dropped (the restore flow opens
-          // the task itself once the content is written).
           console.debug(
             `Ignoring open of ${studentTaskPath}; not available yet`,
             error,

--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -195,8 +195,16 @@ const redirectTaskFileOpensToStudentVersion = (
     void documentManager.services.contents
       .get(studentTaskPath, { content: false })
       .then(() => open(studentTaskPath, widgetName, kernel, options))
-      .catch(() => {
-        // the student copy has not been restored yet; ignore this open.
+      .catch((error) => {
+        // The expected case: the student copy has not been restored yet, so we
+        // ignore this open (the task auto-opens once the content is restored).
+        // Contents are memory-backed in JupyterLite so other failures are not
+        // really expected; log a breadcrumb instead of staying fully silent in
+        // case one ever occurs.
+        console.debug(
+          `Ignoring open of ${studentTaskPath}; not available yet`,
+          error,
+        );
       });
   };
 

--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -174,14 +174,16 @@ const isTaskFile = (path: string): boolean =>
  * transparently opens their own `/student/task.ipynb`. That copy is (re)written
  * asynchronously after a reload (e.g. a language change wipes the memory-backed
  * contents and the frontend re-sends the submission), so opening it too early
- * throws "could not find content" (CRT-397). We therefore only open it once it
- * exists, and otherwise do nothing — the task auto-opens as soon as the content
- * is restored, and we must never fall back to opening the template itself.
+ * throws "could not find content" (CRT-397). We therefore open it only if it
+ * already exists; if it does not, the open is DROPPED — there is no waiting or
+ * retrying here. That is safe because the restore flow (loadSubmission) issues
+ * its own open after writing the file, and we must never fall back to opening
+ * the template itself.
  */
 const redirectTaskFileOpensToStudentVersion = (
   documentManager: IDocumentManager,
 ): void => {
-  const openStudentTaskWhenReady = (
+  const openStudentTaskIfAvailable = (
     open: (
       path: string,
       widgetName?: string,
@@ -194,17 +196,21 @@ const redirectTaskFileOpensToStudentVersion = (
   ): void => {
     void documentManager.services.contents
       .get(studentTaskPath, { content: false })
-      .then(() => open(studentTaskPath, widgetName, kernel, options))
+      .then(
+        () => open(studentTaskPath, widgetName, kernel, options),
+        (error) => {
+          // Only contents.get() rejections land here: the student copy has not
+          // been restored yet, so this open is dropped (the restore flow opens
+          // the task itself once the content is written).
+          console.debug(
+            `Ignoring open of ${studentTaskPath}; not available yet`,
+            error,
+          );
+        },
+      )
       .catch((error) => {
-        // The expected case: the student copy has not been restored yet, so we
-        // ignore this open (the task auto-opens once the content is restored).
-        // Contents are memory-backed in JupyterLite so other failures are not
-        // really expected; log a breadcrumb instead of staying fully silent in
-        // case one ever occurs.
-        console.debug(
-          `Ignoring open of ${studentTaskPath}; not available yet`,
-          error,
-        );
+        // reached only if opening the existing file itself failed
+        console.error(`Failed to open ${studentTaskPath}`, error);
       });
   };
 
@@ -220,7 +226,12 @@ const redirectTaskFileOpensToStudentVersion = (
       return originalOpenOrReveal(path, widgetName, kernel, options);
     }
 
-    openStudentTaskWhenReady(originalOpenOrReveal, widgetName, kernel, options);
+    openStudentTaskIfAvailable(
+      originalOpenOrReveal,
+      widgetName,
+      kernel,
+      options,
+    );
     return undefined;
   };
 
@@ -235,7 +246,7 @@ const redirectTaskFileOpensToStudentVersion = (
       return originalOpen(path, widgetName, kernel, options);
     }
 
-    openStudentTaskWhenReady(originalOpen, widgetName, kernel, options);
+    openStudentTaskIfAvailable(originalOpen, widgetName, kernel, options);
     return undefined;
   };
 };

--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -79,7 +79,7 @@ export const simplifyUserInterface = async (
     }
   }
 
-  hideGradingFolders(fileBrowser);
+  hideRestrictedItems(fileBrowser, mode);
 
   // activate simple mode
   await app.commands.execute("application:toggle-mode");
@@ -139,22 +139,39 @@ const throwOnRestrictedFileOperation = (fileBrowser: FileBrowser): void => {
 };
 
 /**
- * A function to hide grading folders in the file browser.
+ * Hide items the student/viewer must not interact with from the file browser:
+ * the grading folders, and — outside edit mode — the root `task.ipynb`.
+ *
+ * The root `task.ipynb` is the teacher master template. It is shipped as static
+ * app content, so it reappears in the browser after the memory-backed contents
+ * are wiped on a reload (e.g. a language change), and clicking it triggers the
+ * student-path redirect toward a `/student/task.ipynb` that has not been
+ * restored yet — the "could not find content" error (CRT-397). Hiding it also
+ * keeps the template out of the student's view.
+ *
  * A bit hacky because there is no public API to filter items.
- * @param fileBrowser The file browser instance
  */
-const hideGradingFolders = (fileBrowser: FileBrowser): void => {
+const hideRestrictedItems = (fileBrowser: FileBrowser, mode: Mode): void => {
+  const hideTaskFile = mode !== Mode.edit;
   let items: Contents.IModel[] = fileBrowser.model["_items"];
 
-  /**
-   * Override the items getter to filter the desired folder.
-   */
   Object.defineProperty(fileBrowser.model, "_items", {
     get() {
-      return items.filter(
-        (item) =>
-          !(item.type === "directory" && hiddenFolders.includes(item.name)),
-      );
+      return items.filter((item) => {
+        if (item.type === "directory" && hiddenFolders.includes(item.name)) {
+          return false;
+        }
+
+        if (
+          hideTaskFile &&
+          item.type !== "directory" &&
+          protectedFiles.includes(item.name)
+        ) {
+          return false;
+        }
+
+        return true;
+      });
     },
     set(v) {
       items = v;

--- a/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/user-interface.ts
@@ -79,7 +79,7 @@ export const simplifyUserInterface = async (
     }
   }
 
-  hideRestrictedItems(fileBrowser, mode);
+  hideGradingFolders(fileBrowser);
 
   // activate simple mode
   await app.commands.execute("application:toggle-mode");
@@ -139,39 +139,22 @@ const throwOnRestrictedFileOperation = (fileBrowser: FileBrowser): void => {
 };
 
 /**
- * Hide items the student/viewer must not interact with from the file browser:
- * the grading folders, and — outside edit mode — the root `task.ipynb`.
- *
- * The root `task.ipynb` is the teacher master template. It is shipped as static
- * app content, so it reappears in the browser after the memory-backed contents
- * are wiped on a reload (e.g. a language change), and clicking it triggers the
- * student-path redirect toward a `/student/task.ipynb` that has not been
- * restored yet — the "could not find content" error (CRT-397). Hiding it also
- * keeps the template out of the student's view.
- *
+ * A function to hide grading folders in the file browser.
  * A bit hacky because there is no public API to filter items.
+ * @param fileBrowser The file browser instance
  */
-const hideRestrictedItems = (fileBrowser: FileBrowser, mode: Mode): void => {
-  const hideTaskFile = mode !== Mode.edit;
+const hideGradingFolders = (fileBrowser: FileBrowser): void => {
   let items: Contents.IModel[] = fileBrowser.model["_items"];
 
+  /**
+   * Override the items getter to filter the desired folder.
+   */
   Object.defineProperty(fileBrowser.model, "_items", {
     get() {
-      return items.filter((item) => {
-        if (item.type === "directory" && hiddenFolders.includes(item.name)) {
-          return false;
-        }
-
-        if (
-          hideTaskFile &&
-          item.type !== "directory" &&
-          protectedFiles.includes(item.name)
-        ) {
-          return false;
-        }
-
-        return true;
-      });
+      return items.filter(
+        (item) =>
+          !(item.type === "directory" && hiddenFolders.includes(item.name)),
+      );
     },
     set(v) {
       items = v;
@@ -181,13 +164,41 @@ const hideRestrictedItems = (fileBrowser: FileBrowser, mode: Mode): void => {
   fileBrowser.model.refresh();
 };
 
+const studentTaskPath = "/student/task.ipynb";
+
+const isTaskFile = (path: string): boolean =>
+  path === "/task.ipynb" || path === "task.ipynb";
+
+/**
+ * The student never edits the teacher template directly: opening `task.ipynb`
+ * transparently opens their own `/student/task.ipynb`. That copy is (re)written
+ * asynchronously after a reload (e.g. a language change wipes the memory-backed
+ * contents and the frontend re-sends the submission), so opening it too early
+ * throws "could not find content" (CRT-397). We therefore only open it once it
+ * exists, and otherwise do nothing — the task auto-opens as soon as the content
+ * is restored, and we must never fall back to opening the template itself.
+ */
 const redirectTaskFileOpensToStudentVersion = (
   documentManager: IDocumentManager,
 ): void => {
-  const redirect = (path: string): string =>
-    path === "/task.ipynb" || path === "task.ipynb"
-      ? "/student/task.ipynb"
-      : path;
+  const openStudentTaskWhenReady = (
+    open: (
+      path: string,
+      widgetName?: string,
+      kernel?: Partial<Kernel.IModel>,
+      options?: DocumentRegistry.IOpenOptions,
+    ) => IDocumentWidget | undefined,
+    widgetName?: string,
+    kernel?: Partial<Kernel.IModel>,
+    options?: DocumentRegistry.IOpenOptions,
+  ): void => {
+    void documentManager.services.contents
+      .get(studentTaskPath, { content: false })
+      .then(() => open(studentTaskPath, widgetName, kernel, options))
+      .catch(() => {
+        // the student copy has not been restored yet; ignore this open.
+      });
+  };
 
   const originalOpenOrReveal =
     documentManager.openOrReveal.bind(documentManager);
@@ -196,8 +207,14 @@ const redirectTaskFileOpensToStudentVersion = (
     widgetName?: string,
     kernel?: Partial<Kernel.IModel>,
     options?: DocumentRegistry.IOpenOptions,
-  ): ReturnType<IDocumentManager["openOrReveal"]> =>
-    originalOpenOrReveal(redirect(path), widgetName, kernel, options);
+  ): ReturnType<IDocumentManager["openOrReveal"]> => {
+    if (!isTaskFile(path)) {
+      return originalOpenOrReveal(path, widgetName, kernel, options);
+    }
+
+    openStudentTaskWhenReady(originalOpenOrReveal, widgetName, kernel, options);
+    return undefined;
+  };
 
   const originalOpen = documentManager.open.bind(documentManager);
   documentManager.open = (
@@ -205,8 +222,14 @@ const redirectTaskFileOpensToStudentVersion = (
     widgetName,
     kernel,
     options,
-  ): IDocumentWidget | undefined =>
-    originalOpen(redirect(path), widgetName, kernel, options);
+  ): IDocumentWidget | undefined => {
+    if (!isTaskFile(path)) {
+      return originalOpen(path, widgetName, kernel, options);
+    }
+
+    openStudentTaskWhenReady(originalOpen, widgetName, kernel, options);
+    return undefined;
+  };
 };
 
 class HiddenFolderError extends Error {

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -97,13 +97,10 @@ const SolveTaskPage = () => {
   const wasInitialized = useRef(false);
   const isScratchMutexAvailable = useRef(true);
   // The freshest solution the embedded app has pushed up (e.g. the auto-save
-  // triggered right before a language change reloads the iframe). The parent
-  // frame is not reloaded, so this ref survives; we replay it after the reload
-  // instead of racing the still-in-flight backend write with a stale fetch,
-  // which otherwise loses the student's unsaved changes (CRT-397). Keyed by
-  // task id: this page component survives task-to-task navigation (dynamic
-  // route params do not remount it), so an unconsumed stash must never be
-  // replayed into a different task.
+  // triggered right before a language change reloads the iframe).
+  // This allows data persistency after app iframe reloads (e.g. locale change).
+  // Keyed by task id: this page component survives task-to-task navigation,
+  // so an unconsumed stash must never be replayed into a different task.
   const pendingSolution = useRef<{ taskId: number; solution: Blob } | null>(
     null,
   );
@@ -260,13 +257,6 @@ const SolveTaskPage = () => {
           { intl, descriptor: taskMessages.cannotLoadSubmission },
         );
       } catch {
-        // Put the stash back (unless something newer arrived meanwhile) so the
-        // next app load can still restore it — it may hold work that never
-        // reached the backend. A stash for a different task is dropped instead.
-        // A failed replay does not mean the stashed copy is bad (the embedded
-        // app may still be initializing after a locale change), so we must NOT
-        // fall back to the pristine task in that case — it would visibly
-        // discard the stashed work; the next app load replays the stash.
         if (stashedSolution !== null) {
           pendingSolution.current ??= stashed;
           return;
@@ -295,8 +285,7 @@ const SolveTaskPage = () => {
       }
 
       // Stash synchronously so a reload can replay it even if the backend write
-      // below is still in flight (CRT-397). Keyed by task id so it can never be
-      // replayed into a different task.
+      // below is still in flight.
       pendingSolution.current = { taskId: task.id, solution: solutionBlob };
 
       try {

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -212,13 +212,14 @@ const SolveTaskPage = () => {
     ) {
       wasInitialized.current = true;
 
-      try {
-        // Prefer a solution stashed just before a reload (it includes changes
-        // that may not have reached the backend yet); otherwise load the latest
-        // persisted solution.
-        const stashedSolution = pendingSolution.current;
-        pendingSolution.current = null;
+      // Prefer a solution stashed just before a reload (it includes changes
+      // that may not have reached the backend yet); otherwise load the latest
+      // persisted solution. Consume the stash synchronously so a solution
+      // arriving while the load below is in flight is not clobbered.
+      const stashedSolution = pendingSolution.current;
+      pendingSolution.current = null;
 
+      try {
         const solutionFile =
           stashedSolution ??
           (await fetchLatestSolutionFile(
@@ -239,6 +240,11 @@ const SolveTaskPage = () => {
           { intl, descriptor: taskMessages.cannotLoadSubmission },
         );
       } catch {
+        // Put the stash back (unless something newer arrived meanwhile) so the
+        // next app load can still restore it — it may hold work that never
+        // reached the backend.
+        pendingSolution.current ??= stashedSolution;
+
         // if we cannot fetch the latest solution file we load the task from scratch
         await embeddedApp.current.sendRequest("loadTask", {
           task: taskFile,

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -100,8 +100,23 @@ const SolveTaskPage = () => {
   // triggered right before a language change reloads the iframe). The parent
   // frame is not reloaded, so this ref survives; we replay it after the reload
   // instead of racing the still-in-flight backend write with a stale fetch,
-  // which otherwise loses the student's unsaved changes (CRT-397).
-  const pendingSolution = useRef<Blob | null>(null);
+  // which otherwise loses the student's unsaved changes (CRT-397). Keyed by
+  // task id: this page component survives task-to-task navigation (dynamic
+  // route params do not remount it), so an unconsumed stash must never be
+  // replayed into a different task.
+  const pendingSolution = useRef<{ taskId: number; solution: Blob } | null>(
+    null,
+  );
+
+  // Latest-ref mirror of intl so that onAppAvailable's identity does not
+  // rotate on locale changes: useIframeChild eagerly re-invokes a rotated
+  // onAppAvailable against the still-loaded old iframe, which would consume
+  // the stash above right before the locale-triggered reload discards the
+  // result (the same reason task/taskFile revalidation is disabled).
+  const intlRef = useRef(intl);
+  useEffect(() => {
+    intlRef.current = intl;
+  });
 
   const toggleSessionMenu = useCallback(() => {
     setShowSessionMenu((show) => !show);
@@ -212,12 +227,17 @@ const SolveTaskPage = () => {
     ) {
       wasInitialized.current = true;
 
+      const intl = intlRef.current;
+
       // Prefer a solution stashed just before a reload (it includes changes
       // that may not have reached the backend yet); otherwise load the latest
       // persisted solution. Consume the stash synchronously so a solution
-      // arriving while the load below is in flight is not clobbered.
-      const stashedSolution = pendingSolution.current;
+      // arriving while the load below is in flight is not clobbered, and only
+      // accept it for the task it was stashed for.
+      const stashed = pendingSolution.current;
       pendingSolution.current = null;
+      const stashedSolution =
+        stashed?.taskId === task.id ? stashed.solution : null;
 
       try {
         const solutionFile =
@@ -242,8 +262,10 @@ const SolveTaskPage = () => {
       } catch {
         // Put the stash back (unless something newer arrived meanwhile) so the
         // next app load can still restore it — it may hold work that never
-        // reached the backend.
-        pendingSolution.current ??= stashedSolution;
+        // reached the backend. A stash for a different task is dropped instead.
+        if (stashedSolution !== null) {
+          pendingSolution.current ??= stashed;
+        }
 
         // if we cannot fetch the latest solution file we load the task from scratch
         await embeddedApp.current.sendRequest("loadTask", {
@@ -254,9 +276,11 @@ const SolveTaskPage = () => {
         isScratchMutexAvailable.current = true;
       }
     }
-    // since taskFile is a blob, use its hash as a proxy for its content
+    // since taskFile is a blob, use its hash as a proxy for its content.
+    // intl is intentionally read through intlRef (not listed as a dep): see the
+    // comment on intlRef — a locale change must not rotate this callback.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [embeddedApp, taskFileHash, session, task, intl.locale]);
+  }, [embeddedApp, taskFileHash, session, task]);
 
   const onReceiveTaskSolution = useCallback(
     async (solutionBlob: Blob) => {
@@ -266,8 +290,9 @@ const SolveTaskPage = () => {
       }
 
       // Stash synchronously so a reload can replay it even if the backend write
-      // below is still in flight (CRT-397).
-      pendingSolution.current = solutionBlob;
+      // below is still in flight (CRT-397). Keyed by task id so it can never be
+      // replayed into a different task.
+      pendingSolution.current = { taskId: task.id, solution: solutionBlob };
 
       try {
         await createSolution(session.klass.id, session.id, task.id, {

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -263,8 +263,13 @@ const SolveTaskPage = () => {
         // Put the stash back (unless something newer arrived meanwhile) so the
         // next app load can still restore it — it may hold work that never
         // reached the backend. A stash for a different task is dropped instead.
+        // A failed replay does not mean the stashed copy is bad (the embedded
+        // app may still be initializing after a locale change), so we must NOT
+        // fall back to the pristine task in that case — it would visibly
+        // discard the stashed work; the next app load replays the stash.
         if (stashedSolution !== null) {
           pendingSolution.current ??= stashed;
+          return;
         }
 
         // if we cannot fetch the latest solution file we load the task from scratch

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -96,6 +96,12 @@ const SolveTaskPage = () => {
   const embeddedApp = useRef<EmbeddedAppRef | null>(null);
   const wasInitialized = useRef(false);
   const isScratchMutexAvailable = useRef(true);
+  // The freshest solution the embedded app has pushed up (e.g. the auto-save
+  // triggered right before a language change reloads the iframe). The parent
+  // frame is not reloaded, so this ref survives; we replay it after the reload
+  // instead of racing the still-in-flight backend write with a stale fetch,
+  // which otherwise loses the student's unsaved changes (CRT-397).
+  const pendingSolution = useRef<Blob | null>(null);
 
   const toggleSessionMenu = useCallback(() => {
     setShowSessionMenu((show) => !show);
@@ -207,11 +213,19 @@ const SolveTaskPage = () => {
       wasInitialized.current = true;
 
       try {
-        const solutionFile = await fetchLatestSolutionFile(
-          session.klass.id,
-          session.id,
-          task.id,
-        );
+        // Prefer a solution stashed just before a reload (it includes changes
+        // that may not have reached the backend yet); otherwise load the latest
+        // persisted solution.
+        const stashedSolution = pendingSolution.current;
+        pendingSolution.current = null;
+
+        const solutionFile =
+          stashedSolution ??
+          (await fetchLatestSolutionFile(
+            session.klass.id,
+            session.id,
+            task.id,
+          ));
 
         isScratchMutexAvailable.current = false;
 
@@ -244,6 +258,10 @@ const SolveTaskPage = () => {
         console.error("No session or task available");
         return;
       }
+
+      // Stash synchronously so a reload can replay it even if the backend write
+      // below is still in flight (CRT-397).
+      pendingSolution.current = solutionBlob;
 
       try {
         await createSolution(session.klass.id, session.id, task.id, {


### PR DESCRIPTION
## Problem (CRT-397)

In the student Jupyter interface, making unsaved changes and then **changing the UI language** (a) loses the unsaved work and (b) throws *"could not find content with path student/task.ipynb"* when the student clicks the task in the file tree. [Jam](https://jam.dev/c/7eb26ff7-8396-4758-bfa8-315b24b5f2c4).

## Root cause

Changing the language reloads the iframe (JupyterLab applies locale bundles only at load). JupyterLite contents are **memory-backed**, so the reload wipes the workspace. Two independent defects surface:

**1. The content-not-found error.** In solve mode the visible root `task.ipynb` is the student's *handle* to their task: `redirectTaskFileOpensToStudentVersion` transparently redirects a click on it to `/student/task.ipynb`. After the reload wipes memory, `/student/task.ipynb` hasn't been re-written yet (the frontend re-sends it asynchronously), so the redirect opens a path that doesn't exist → the error.

**2. Lost unsaved changes.** The pre-reload auto-save pushes the current solution up (`postTaskSolution`), but `EmbeddedApp`'s handler doesn't await the backend write, so the iframe navigates while the POST is in flight. After the reload, `onAppAvailable`'s `fetchLatestSolutionFile` races that POST and reads the **stale** solution.

## Fix

- **`user-interface.ts`** — **guard** the student-task redirect: open `/student/task.ipynb` only once it exists (an async `contents.get` check); otherwise do nothing (the task auto-opens as soon as the content is restored). `task.ipynb` stays visible — it's the student's own entry point — and the template is never opened.
- **`solve.tsx`** — stash the solution the embedded app pushes (`onReceiveTaskSolution`) in a `useRef`. The parent frame isn't reloaded, so the ref survives; `onAppAvailable` **replays the stashed solution** after the reload instead of re-fetching, so the freshest edits survive.

No change to the reload mechanism, so this is independent of CRT-363's `mode`→`crtMode` rename.

## Verification

Frontend + extension `tsc --noEmit` and `eslint` clean. **In-app smoke test recommended** on a rebuilt JupyterLite: as a student, edit → change language → confirm edits survive, no content error, and `task.ipynb` still opens the student copy.