### PR TITLE
[CRT-443] Do not let students read a task's reference solutions

### DIFF
--- a/backend/src/api/tasks/reference-solutions-authorization.spec.ts
+++ b/backend/src/api/tasks/reference-solutions-authorization.spec.ts
@@ -55,6 +55,18 @@ describe("TasksController reference-solutions authorization", () => {
     TasksController.prototype.findOneWithReferenceSolutions;
   const taskHandler = TasksController.prototype.findOne;
 
+  it("scopes reference solutions to exactly teachers and admins", () => {
+    const allowedRoles = reflector.get<Role[]>(
+      ALLOWED_ROLES,
+      referenceSolutionsHandler,
+    );
+
+    expect(allowedRoles).toHaveLength(2);
+    expect(allowedRoles).toEqual(
+      expect.arrayContaining([UserType.ADMIN, UserType.TEACHER]),
+    );
+  });
+
   it("denies a student reading a task's reference solutions", async () => {
     const guard = buildGuard(student, true);
 

--- a/backend/src/api/tasks/reference-solutions-authorization.spec.ts
+++ b/backend/src/api/tasks/reference-solutions-authorization.spec.ts
@@ -1,0 +1,91 @@
+import { ExecutionContext, ForbiddenException } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { Student, User, UserType } from "@prisma/client";
+import { RoleGuard } from "../authentication/role.guard";
+import { AuthenticationService } from "../authentication/authentication.service";
+import { TasksController } from "./tasks.controller";
+
+// The reference-solutions endpoint returns each reference solution's file and
+// tests - the task's answer key - so it must be teacher/admin only. Enforcement
+// is entirely the @Roles decorator read by the global RoleGuard, so this
+// exercises the guard against the real controller metadata: a student is denied
+// on GET :id/with-reference-solutions but still allowed on the plain GET :id
+// they legitimately use.
+describe("TasksController reference-solutions authorization", () => {
+  const buildGuard = (
+    principal: User | Student,
+    isStudent: boolean,
+  ): RoleGuard => {
+    const authenticationService = {
+      findUserByAuthTokenOrThrow: jest.fn().mockResolvedValue(principal),
+      isStudent: jest.fn().mockReturnValue(isStudent),
+    } as unknown as AuthenticationService;
+
+    // a real Reflector so the guard reads the actual @Roles metadata off the
+    // controller handlers below
+    return new RoleGuard(authenticationService, new Reflector());
+  };
+
+  const contextForHandler = (
+    handler: (...args: unknown[]) => unknown,
+  ): ExecutionContext => {
+    const request: Record<string, unknown> = {
+      headers: { authorization: "Bearer test-token" },
+      query: {},
+    };
+
+    return {
+      getType: () => "http",
+      getHandler: () => handler,
+      getClass: () => TasksController,
+      switchToHttp: () => ({
+        getRequest: () => request,
+        getResponse: () => ({}),
+        getNext: () => ({}),
+      }),
+    } as unknown as ExecutionContext;
+  };
+
+  // isStudent() checks for an "authenticatedStudent"/"anonymousStudent" property
+  const student = { id: 1, authenticatedStudent: {} } as unknown as Student;
+  const teacher = { id: 2, type: UserType.TEACHER } as unknown as User;
+  const admin = { id: 3, type: UserType.ADMIN } as unknown as User;
+
+  const referenceSolutionsHandler =
+    TasksController.prototype.findOneWithReferenceSolutions;
+  const taskHandler = TasksController.prototype.findOne;
+
+  it("denies a student reading a task's reference solutions", async () => {
+    const guard = buildGuard(student, true);
+
+    await expect(
+      guard.canActivate(contextForHandler(referenceSolutionsHandler)),
+    ).rejects.toThrow(ForbiddenException);
+  });
+
+  // positive control: the fix must scope the restriction to reference solutions
+  // and must not lock students out of the task itself
+  it("still allows a student to read the plain task", async () => {
+    const guard = buildGuard(student, true);
+
+    await expect(
+      guard.canActivate(contextForHandler(taskHandler)),
+    ).resolves.toBe(true);
+  });
+
+  it("allows a teacher to read reference solutions", async () => {
+    const guard = buildGuard(teacher, false);
+
+    await expect(
+      guard.canActivate(contextForHandler(referenceSolutionsHandler)),
+    ).resolves.toBe(true);
+  });
+
+  it("allows an admin to read reference solutions", async () => {
+    const guard = buildGuard(admin, false);
+
+    await expect(
+      guard.canActivate(contextForHandler(referenceSolutionsHandler)),
+    ).resolves.toBe(true);
+  });
+});

--- a/backend/src/api/tasks/reference-solutions-authorization.spec.ts
+++ b/backend/src/api/tasks/reference-solutions-authorization.spec.ts
@@ -3,6 +3,7 @@ import { Reflector } from "@nestjs/core";
 import { Student, User, UserType } from "@prisma/client";
 import { RoleGuard } from "../authentication/role.guard";
 import { AuthenticationService } from "../authentication/authentication.service";
+import { ALLOWED_ROLES, Role } from "../authentication/role.decorator";
 import { TasksController } from "./tasks.controller";
 
 // The reference-solutions endpoint returns each reference solution's file and
@@ -12,22 +13,27 @@ import { TasksController } from "./tasks.controller";
 // on GET :id/with-reference-solutions but still allowed on the plain GET :id
 // they legitimately use.
 describe("TasksController reference-solutions authorization", () => {
-  const buildGuard = (
-    principal: User | Student,
-    isStudent: boolean,
-  ): RoleGuard => {
+  const reflector = new Reflector();
+
+  const buildGuard = (principal: User | Student): RoleGuard => {
     const authenticationService = {
       findUserByAuthTokenOrThrow: jest.fn().mockResolvedValue(principal),
-      isStudent: jest.fn().mockReturnValue(isStudent),
+      isStudent: jest
+        .fn()
+        .mockImplementation(
+          (authenticatedPrincipal: User | Student) =>
+            "authenticatedStudent" in authenticatedPrincipal ||
+            "anonymousStudent" in authenticatedPrincipal,
+        ),
     } as unknown as AuthenticationService;
 
     // a real Reflector so the guard reads the actual @Roles metadata off the
     // controller handlers below
-    return new RoleGuard(authenticationService, new Reflector());
+    return new RoleGuard(authenticationService, reflector);
   };
 
   const contextForHandler = (
-    handler: (...args: unknown[]) => unknown,
+    handler: (...args: never[]) => unknown,
   ): ExecutionContext => {
     const request: Record<string, unknown> = {
       headers: { authorization: "Bearer test-token" },
@@ -68,7 +74,7 @@ describe("TasksController reference-solutions authorization", () => {
   });
 
   it("denies a student reading a task's reference solutions", async () => {
-    const guard = buildGuard(student, true);
+    const guard = buildGuard(student);
 
     await expect(
       guard.canActivate(contextForHandler(referenceSolutionsHandler)),
@@ -78,7 +84,7 @@ describe("TasksController reference-solutions authorization", () => {
   // positive control: the fix must scope the restriction to reference solutions
   // and must not lock students out of the task itself
   it("still allows a student to read the plain task", async () => {
-    const guard = buildGuard(student, true);
+    const guard = buildGuard(student);
 
     await expect(
       guard.canActivate(contextForHandler(taskHandler)),
@@ -86,7 +92,7 @@ describe("TasksController reference-solutions authorization", () => {
   });
 
   it("allows a teacher to read reference solutions", async () => {
-    const guard = buildGuard(teacher, false);
+    const guard = buildGuard(teacher);
 
     await expect(
       guard.canActivate(contextForHandler(referenceSolutionsHandler)),
@@ -94,7 +100,7 @@ describe("TasksController reference-solutions authorization", () => {
   });
 
   it("allows an admin to read reference solutions", async () => {
-    const guard = buildGuard(admin, false);
+    const guard = buildGuard(admin);
 
     await expect(
       guard.canActivate(contextForHandler(referenceSolutionsHandler)),

--- a/backend/src/api/tasks/tasks.controller.ts
+++ b/backend/src/api/tasks/tasks.controller.ts
@@ -185,7 +185,11 @@ export class TasksController {
   }
 
   @Get(":id/with-reference-solutions")
-  @Roles([UserType.ADMIN, UserType.TEACHER, NonUserRoles.STUDENT])
+  // Students must never read reference solutions: the response embeds each
+  // reference solution's file (base64) and its tests, i.e. the task's answers.
+  // Only the teacher-facing task detail and reference solution pages use this
+  // endpoint; the student flow reads the task through `:id` and `:id/download`.
+  @Roles([UserType.ADMIN, UserType.TEACHER])
   @ApiOkResponse({ type: ExistingTaskWithReferenceSolutionsDto })
   @ApiQuery({
     name: "includeSoftDelete",


### PR DESCRIPTION
GET /tasks/:id/with-reference-solutions returned each reference solution's file (base64) and its tests - the task's answer key - to anyone allowed on the endpoint, and the endpoint allowed STUDENT. Any authenticated student could read the answers to any task by id.

Remove STUDENT from the endpoint's @Roles. Only the teacher-facing task detail and reference-solution pages use it; the student flow reads the task through :id and :id/download, which are unaffected.

Enforcement is the @Roles decorator read by the global RoleGuard, so the test drives the guard against the real controller metadata: a student is denied on :id/with-reference-solutions (ForbiddenException) while still allowed on the plain :id, and teacher/admin remain allowed. Confirmed the deny case fails without this change (the student resolves instead of being rejected) and passes with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block students from reading reference solutions by restricting `GET /tasks/:id/with-reference-solutions` to `ADMIN` and `TEACHER` only. Addresses CRT-443.

- **Bug Fixes**
  - Scopes allowed roles exactly to `[ADMIN, TEACHER]`; removes `STUDENT`. Student `GET /tasks/:id` and `:id/download` remain allowed.
  - Adds authorization tests using real controller metadata and production-like `isStudent`; students are forbidden, teachers/admins allowed.

<sup>Written for commit c6935c4b7703327adcfb3470415f312706218b94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

