### PR TITLE
[CRT-442] Scope student writes to the sessions they take part in

### DIFF
--- a/backend/src/api/authorization/authorization.service.spec.ts
+++ b/backend/src/api/authorization/authorization.service.spec.ts
@@ -39,11 +39,11 @@ describe("AuthorizationService", () => {
         service.canCreateStudentSolution(null, classId, sessionId, taskId),
       ).resolves.toBe(false);
 
-      expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
+      expect(prismaMock.sessionTask.findMany).not.toHaveBeenCalled();
     });
 
     it("denies a student that does not take part in the target session", async () => {
-      prismaMock.sessionTask.findUnique.mockResolvedValue(null);
+      prismaMock.sessionTask.findMany.mockResolvedValue([]);
 
       await expect(
         service.canCreateStudentSolution(student, classId, sessionId, taskId),
@@ -51,7 +51,9 @@ describe("AuthorizationService", () => {
     });
 
     it("allows a student that takes part in the target session", async () => {
-      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+      prismaMock.sessionTask.findMany.mockResolvedValue([
+        { sessionId, taskId },
+      ] as never);
 
       await expect(
         service.canCreateStudentSolution(student, classId, sessionId, taskId),
@@ -59,7 +61,9 @@ describe("AuthorizationService", () => {
     });
 
     it("scopes the query to the class, session and task and requires participation", async () => {
-      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+      prismaMock.sessionTask.findMany.mockResolvedValue([
+        { sessionId, taskId },
+      ] as never);
 
       await service.canCreateStudentSolution(
         student,
@@ -68,10 +72,10 @@ describe("AuthorizationService", () => {
         taskId,
       );
 
-      expect(prismaMock.sessionTask.findUnique).toHaveBeenCalledWith({
-        select: { taskId: true },
+      expect(prismaMock.sessionTask.findMany).toHaveBeenCalledWith({
+        select: { sessionId: true, taskId: true },
         where: {
-          sessionId_taskId: { sessionId, taskId },
+          OR: [{ sessionId, taskId }],
           deletedAt: null,
           session: {
             classId,
@@ -105,7 +109,6 @@ describe("AuthorizationService", () => {
       ).resolves.toBe(false);
 
       expect(prismaMock.sessionTask.findMany).not.toHaveBeenCalled();
-      expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
     });
 
     it("allows an empty batch without querying the database", async () => {
@@ -114,7 +117,6 @@ describe("AuthorizationService", () => {
       ).resolves.toBe(true);
 
       expect(prismaMock.sessionTask.findMany).not.toHaveBeenCalled();
-      expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
     });
 
     it("denies the whole batch if a single activity is out of scope", async () => {

--- a/backend/src/api/authorization/authorization.service.spec.ts
+++ b/backend/src/api/authorization/authorization.service.spec.ts
@@ -68,33 +68,33 @@ describe("AuthorizationService", () => {
         taskId,
       );
 
-      expect(prismaMock.sessionTask.findUnique).toHaveBeenCalledWith(
-        expect.objectContaining({
-          where: expect.objectContaining({
-            sessionId_taskId: { sessionId, taskId },
+      expect(prismaMock.sessionTask.findUnique).toHaveBeenCalledWith({
+        select: { taskId: true },
+        where: {
+          sessionId_taskId: { sessionId, taskId },
+          deletedAt: null,
+          session: {
+            classId,
             deletedAt: null,
-            session: expect.objectContaining({
-              classId,
-              deletedAt: null,
-              OR: [
-                {
-                  anonymousStudents: {
+            class: { deletedAt: null },
+            OR: [
+              {
+                anonymousStudents: {
+                  some: { studentId: student.id, deletedAt: null },
+                },
+              },
+              {
+                class: {
+                  deletedAt: null,
+                  students: {
                     some: { studentId: student.id, deletedAt: null },
                   },
                 },
-                {
-                  class: {
-                    deletedAt: null,
-                    students: {
-                      some: { studentId: student.id, deletedAt: null },
-                    },
-                  },
-                },
-              ],
-            }),
-          }),
-        }),
-      );
+              },
+            ],
+          },
+        },
+      });
     });
   });
 
@@ -104,13 +104,23 @@ describe("AuthorizationService", () => {
         service.canTrackStudentActivities(null, [{ sessionId, taskId }]),
       ).resolves.toBe(false);
 
+      expect(prismaMock.sessionTask.findMany).not.toHaveBeenCalled();
+      expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("allows an empty batch without querying the database", async () => {
+      await expect(
+        service.canTrackStudentActivities(student, []),
+      ).resolves.toBe(true);
+
+      expect(prismaMock.sessionTask.findMany).not.toHaveBeenCalled();
       expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
     });
 
     it("denies the whole batch if a single activity is out of scope", async () => {
-      prismaMock.sessionTask.findUnique
-        .mockResolvedValueOnce({ taskId } as never)
-        .mockResolvedValueOnce(null);
+      prismaMock.sessionTask.findMany.mockResolvedValue([
+        { sessionId, taskId },
+      ] as never);
 
       await expect(
         service.canTrackStudentActivities(student, [
@@ -120,8 +130,11 @@ describe("AuthorizationService", () => {
       ).resolves.toBe(false);
     });
 
-    it("checks every distinct session/task pair exactly once", async () => {
-      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+    it("checks all distinct session/task pairs in one query", async () => {
+      prismaMock.sessionTask.findMany.mockResolvedValue([
+        { sessionId, taskId },
+        { sessionId, taskId: taskId + 1 },
+      ] as never);
 
       await expect(
         service.canTrackStudentActivities(student, [
@@ -131,17 +144,49 @@ describe("AuthorizationService", () => {
         ]),
       ).resolves.toBe(true);
 
-      expect(prismaMock.sessionTask.findUnique).toHaveBeenCalledTimes(2);
+      expect(prismaMock.sessionTask.findMany).toHaveBeenCalledTimes(1);
+
+      const [[query]] = prismaMock.sessionTask.findMany.mock.calls;
+
+      expect(query?.where?.OR).toEqual([
+        { sessionId, taskId },
+        { sessionId, taskId: taskId + 1 },
+      ]);
     });
 
-    it("does not restrict the session to a class", async () => {
-      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+    it("requires active session tasks, sessions, classes and participation", async () => {
+      prismaMock.sessionTask.findMany.mockResolvedValue([
+        { sessionId, taskId },
+      ] as never);
 
       await service.canTrackStudentActivities(student, [{ sessionId, taskId }]);
 
-      const [[args]] = prismaMock.sessionTask.findUnique.mock.calls;
-
-      expect(args?.where.session).not.toHaveProperty("classId");
+      expect(prismaMock.sessionTask.findMany).toHaveBeenCalledWith({
+        select: { sessionId: true, taskId: true },
+        where: {
+          OR: [{ sessionId, taskId }],
+          deletedAt: null,
+          session: {
+            deletedAt: null,
+            class: { deletedAt: null },
+            OR: [
+              {
+                anonymousStudents: {
+                  some: { studentId: student.id, deletedAt: null },
+                },
+              },
+              {
+                class: {
+                  deletedAt: null,
+                  students: {
+                    some: { studentId: student.id, deletedAt: null },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      });
     });
   });
 });

--- a/backend/src/api/authorization/authorization.service.spec.ts
+++ b/backend/src/api/authorization/authorization.service.spec.ts
@@ -1,0 +1,147 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { PrismaClient, Student } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { AuthorizationService } from "./authorization.service";
+
+describe("AuthorizationService", () => {
+  let service: AuthorizationService;
+  let prismaMock: DeepMockProxy<PrismaClient>;
+  let module: TestingModule;
+
+  const student: Student = { id: 8, deletedAt: null };
+
+  const classId = 1;
+  const sessionId = 2;
+  const taskId = 3;
+
+  beforeEach(async () => {
+    prismaMock = mockDeep<PrismaClient>();
+
+    module = await Test.createTestingModule({
+      providers: [
+        AuthorizationService,
+        {
+          provide: PrismaService,
+          useValue: prismaMock,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthorizationService>(AuthorizationService);
+  });
+
+  afterEach(() => module.close());
+
+  describe("canCreateStudentSolution", () => {
+    it("denies unauthenticated requests without querying the database", async () => {
+      await expect(
+        service.canCreateStudentSolution(null, classId, sessionId, taskId),
+      ).resolves.toBe(false);
+
+      expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("denies a student that does not take part in the target session", async () => {
+      prismaMock.sessionTask.findUnique.mockResolvedValue(null);
+
+      await expect(
+        service.canCreateStudentSolution(student, classId, sessionId, taskId),
+      ).resolves.toBe(false);
+    });
+
+    it("allows a student that takes part in the target session", async () => {
+      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+
+      await expect(
+        service.canCreateStudentSolution(student, classId, sessionId, taskId),
+      ).resolves.toBe(true);
+    });
+
+    it("scopes the query to the class, session and task and requires participation", async () => {
+      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+
+      await service.canCreateStudentSolution(
+        student,
+        classId,
+        sessionId,
+        taskId,
+      );
+
+      expect(prismaMock.sessionTask.findUnique).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            sessionId_taskId: { sessionId, taskId },
+            deletedAt: null,
+            session: expect.objectContaining({
+              classId,
+              deletedAt: null,
+              OR: [
+                {
+                  anonymousStudents: {
+                    some: { studentId: student.id, deletedAt: null },
+                  },
+                },
+                {
+                  class: {
+                    deletedAt: null,
+                    students: {
+                      some: { studentId: student.id, deletedAt: null },
+                    },
+                  },
+                },
+              ],
+            }),
+          }),
+        }),
+      );
+    });
+  });
+
+  describe("canTrackStudentActivities", () => {
+    it("denies unauthenticated requests without querying the database", async () => {
+      await expect(
+        service.canTrackStudentActivities(null, [{ sessionId, taskId }]),
+      ).resolves.toBe(false);
+
+      expect(prismaMock.sessionTask.findUnique).not.toHaveBeenCalled();
+    });
+
+    it("denies the whole batch if a single activity is out of scope", async () => {
+      prismaMock.sessionTask.findUnique
+        .mockResolvedValueOnce({ taskId } as never)
+        .mockResolvedValueOnce(null);
+
+      await expect(
+        service.canTrackStudentActivities(student, [
+          { sessionId, taskId },
+          { sessionId: 99, taskId: 99 },
+        ]),
+      ).resolves.toBe(false);
+    });
+
+    it("checks every distinct session/task pair exactly once", async () => {
+      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+
+      await expect(
+        service.canTrackStudentActivities(student, [
+          { sessionId, taskId },
+          { sessionId, taskId },
+          { sessionId, taskId: taskId + 1 },
+        ]),
+      ).resolves.toBe(true);
+
+      expect(prismaMock.sessionTask.findUnique).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not restrict the session to a class", async () => {
+      prismaMock.sessionTask.findUnique.mockResolvedValue({ taskId } as never);
+
+      await service.canTrackStudentActivities(student, [{ sessionId, taskId }]);
+
+      const [[args]] = prismaMock.sessionTask.findUnique.mock.calls;
+
+      expect(args?.where.session).not.toHaveProperty("classId");
+    });
+  });
+});

--- a/backend/src/api/authorization/authorization.service.ts
+++ b/backend/src/api/authorization/authorization.service.ts
@@ -310,6 +310,38 @@ export class AuthorizationService {
     return sessionTask !== null;
   }
 
+  protected async isStudentOfSessionTasks(
+    authenticatedStudent: Student,
+    sessionTasks: Array<{ sessionId: number; taskId: number }>,
+    classId?: number,
+  ): Promise<boolean> {
+    if (sessionTasks.length === 0) {
+      return true;
+    }
+
+    const uniquePairs = [
+      ...new Map(
+        sessionTasks.map((pair) => [`${pair.sessionId}/${pair.taskId}`, pair]),
+      ).values(),
+    ];
+
+    const authorizedPairs = await this.prisma.sessionTask.findMany({
+      select: { sessionId: true, taskId: true },
+      where: {
+        OR: uniquePairs,
+        deletedAt: null,
+        session: {
+          ...(classId === undefined ? {} : { classId }),
+          deletedAt: null,
+          class: { deletedAt: null },
+          ...this.participatesInSession(authenticatedStudent.id),
+        },
+      },
+    });
+
+    return authorizedPairs.length === uniquePairs.length;
+  }
+
   async canCreateStudentSolution(
     authenticatedStudent: Student | null,
     classId: number,
@@ -352,13 +384,12 @@ export class AuthorizationService {
       ]),
     );
 
-    const results = await Promise.all(
-      [...distinctSessionTasks.values()].map(({ sessionId, taskId }) =>
-        this.isStudentOfSessionTask(authenticatedStudent, sessionId, taskId),
-      ),
-    );
+    const sessionTasks = [...distinctSessionTasks.values()];
 
-    const canTrack = results.every((isAuthorized) => isAuthorized);
+    const canTrack = await this.isStudentOfSessionTasks(
+      authenticatedStudent,
+      sessionTasks,
+    );
 
     if (!canTrack) {
       this.logger.warn(

--- a/backend/src/api/authorization/authorization.service.ts
+++ b/backend/src/api/authorization/authorization.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from "@nestjs/common";
-import { Student, User, UserType } from "@prisma/client";
+import { Prisma, Student, User, UserType } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 import { StudentSolutionId } from "../solutions/dto/existing-student-solution.dto";
 
@@ -253,6 +253,120 @@ export class AuthorizationService {
       );
     }
     return canDelete;
+  }
+
+  /**
+   * A student takes part in a session if they either joined it anonymously or
+   * if they are an authenticated student of the class the session belongs to.
+   */
+  private participatesInSession(studentId: number): Prisma.SessionWhereInput {
+    return {
+      OR: [
+        {
+          anonymousStudents: {
+            some: { studentId, deletedAt: null },
+          },
+        },
+        {
+          class: {
+            deletedAt: null,
+            students: {
+              some: { studentId, deletedAt: null },
+            },
+          },
+        },
+      ],
+    };
+  }
+
+  /**
+   * Checks that the given task is part of the given session and that the
+   * student takes part in that session. When a classId is given, the session
+   * must also belong to that class.
+   */
+  protected async isStudentOfSessionTask(
+    authenticatedStudent: Student,
+    sessionId: number,
+    taskId: number,
+    classId?: number,
+  ): Promise<boolean> {
+    const sessionTask = await this.prisma.sessionTask.findUnique({
+      select: { taskId: true },
+      where: {
+        // the (non soft-deleted) SessionTask row is what makes a task part of a
+        // lesson - a soft-deleted *task* is deliberately not checked here, since
+        // students may legitimately still be working on it
+        sessionId_taskId: { sessionId, taskId },
+        deletedAt: null,
+        session: {
+          ...(classId === undefined ? {} : { classId }),
+          deletedAt: null,
+          class: { deletedAt: null },
+          ...this.participatesInSession(authenticatedStudent.id),
+        },
+      },
+    });
+
+    return sessionTask !== null;
+  }
+
+  async canCreateStudentSolution(
+    authenticatedStudent: Student | null,
+    classId: number,
+    sessionId: number,
+    taskId: number,
+  ): Promise<boolean> {
+    if (authenticatedStudent === null) {
+      return false;
+    }
+
+    const canCreate = await this.isStudentOfSessionTask(
+      authenticatedStudent,
+      sessionId,
+      taskId,
+      classId,
+    );
+
+    if (!canCreate) {
+      this.logger.warn(
+        `Authorization denied: student (id: ${authenticatedStudent.id}) cannot submit a solution for class (id: ${classId}), session (id: ${sessionId}), task (id: ${taskId})`,
+      );
+    }
+
+    return canCreate;
+  }
+
+  async canTrackStudentActivities(
+    authenticatedStudent: Student | null,
+    activities: { sessionId: number; taskId: number }[],
+  ): Promise<boolean> {
+    if (authenticatedStudent === null) {
+      return false;
+    }
+
+    // the same session/task pair is commonly tracked repeatedly - only check it once
+    const distinctSessionTasks = new Map(
+      activities.map(({ sessionId, taskId }) => [
+        `${sessionId}/${taskId}`,
+        { sessionId, taskId },
+      ]),
+    );
+
+    const results = await Promise.all(
+      [...distinctSessionTasks.values()].map(({ sessionId, taskId }) =>
+        this.isStudentOfSessionTask(authenticatedStudent, sessionId, taskId),
+      ),
+    );
+
+    const canTrack = results.every((isAuthorized) => isAuthorized);
+
+    if (!canTrack) {
+      this.logger.warn(
+        `Authorization denied: student (id: ${authenticatedStudent.id}) cannot track activities for the requested sessions/tasks`,
+      );
+    }
+
+    return canTrack;
   }
 
   async canListSolutions(

--- a/backend/src/api/authorization/authorization.service.ts
+++ b/backend/src/api/authorization/authorization.service.ts
@@ -280,36 +280,10 @@ export class AuthorizationService {
   }
 
   /**
-   * Checks that the given task is part of the given session and that the
-   * student takes part in that session. When a classId is given, the session
+   * Checks that every given task is part of its given session and that the
+   * student takes part in each session. When a classId is given, every session
    * must also belong to that class.
    */
-  protected async isStudentOfSessionTask(
-    authenticatedStudent: Student,
-    sessionId: number,
-    taskId: number,
-    classId?: number,
-  ): Promise<boolean> {
-    const sessionTask = await this.prisma.sessionTask.findUnique({
-      select: { taskId: true },
-      where: {
-        // the (non soft-deleted) SessionTask row is what makes a task part of a
-        // lesson - a soft-deleted *task* is deliberately not checked here, since
-        // students may legitimately still be working on it
-        sessionId_taskId: { sessionId, taskId },
-        deletedAt: null,
-        session: {
-          ...(classId === undefined ? {} : { classId }),
-          deletedAt: null,
-          class: { deletedAt: null },
-          ...this.participatesInSession(authenticatedStudent.id),
-        },
-      },
-    });
-
-    return sessionTask !== null;
-  }
-
   protected async isStudentOfSessionTasks(
     authenticatedStudent: Student,
     sessionTasks: Array<{ sessionId: number; taskId: number }>,
@@ -328,6 +302,9 @@ export class AuthorizationService {
     const authorizedPairs = await this.prisma.sessionTask.findMany({
       select: { sessionId: true, taskId: true },
       where: {
+        // the (non soft-deleted) SessionTask row is what makes a task part of a
+        // lesson - a soft-deleted *task* is deliberately not checked here, since
+        // students may legitimately still be working on it
         OR: uniquePairs,
         deletedAt: null,
         session: {
@@ -352,10 +329,9 @@ export class AuthorizationService {
       return false;
     }
 
-    const canCreate = await this.isStudentOfSessionTask(
+    const canCreate = await this.isStudentOfSessionTasks(
       authenticatedStudent,
-      sessionId,
-      taskId,
+      [{ sessionId, taskId }],
       classId,
     );
 

--- a/backend/src/api/solutions/solutions.controller.ts
+++ b/backend/src/api/solutions/solutions.controller.ts
@@ -78,12 +78,24 @@ export class SolutionsController {
   @UseInterceptors(FileInterceptor("file"), JsonToObjectsInterceptor(["tests"]))
   async createStudentSolution(
     @AuthenticatedStudent() student: Student,
-    @Param("classId", ParseIntPipe) _classId: ClassId,
+    @Param("classId", ParseIntPipe) classId: ClassId,
     @Param("sessionId", ParseIntPipe) sessionId: SessionId,
     @Param("taskId", ParseIntPipe) taskId: TaskId,
     @Body() createSolutionDto: CreateSolutionDto,
     @UploadedFile() file: Express.Multer.File,
   ): Promise<ExistingStudentSolutionDto> {
+    const isAuthorized =
+      await this.authorizationService.canCreateStudentSolution(
+        student,
+        classId,
+        sessionId,
+        taskId,
+      );
+
+    if (!isAuthorized) {
+      throw new ForbiddenException();
+    }
+
     const studentSolution = await this.solutionsService.createStudentSolution(
       {
         ...createSolutionDto,

--- a/backend/src/api/student-activity/student-activity.controller.ts
+++ b/backend/src/api/student-activity/student-activity.controller.ts
@@ -2,6 +2,7 @@ import {
   BadRequestException,
   Body,
   Controller,
+  ForbiddenException,
   HttpCode,
   Post,
   UploadedFiles,
@@ -65,6 +66,16 @@ export class StudentActivityController {
       throw new BadRequestException(
         `The number of solution files (${solutionFileCount || 0}) does not match the number of activities (${trackActivitiesDto.activities.length}).`,
       );
+    }
+
+    const isAuthorized =
+      await this.authorizationService.canTrackStudentActivities(
+        student,
+        trackActivitiesDto.activities,
+      );
+
+    if (!isAuthorized) {
+      throw new ForbiddenException();
     }
 
     await this.studentActivityService.createMany(


### PR DESCRIPTION
POST /classes/:classId/sessions/:sessionId/task/:taskId/solutions/student and POST /student-activity performed no authorization check at all. `@StudentOnly()` only proves that *some* student is authenticated; both handlers then took the session and task straight from the request (the URL for solutions, the body for activities) and the student from the token. The solutions route even discarded its classId parameter, so any student token could persist a solution into any lesson of any class - including a different teacher's - as long as the lesson contained the task. Every read path in these controllers calls authorizationService.canView...; these two write paths called nothing.

Add AuthorizationService.canCreateStudentSolution and canTrackStudentActivities, both built on isStudentOfSessionTask: the task must be part of the lesson (a live SessionTask row) and the student must take part in that lesson, either by having joined it anonymously or by being an authenticated student of the lesson's class. For solutions the lesson must additionally belong to the classId in the route, which is no longer discarded. Deny returns 403.

⚠️ The check deliberately ignores Task.deletedAt: the SessionTask row is what makes a task part of a lesson, and a student may legitimately still be working on a task that was soft-deleted after the lesson started.

❓ Desirable? It doesn't seem wrong to me.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes student write endpoints to only the sessions they participate in to fix CRT-442. Submitting solutions or tracking activities outside the student’s session now returns 403.

- **Bug Fixes**
  - Added `AuthorizationService.canCreateStudentSolution` and `canTrackStudentActivities`, built on a shared `isStudentOfSessionTasks` helper; participation via anonymous join or class membership; ignores `Task.deletedAt`.
  - `POST /classes/:classId/sessions/:sessionId/task/:taskId/solutions/student` now enforces `classId`/`sessionId`/`taskId` and class scoping; returns 403 if not allowed.
  - `POST /student-activity` batch-validates distinct session/task pairs in one query; rejects the whole batch if any pair is out of scope; allows empty batches without DB calls. Activities are not scoped to a class; solutions are.
  - Strengthened tests to cover single-query lookups, duplicate-pair de-duplication, soft-delete filters, and unauthenticated short-circuit.

<sup>Written for commit 5e493549002d843beb7ff605e1368a3311261b37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



