### PR TITLE
[CRT-444] Reject lesson updates that lock out students

### DIFF
--- a/backend/src/api/sessions/session-update-with-students.spec.ts
+++ b/backend/src/api/sessions/session-update-with-students.spec.ts
@@ -1,0 +1,147 @@
+import { ConflictException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { SessionsService } from "./sessions.service";
+
+// Once students have joined a lesson, removing its tasks or changing its
+// sharing type takes the lesson away from them (nothing left to solve, or an
+// anonymous lesson that stops admitting anonymous students). SessionsService
+// .update must reject both while still allowing harmless edits. The rule lives
+// in the interactive transaction, so these drive update() with a mocked Prisma:
+// $transaction runs the callback against a mock tx, session.findFirst stands in
+// for "does the lesson have students", and session.findUniqueOrThrow for the
+// lesson's current tasks and sharing type.
+describe("SessionsService.update — students already joined", () => {
+  const sessionId = 1;
+
+  const buildService = (opts: {
+    existingTaskIds: number[];
+    existingIsAnonymous: boolean;
+    hasStudents: boolean;
+  }): { service: SessionsService; tx: MockTx } => {
+    const tx = {
+      session: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          isAnonymous: opts.existingIsAnonymous,
+          tasks: opts.existingTaskIds.map((taskId) => ({ taskId })),
+        }),
+        // hasStudentsTx() resolves to a row iff the lesson has students
+        findFirst: jest
+          .fn()
+          .mockResolvedValue(opts.hasStudents ? { id: sessionId } : null),
+        update: jest
+          .fn()
+          .mockResolvedValue({ id: sessionId, tasks: [], lesson: null }),
+      },
+      sessionTask: {
+        deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+        upsert: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    const prisma = {
+      $transaction: jest.fn((callback: (client: MockTx) => Promise<unknown>) =>
+        callback(tx),
+      ),
+    } as unknown as PrismaService;
+
+    return { service: new SessionsService(prisma), tx };
+  };
+
+  const update = (
+    service: SessionsService,
+    session: Prisma.SessionUpdateInput,
+    taskIds: number[],
+  ): Promise<unknown> => service.update(sessionId, session, taskIds, 1);
+
+  describe("with students in the lesson", () => {
+    it("rejects removing a task", async () => {
+      const { service, tx } = buildService({
+        existingTaskIds: [10, 20],
+        existingIsAnonymous: true,
+        hasStudents: true,
+      });
+
+      // drop task 20
+      await expect(
+        update(service, { isAnonymous: true }, [10]),
+      ).rejects.toThrow(ConflictException);
+
+      // the update must be refused, not partially applied
+      expect(tx.session.update).not.toHaveBeenCalled();
+      expect(tx.sessionTask.deleteMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects making the lesson non-anonymous", async () => {
+      const { service, tx } = buildService({
+        existingTaskIds: [10, 20],
+        existingIsAnonymous: true,
+        hasStudents: true,
+      });
+
+      await expect(
+        update(service, { isAnonymous: false }, [10, 20]),
+      ).rejects.toThrow(ConflictException);
+
+      expect(tx.session.update).not.toHaveBeenCalled();
+    });
+
+    // positive controls: a fix that refused every update of a lesson with
+    // students would satisfy the rejections above without being correct
+    it("allows renaming without touching tasks or sharing type", async () => {
+      const { service, tx } = buildService({
+        existingTaskIds: [10, 20],
+        existingIsAnonymous: true,
+        hasStudents: true,
+      });
+
+      await expect(
+        update(service, { title: "renamed", isAnonymous: true }, [10, 20]),
+      ).resolves.toBeDefined();
+
+      expect(tx.session.update).toHaveBeenCalledTimes(1);
+    });
+
+    it("allows adding a task", async () => {
+      const { service, tx } = buildService({
+        existingTaskIds: [10, 20],
+        existingIsAnonymous: true,
+        hasStudents: true,
+      });
+
+      await expect(
+        update(service, { isAnonymous: true }, [10, 20, 30]),
+      ).resolves.toBeDefined();
+
+      expect(tx.session.update).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("with no students in the lesson", () => {
+    it("allows removing a task and changing the sharing type", async () => {
+      const { service, tx } = buildService({
+        existingTaskIds: [10, 20],
+        existingIsAnonymous: true,
+        hasStudents: false,
+      });
+
+      await expect(
+        update(service, { isAnonymous: false }, [10]),
+      ).resolves.toBeDefined();
+
+      expect(tx.session.update).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+type MockTx = {
+  session: {
+    findUniqueOrThrow: jest.Mock;
+    findFirst: jest.Mock;
+    update: jest.Mock;
+  };
+  sessionTask: {
+    deleteMany: jest.Mock;
+    upsert: jest.Mock;
+  };
+};

--- a/backend/src/api/sessions/session-update-with-students.spec.ts
+++ b/backend/src/api/sessions/session-update-with-students.spec.ts
@@ -13,6 +13,16 @@ import { SessionsService } from "./sessions.service";
 // lesson's current tasks and sharing type.
 describe("SessionsService.update — students already joined", () => {
   const sessionId = 1;
+  const classId = 1;
+  const updatedSession = { id: sessionId, tasks: [], lesson: null };
+  const compactInclude = {
+    tasks: {
+      where: { deletedAt: null },
+      orderBy: { index: "asc" },
+      select: { taskId: true, index: true },
+    },
+    lesson: { select: { id: true, title: true } },
+  };
 
   const buildService = (opts: {
     existingTaskIds: number[];
@@ -29,9 +39,7 @@ describe("SessionsService.update — students already joined", () => {
         findFirst: jest
           .fn()
           .mockResolvedValue(opts.hasStudents ? { id: sessionId } : null),
-        update: jest
-          .fn()
-          .mockResolvedValue({ id: sessionId, tasks: [], lesson: null }),
+        update: jest.fn().mockResolvedValue(updatedSession),
       },
       sessionTask: {
         deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
@@ -52,7 +60,7 @@ describe("SessionsService.update — students already joined", () => {
     service: SessionsService,
     session: Prisma.SessionUpdateInput,
     taskIds: number[],
-  ): Promise<unknown> => service.update(sessionId, session, taskIds, 1);
+  ): Promise<unknown> => service.update(sessionId, session, taskIds, classId);
 
   describe("with students in the lesson", () => {
     it("rejects removing a task", async () => {
@@ -65,11 +73,51 @@ describe("SessionsService.update — students already joined", () => {
       // drop task 20
       await expect(
         update(service, { isAnonymous: true }, [10]),
-      ).rejects.toThrow(ConflictException);
+      ).rejects.toThrow(
+        new ConflictException(
+          "Cannot remove tasks (ids: 20) from lesson (id: 1) because students already joined it",
+        ),
+      );
+
+      expect(tx.session.findUniqueOrThrow).toHaveBeenCalledWith({
+        where: {
+          classId,
+          id: sessionId,
+          deletedAt: null,
+          status: "CREATED",
+        },
+        include: {
+          tasks: {
+            where: { deletedAt: null },
+            select: { taskId: true },
+          },
+        },
+      });
+      expect(tx.session.findFirst).toHaveBeenCalledWith({
+        where: {
+          id: sessionId,
+          deletedAt: null,
+          OR: [
+            {
+              anonymousStudents: {
+                some: { deletedAt: null },
+              },
+            },
+            {
+              class: {
+                students: {
+                  some: { deletedAt: null },
+                },
+              },
+            },
+          ],
+        },
+      });
 
       // the update must be refused, not partially applied
       expect(tx.session.update).not.toHaveBeenCalled();
       expect(tx.sessionTask.deleteMany).not.toHaveBeenCalled();
+      expect(tx.sessionTask.upsert).not.toHaveBeenCalled();
     });
 
     it("rejects making the lesson non-anonymous", async () => {
@@ -81,9 +129,35 @@ describe("SessionsService.update — students already joined", () => {
 
       await expect(
         update(service, { isAnonymous: false }, [10, 20]),
-      ).rejects.toThrow(ConflictException);
+      ).rejects.toThrow(
+        new ConflictException(
+          "Cannot change the sharing type of lesson (id: 1) because students already joined it",
+        ),
+      );
 
       expect(tx.session.update).not.toHaveBeenCalled();
+      expect(tx.sessionTask.deleteMany).not.toHaveBeenCalled();
+      expect(tx.sessionTask.upsert).not.toHaveBeenCalled();
+    });
+
+    it("rejects making a non-anonymous lesson anonymous", async () => {
+      const { service, tx } = buildService({
+        existingTaskIds: [10, 20],
+        existingIsAnonymous: false,
+        hasStudents: true,
+      });
+
+      await expect(
+        update(service, { isAnonymous: true }, [10, 20]),
+      ).rejects.toThrow(
+        new ConflictException(
+          "Cannot change the sharing type of lesson (id: 1) because students already joined it",
+        ),
+      );
+
+      expect(tx.session.update).not.toHaveBeenCalled();
+      expect(tx.sessionTask.deleteMany).not.toHaveBeenCalled();
+      expect(tx.sessionTask.upsert).not.toHaveBeenCalled();
     });
 
     // positive controls: a fix that refused every update of a lesson with
@@ -97,9 +171,21 @@ describe("SessionsService.update — students already joined", () => {
 
       await expect(
         update(service, { title: "renamed", isAnonymous: true }, [10, 20]),
-      ).resolves.toBeDefined();
+      ).resolves.toEqual(updatedSession);
 
       expect(tx.session.update).toHaveBeenCalledTimes(1);
+      expect(tx.session.update).toHaveBeenCalledWith({
+        data: { title: "renamed", isAnonymous: true },
+        where: { classId, id: sessionId },
+        include: compactInclude,
+      });
+      expect(tx.sessionTask.deleteMany).toHaveBeenCalledWith({
+        where: {
+          taskId: { notIn: [10, 20] },
+          sessionId,
+        },
+      });
+      expect(tx.sessionTask.upsert).toHaveBeenCalledTimes(2);
     });
 
     it("allows adding a task", async () => {
@@ -111,9 +197,17 @@ describe("SessionsService.update — students already joined", () => {
 
       await expect(
         update(service, { isAnonymous: true }, [10, 20, 30]),
-      ).resolves.toBeDefined();
+      ).resolves.toEqual(updatedSession);
 
       expect(tx.session.update).toHaveBeenCalledTimes(1);
+      expect(tx.sessionTask.upsert).toHaveBeenCalledTimes(3);
+      expect(tx.sessionTask.upsert).toHaveBeenNthCalledWith(3, {
+        where: {
+          sessionId_taskId: { sessionId, taskId: 30 },
+        },
+        update: { index: 2, deletedAt: null },
+        create: { taskId: 30, index: 2, sessionId },
+      });
     });
   });
 
@@ -127,9 +221,28 @@ describe("SessionsService.update — students already joined", () => {
 
       await expect(
         update(service, { isAnonymous: false }, [10]),
-      ).resolves.toBeDefined();
+      ).resolves.toEqual(updatedSession);
 
       expect(tx.session.update).toHaveBeenCalledTimes(1);
+      expect(tx.session.update).toHaveBeenCalledWith({
+        data: { isAnonymous: false },
+        where: { classId, id: sessionId },
+        include: compactInclude,
+      });
+      expect(tx.sessionTask.deleteMany).toHaveBeenCalledWith({
+        where: {
+          taskId: { notIn: [10] },
+          sessionId,
+        },
+      });
+      expect(tx.sessionTask.upsert).toHaveBeenCalledTimes(1);
+      expect(tx.sessionTask.upsert).toHaveBeenCalledWith({
+        where: {
+          sessionId_taskId: { sessionId, taskId: 10 },
+        },
+        update: { index: 0, deletedAt: null },
+        create: { taskId: 10, index: 0, sessionId },
+      });
     });
   });
 });

--- a/backend/src/api/sessions/sessions.service.ts
+++ b/backend/src/api/sessions/sessions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { ConflictException, Injectable, Logger } from "@nestjs/common";
 import { Session, Prisma, SessionStatus } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 import { getCurrentStudentSolutions } from "@prisma/client/sql";
@@ -121,31 +121,50 @@ export class SessionsService {
     classId?: number,
     includeSoftDelete = false,
   ): Promise<Session> {
-    const [_find, _del, update] = await this.prisma.$transaction([
+    // an interactive transaction so that the students of the lesson are read
+    // in the same transaction that writes the update - a student joining
+    // in-between would otherwise be locked out by the very update we guard
+    // against below.
+    const update = await this.prisma.$transaction(async (tx) => {
       // ensure the session exists and hasn't started yet
-      this.prisma.session.findUniqueOrThrow({
+      const existing = await tx.session.findUniqueOrThrow({
         where: includeSoftDelete
           ? { classId, id, status: "CREATED" }
           : { classId, id, deletedAt: null, status: "CREATED" },
-      }),
+        include: {
+          tasks: { where: { deletedAt: null }, select: { taskId: true } },
+        },
+      });
+
+      await this.assertStudentsKeepAccess(
+        tx,
+        id,
+        existing,
+        session,
+        taskIds,
+        includeSoftDelete,
+      );
+
       // we could do `deleteMany` and `createMany` within the same update(),
-      // however we need a transaction because of this open bug:
+      // however we need separate statements because of this open bug:
       // https://github.com/prisma/prisma/issues/16606
-      this.prisma.sessionTask.deleteMany({
+      await tx.sessionTask.deleteMany({
         where: {
           taskId: {
             notIn: taskIds,
           },
           sessionId: id,
         },
-      }),
-      this.prisma.session.update({
+      });
+
+      const updated = await tx.session.update({
         data: session,
         where: { classId, id },
         include: compactInclude,
-      }),
-      ...taskIds.map((taskId, index) =>
-        this.prisma.sessionTask.upsert({
+      });
+
+      for (const [index, taskId] of taskIds.entries()) {
+        await tx.sessionTask.upsert({
           where: {
             sessionId_taskId: {
               sessionId: id,
@@ -158,12 +177,54 @@ export class SessionsService {
             index,
             sessionId: id,
           },
-        }),
-      ),
-    ]);
+        });
+      }
+
+      return updated;
+    });
 
     this.logger.log(`Updated lesson (id: ${id}) with ${taskIds.length} tasks`);
     return update;
+  }
+
+  /**
+   * Students that already joined a lesson lose access to it when its tasks are
+   * removed or when it stops being anonymous. The lesson form disables both
+   * operations as soon as a lesson has students (EditingMode.restricted);
+   * this enforces the same rule for direct API calls.
+   */
+  private async assertStudentsKeepAccess(
+    tx: PrismaTransactionClient,
+    id: SessionId,
+    existing: { isAnonymous: boolean; tasks: { taskId: number }[] },
+    session: Prisma.SessionUpdateInput,
+    taskIds: number[],
+    includeSoftDelete: boolean,
+  ): Promise<void> {
+    const hasStudents = await this.hasStudentsTx(tx, id, includeSoftDelete);
+
+    if (!hasStudents) {
+      return;
+    }
+
+    const removedTaskIds = existing.tasks
+      .map(({ taskId }) => taskId)
+      .filter((taskId) => !taskIds.includes(taskId));
+
+    if (removedTaskIds.length > 0) {
+      throw new ConflictException(
+        `Cannot remove tasks (ids: ${removedTaskIds.join(", ")}) from lesson (id: ${id}) because students already joined it`,
+      );
+    }
+
+    if (
+      typeof session.isAnonymous === "boolean" &&
+      session.isAnonymous !== existing.isAnonymous
+    ) {
+      throw new ConflictException(
+        `Cannot change the sharing type of lesson (id: ${id}) because students already joined it`,
+      );
+    }
   }
 
   async hasStudents(

--- a/backend/src/api/sessions/sessions.service.ts
+++ b/backend/src/api/sessions/sessions.service.ts
@@ -121,10 +121,12 @@ export class SessionsService {
     classId?: number,
     includeSoftDelete = false,
   ): Promise<Session> {
-    // an interactive transaction so that the students of the lesson are read
-    // in the same transaction that writes the update - a student joining
-    // in-between would otherwise be locked out by the very update we guard
-    // against below.
+    // FIXME: CRT-450 -> At READ COMMITTED, this interactive transaction does not
+    // prevent a student from joining after the student check but before the
+    // update commits. Move all transactions to the planned SERIALIZABLE
+    // transaction() wrapper so joining and updating participate in the same
+    // concurrency protocol. Similar read-then-write races may exist elsewhere;
+    // that broader risk is accepted until the migration is complete.
     const update = await this.prisma.$transaction(async (tx) => {
       // ensure the session exists and hasn't started yet
       const existing = await tx.session.findUniqueOrThrow({


### PR DESCRIPTION
…ined

Once students have joined a lesson, removing its tasks or turning an anonymous lesson private takes it away from them: without tasks there is nothing left to solve, and a private lesson rejects the anonymous students already in it. The lesson form disables both operations once a lesson has students (EditingMode.restricted), but the API enforced nothing - a plain PATCH passed the ownership-only authorization check and the service then unconditionally soft-deleted the SessionTask rows and wrote isAnonymous, locking every student out of a running lesson.

Enforce the same rule in SessionsService.update and answer 409. The array form of $transaction cannot express a conditional, so update becomes an interactive transaction, which also closes a race: the students are read in the same transaction that writes the update, so a student joining in between cannot be locked out by the very update being guarded.

The test drives update() with a mocked Prisma - $transaction runs the callback against a mock tx - and asserts a lesson with students refuses task removal and sharing-type changes (ConflictException) while still allowing renames and task additions, and that a lesson with no students allows everything. Confirmed the two rejections fail without the guard call (the update resolves) and pass with it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject lesson updates that would lock out joined students. Fixes CRT-444 by returning 409 and guarding in one interactive `prisma.$transaction`; documents a remaining join race (CRT-450).

- **Bug Fixes**
  - Refuse removing existing tasks or changing `isAnonymous` when students are present (`ConflictException`, 409).
  - Run presence check and update inside a single interactive `prisma.$transaction`; add FIXME on READ COMMITTED race and planned SERIALIZABLE wrapper (CRT-450).
  - Allow safe edits (rename, add tasks); allow all changes when no students.
  - Expand tests to increase coverage: both `isAnonymous` flips, task add/remove, rename; assert no partial writes on rejection using a mocked transaction.

<sup>Written for commit a193d73203effa109bb88c34e8dfefd1155ed4e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

