### PR TITLE
[CRT-439] Logged-in class students shouldn't be displayed in anonymous lessons

### DIFF
--- a/frontend/src/hooks/useStudentProgress.ts
+++ b/frontend/src/hooks/useStudentProgress.ts
@@ -14,11 +14,28 @@ export type ResolvedStudent = ClassStudent | AnonymousStudent;
 
 export const useStudentProgress = (
   klass: ExistingClassExtended | undefined,
+  session: ExistingSessionExtended | undefined,
   activeStudentIds: number[],
 ): ResolvedStudent[] =>
   useMemo(() => {
-    if (!klass) {
+    if (!klass || !session) {
       return [];
+    }
+
+    // In an anonymous lesson students participate with ad-hoc anonymous
+    // identities, so the class roster is not part of the lesson: seeding the
+    // list with it would show the real class members (with their tasks
+    // eternally "not started") next to the anonymous participants, and
+    // resolving ids against the roster would reveal identities. Every
+    // participant is shown with an ad-hoc identity instead, even if they
+    // happen to also be a registered class member (CRT-439).
+    if (session.isAnonymous) {
+      return [...new Set(activeStudentIds)].map<ResolvedStudent>(
+        (studentId) => ({
+          isAnonymous: true,
+          studentId,
+        }),
+      );
     }
 
     const studentsById = new Map(
@@ -37,7 +54,7 @@ export const useStudentProgress = (
           studentId,
         } satisfies AnonymousStudent),
     );
-  }, [klass, activeStudentIds]);
+  }, [klass, session, activeStudentIds]);
 
 export const useSessionStudents = (
   classId: number,
@@ -62,7 +79,7 @@ export const useSessionStudents = (
     isLoading: isLoadingSession,
   } = useClassSession(classId, sessionId);
 
-  const students = useStudentProgress(klass, activeStudentIds);
+  const students = useStudentProgress(klass, session, activeStudentIds);
 
   return {
     klass,


### PR DESCRIPTION
> **Note:** rebased on top of #605 (CRT-434 progress-list refactoring) and targeting its branch — this PR now shows only the CRT-439 delta. Re-target to `main` once #605 merges.

## Problem (CRT-439)

In an anonymous lesson, the teacher saw the real class members listed on the progress pages alongside the ad-hoc anonymous participants — with the class members' tasks eternally "not started", since they never actually join an anonymous lesson. This also made the missing "anonymize names" dial moot: the identities it would hide were displayed unconditionally.

## Root cause

The student list was seeded with the **full class roster** regardless of session type. In an anonymous session the roster members are not participants — students join with ad-hoc anonymous identities.

## Fix

Thanks to the CRT-434 refactoring, the roster-merging now lives in one place — so the fix is a single change to `useStudentProgress`: for `session.isAnonymous`, skip the roster entirely and derive the student list solely from actual session activity, displaying every participant with an ad-hoc identity (generated nickname) even if they happen to also be a registered class member. Both progress views inherit this via `useSessionStudents`; private lessons are unchanged.

## About the missing "anonymize names" dial

The dial is intentionally hidden on anonymous lessons (`showAnonymizationToggle={session?.isAnonymous === false}`). With the roster no longer displayed there are **no real identities left** on these pages — anonymous participants have no pseudonym, so `StudentName` always renders a generated nickname regardless of the toggle. The dial therefore stays hidden as there is nothing for it to do.

## Verification

- tsc + eslint clean; `useStudentProgress` has no other callers.
- Non-anonymous path: identical behavior to #605's refactored code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)