### PR TITLE
Exclude all git submodules from Sonar analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -14,4 +14,8 @@ sonar.cpd.exclusions=**/__tests__/**/*,**/*.spec.ts,**/*.spec.tsx,**/e2e/tests/*
 # Certain files are fully excluded from the analysis. This includes
 # - all generated files
 # - all coverage files
-sonar.exclusions=**/generated/**/*,**/backend/src/ast/antlr-grammars/**/*,./backend/coverage/**/*,./backend/coverage-nest-e2e/**/*,./backend/coverage-e2e/**/*,./frontend/coverage/**/*,./frontend/coverage-pw/**/*,./frontend/coverage-ct/**/*,./frontend/coverage-storybook/**/*,./apps/scratch/coverage/**/*
+# - all git submodules (external dependencies, not our source code).
+#   Keep this list in sync with the `path` entries in .gitmodules:
+#   frontend/storybook-submodule, apps/jupyter/otter-grader,
+#   backend/src/ast/antlr-grammars, apps/scratch/src/scratch-editor
+sonar.exclusions=**/generated/**/*,**/frontend/storybook-submodule/**/*,**/apps/jupyter/otter-grader/**/*,**/backend/src/ast/antlr-grammars/**/*,**/apps/scratch/src/scratch-editor/**/*,./backend/coverage/**/*,./backend/coverage-nest-e2e/**/*,./backend/coverage-e2e/**/*,./frontend/coverage/**/*,./frontend/coverage-pw/**/*,./frontend/coverage-ct/**/*,./frontend/coverage-storybook/**/*,./apps/scratch/coverage/**/*


### PR DESCRIPTION
## Problem

Sonar analyzes vendored dependency code pulled in as git submodules — most notably the Scratch editor (`apps/scratch/src/scratch-editor`), plus `apps/jupyter/otter-grader` and `frontend/storybook-submodule`. The reported issues there are impractical to fix and outside the scope of our actual source code. Only the antlr grammars submodule (`backend/src/ast/antlr-grammars`) was excluded so far.

## Change

Add all four `.gitmodules` paths to `sonar.exclusions` in `sonar-project.properties`, so submodules are completely excluded from analysis — issues, coverage, and duplication alike. A comment keeps the list in sync with `.gitmodules`.

## Verification

- The CI sonar job passes no scanner `args`, so `sonar-project.properties` is authoritative.
- Exclusion patterns follow the existing convention (`**/<path>/**/*`), matching the style of the already-working antlr-grammars exclusion.
- Once this runs on SonarCloud, the analyzed-files count should drop accordingly; findings inside submodule paths should disappear from new analyses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude all git submodules from Sonar analysis to stop noise from vendored code and keep metrics focused on our source.

- **Bug Fixes**
  - Added `frontend/storybook-submodule`, `apps/jupyter/otter-grader`, `backend/src/ast/antlr-grammars`, and `apps/scratch/src/scratch-editor` to `sonar.exclusions` in `sonar-project.properties`.
  - Submodules are now excluded from issues, coverage, and duplication; comment notes to keep exclusions synced with `.gitmodules`.

<sup>Written for commit 0d78ee08f6c6691bdb3e9caa507464a53ba1ebc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

