### PR TITLE
[CRT-445] Refuse editing a public task other users' lessons depend on

### DIFF
--- a/backend/src/api/tasks/task-update.controller.spec.ts
+++ b/backend/src/api/tasks/task-update.controller.spec.ts
@@ -1,0 +1,77 @@
+import { ConflictException } from "@nestjs/common";
+import { TaskType, User, UserType } from "@prisma/client";
+import { AuthorizationService } from "../authorization/authorization.service";
+import { ErrorCode } from "../exceptions/error-codes";
+import { UpdateTaskDto } from "./dto";
+import { TasksController } from "./tasks.controller";
+import { TaskInOtherUsersLessonError, TasksService } from "./tasks.service";
+
+describe("TasksController.update", () => {
+  it("maps a task used by another user's lesson to the exact conflict response", async () => {
+    const tasksService = {
+      update: jest.fn().mockRejectedValue(new TaskInOtherUsersLessonError()),
+    } as unknown as TasksService;
+
+    const authorizationService = {
+      canUpdateTask: jest.fn().mockResolvedValue(true),
+    } as unknown as AuthorizationService;
+
+    const controller = new TasksController(tasksService, authorizationService);
+
+    const user = { id: 7, type: UserType.TEACHER } as User;
+
+    const updateTaskDto = {
+      title: "rewritten",
+      description: "new",
+      type: TaskType.SCRATCH,
+      isPublic: false,
+      referenceSolutions: [],
+    } as unknown as UpdateTaskDto;
+
+    const taskFile = {
+      mimetype: "application/json",
+      buffer: Buffer.from([1, 2, 3]),
+    } as Express.Multer.File;
+
+    let thrown: unknown;
+
+    try {
+      await controller.update(
+        user,
+        1,
+        updateTaskDto,
+        { taskFile: [taskFile], referenceSolutionsFiles: [] },
+        false,
+      );
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown).toBeInstanceOf(ConflictException);
+
+    const conflict = thrown as ConflictException;
+
+    expect(conflict.getStatus()).toBe(409);
+
+    expect(conflict.getResponse()).toEqual({
+      errorCode: ErrorCode.TASK_IN_OTHER_USERS_LESSON,
+    });
+
+    expect(authorizationService.canUpdateTask).toHaveBeenCalledWith(user, 1);
+
+    expect(tasksService.update).toHaveBeenCalledWith(
+      1,
+      {
+        title: "rewritten",
+        description: "new",
+        type: TaskType.SCRATCH,
+        isPublic: false,
+      },
+      "application/json",
+      taskFile.buffer,
+      [],
+      [],
+      false,
+    );
+  });
+});

--- a/backend/src/api/tasks/task-update.spec.ts
+++ b/backend/src/api/tasks/task-update.spec.ts
@@ -15,6 +15,32 @@ import {
 // lesson with students" checks (called in that order for a public task).
 describe("TasksService.update", () => {
   const taskId = 1;
+  const taskData = new Uint8Array([1, 2, 3]);
+  const updatedTask = { id: taskId };
+  const studentUsageQuery = {
+    where: {
+      taskId,
+      task: { deletedAt: null },
+      session: {
+        deletedAt: null,
+        OR: [
+          {
+            anonymousStudents: {
+              some: { deletedAt: null },
+            },
+          },
+          {
+            class: {
+              deletedAt: null,
+              students: {
+                some: { deletedAt: null },
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
 
   const buildService = (opts: {
     isPublic: boolean;
@@ -41,7 +67,7 @@ describe("TasksService.update", () => {
           isPublic: opts.isPublic,
           creatorId: opts.creatorId,
         }),
-        update: jest.fn().mockResolvedValue({ id: taskId }),
+        update: jest.fn().mockResolvedValue(updatedTask),
       },
       sessionTask: { findFirst },
       referenceSolution: { deleteMany: jest.fn().mockResolvedValue({}) },
@@ -63,9 +89,25 @@ describe("TasksService.update", () => {
   const update = (
     service: TasksService,
     task: TaskUpdateInput,
+    includeSoftDelete = false,
   ): Promise<unknown> =>
     // no reference solutions, so the pre-transaction hashing is a no-op
-    service.update(taskId, task, "application/json", new Uint8Array(), [], []);
+    service.update(
+      taskId,
+      task,
+      "application/json",
+      taskData,
+      [],
+      [],
+      includeSoftDelete,
+    );
+
+  const expectNoWrites = (tx: MockTx): void => {
+    expect(tx.referenceSolution.deleteMany).not.toHaveBeenCalled();
+    expect(tx.solution.deleteMany).not.toHaveBeenCalled();
+    expect(tx.solution.createMany).not.toHaveBeenCalled();
+    expect(tx.task.update).not.toHaveBeenCalled();
+  };
 
   it("refuses to edit a public task another user's lesson depends on", async () => {
     const { service, tx } = buildService({
@@ -79,11 +121,24 @@ describe("TasksService.update", () => {
       TaskInOtherUsersLessonError,
     );
 
-    expect(tx.task.update).not.toHaveBeenCalled();
+    expect(tx.sessionTask.findFirst).toHaveBeenCalledTimes(1);
+    expect(tx.sessionTask.findFirst).toHaveBeenCalledWith({
+      where: {
+        taskId,
+        session: {
+          deletedAt: null,
+          class: {
+            teacherId: { not: 7 },
+            deletedAt: null,
+          },
+        },
+      },
+    });
+    expectNoWrites(tx);
   });
 
   it("does not apply the other-users rule to a public task no one else uses", async () => {
-    const { service } = buildService({
+    const { service, tx } = buildService({
       isPublic: true,
       creatorId: 7,
       inUseByOthers: false,
@@ -95,10 +150,31 @@ describe("TasksService.update", () => {
     await expect(update(service, { title: "rewritten" })).rejects.toThrow(
       TaskInUseByClassOrLessonWithStudentsError,
     );
+
+    expect(tx.sessionTask.findFirst).toHaveBeenCalledTimes(2);
+    expect(tx.sessionTask.findFirst).toHaveBeenNthCalledWith(1, {
+      where: {
+        taskId,
+        session: {
+          deletedAt: null,
+          class: {
+            teacherId: { not: 7 },
+            deletedAt: null,
+          },
+        },
+      },
+    });
+
+    expect(tx.sessionTask.findFirst).toHaveBeenNthCalledWith(
+      2,
+      studentUsageQuery,
+    );
+
+    expectNoWrites(tx);
   });
 
   it("does not apply the other-users rule to a private task", async () => {
-    const { service } = buildService({
+    const { service, tx } = buildService({
       isPublic: false,
       creatorId: 7,
       inUseByOthers: true, // irrelevant: the check is skipped for private tasks
@@ -108,6 +184,11 @@ describe("TasksService.update", () => {
     await expect(update(service, { title: "rewritten" })).rejects.toThrow(
       TaskInUseByClassOrLessonWithStudentsError,
     );
+
+    expect(tx.sessionTask.findFirst).toHaveBeenCalledTimes(1);
+    expect(tx.sessionTask.findFirst).toHaveBeenCalledWith(studentUsageQuery);
+
+    expectNoWrites(tx);
   });
 
   it("persists the caller's field changes on a permitted update", async () => {
@@ -118,18 +199,31 @@ describe("TasksService.update", () => {
       inUseByStudents: false,
     });
 
-    await update(service, { title: "rewritten", description: "new" });
+    await expect(
+      update(service, { title: "rewritten", description: "new" }),
+    ).resolves.toEqual(updatedTask);
+
+    expect(tx.task.findUniqueOrThrow).toHaveBeenCalledWith({
+      where: { id: taskId, deletedAt: null },
+      select: { isPublic: true, creatorId: true },
+    });
 
     // guards against the parameter being shadowed by the fetched task, which
     // would silently drop the caller's field changes from the write
-    expect(tx.task.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({
-          title: "rewritten",
-          description: "new",
-        }),
-      }),
-    );
+    expect(tx.task.update).toHaveBeenCalledWith({
+      data: {
+        title: "rewritten",
+        description: "new",
+        mimeType: "application/json",
+        data: taskData,
+        referenceSolutions: {
+          create: [],
+          update: [],
+        },
+      },
+      where: { id: taskId },
+      omit: { data: true },
+    });
   });
 });
 

--- a/backend/src/api/tasks/task-update.spec.ts
+++ b/backend/src/api/tasks/task-update.spec.ts
@@ -1,0 +1,141 @@
+import { PrismaService } from "src/prisma/prisma.service";
+import {
+  TaskInOtherUsersLessonError,
+  TaskInUseByClassOrLessonWithStudentsError,
+  TasksService,
+  TaskUpdateInput,
+} from "./tasks.service";
+
+// TasksService.update refuses to edit a public task that another user's lesson
+// depends on (the same rule deleteById already enforces), and must otherwise
+// persist the caller's field changes. Both are exercised here by driving
+// update() with a mocked Prisma: $transaction runs the callback against a mock
+// tx, task.findUniqueOrThrow yields the task's isPublic/creatorId, and
+// sessionTask.findFirst stands in for the "used by other users" / "used by a
+// lesson with students" checks (called in that order for a public task).
+describe("TasksService.update", () => {
+  const taskId = 1;
+
+  const buildService = (opts: {
+    isPublic: boolean;
+    creatorId: number | null;
+    inUseByOthers: boolean;
+    inUseByStudents: boolean;
+  }): { service: TasksService; tx: MockTx } => {
+    const findFirst = jest.fn();
+    if (opts.isPublic) {
+      // first call: used by other users; second: used by a lesson with students
+      findFirst
+        .mockResolvedValueOnce(opts.inUseByOthers ? { id: taskId } : null)
+        .mockResolvedValueOnce(opts.inUseByStudents ? { id: taskId } : null);
+    } else {
+      // the other-users check is skipped, so findFirst is only the student one
+      findFirst.mockResolvedValueOnce(
+        opts.inUseByStudents ? { id: taskId } : null,
+      );
+    }
+
+    const tx = {
+      task: {
+        findUniqueOrThrow: jest.fn().mockResolvedValue({
+          isPublic: opts.isPublic,
+          creatorId: opts.creatorId,
+        }),
+        update: jest.fn().mockResolvedValue({ id: taskId }),
+      },
+      sessionTask: { findFirst },
+      referenceSolution: { deleteMany: jest.fn().mockResolvedValue({}) },
+      solution: {
+        deleteMany: jest.fn().mockResolvedValue({}),
+        createMany: jest.fn().mockResolvedValue({}),
+      },
+    };
+
+    const prisma = {
+      $transaction: jest.fn((callback: (client: MockTx) => Promise<unknown>) =>
+        callback(tx),
+      ),
+    } as unknown as PrismaService;
+
+    return { service: new TasksService(prisma), tx };
+  };
+
+  const update = (
+    service: TasksService,
+    task: TaskUpdateInput,
+  ): Promise<unknown> =>
+    // no reference solutions, so the pre-transaction hashing is a no-op
+    service.update(taskId, task, "application/json", new Uint8Array(), [], []);
+
+  it("refuses to edit a public task another user's lesson depends on", async () => {
+    const { service, tx } = buildService({
+      isPublic: true,
+      creatorId: 7,
+      inUseByOthers: true,
+      inUseByStudents: false,
+    });
+
+    await expect(update(service, { title: "rewritten" })).rejects.toThrow(
+      TaskInOtherUsersLessonError,
+    );
+
+    expect(tx.task.update).not.toHaveBeenCalled();
+  });
+
+  it("does not apply the other-users rule to a public task no one else uses", async () => {
+    const { service } = buildService({
+      isPublic: true,
+      creatorId: 7,
+      inUseByOthers: false,
+      inUseByStudents: true,
+    });
+
+    // reaching the students-in-use check (a different error) proves the
+    // other-users guard let this through rather than blocking it
+    await expect(update(service, { title: "rewritten" })).rejects.toThrow(
+      TaskInUseByClassOrLessonWithStudentsError,
+    );
+  });
+
+  it("does not apply the other-users rule to a private task", async () => {
+    const { service } = buildService({
+      isPublic: false,
+      creatorId: 7,
+      inUseByOthers: true, // irrelevant: the check is skipped for private tasks
+      inUseByStudents: true,
+    });
+
+    await expect(update(service, { title: "rewritten" })).rejects.toThrow(
+      TaskInUseByClassOrLessonWithStudentsError,
+    );
+  });
+
+  it("persists the caller's field changes on a permitted update", async () => {
+    const { service, tx } = buildService({
+      isPublic: false,
+      creatorId: 7,
+      inUseByOthers: false,
+      inUseByStudents: false,
+    });
+
+    await update(service, { title: "rewritten", description: "new" });
+
+    // guards against the parameter being shadowed by the fetched task, which
+    // would silently drop the caller's field changes from the write
+    expect(tx.task.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          title: "rewritten",
+          description: "new",
+        }),
+      }),
+    );
+  });
+});
+
+type MockTx = {
+  task: { findUniqueOrThrow: jest.Mock; update: jest.Mock };
+  sessionTask: { findFirst: jest.Mock };
+  referenceSolution: { deleteMany: jest.Mock };
+  solution: { deleteMany: jest.Mock; createMany: jest.Mock };
+};

--- a/backend/src/api/tasks/tasks.controller.ts
+++ b/backend/src/api/tasks/tasks.controller.ts
@@ -328,6 +328,11 @@ export class TasksController {
           errorCode: ErrorCode.TASK_IN_USE_BY_LESSON_OR_CLASS_WITH_STUDENTS,
         });
       }
+      if (error instanceof TaskInOtherUsersLessonError) {
+        throw new ConflictException({
+          errorCode: ErrorCode.TASK_IN_OTHER_USERS_LESSON,
+        });
+      }
       if (error instanceof DuplicateReferenceSolutionError) {
         throw new BadRequestException({
           errorCode: ErrorCode.DUPLICATE_REFERENCE_SOLUTION,

--- a/backend/src/api/tasks/tasks.service.ts
+++ b/backend/src/api/tasks/tasks.service.ts
@@ -334,6 +334,32 @@ export class TasksService {
     }
 
     return this.prisma.$transaction(async (tx) => {
+      // named existingTask, not task, so it does not shadow the `task` update
+      // input spread into tx.task.update() below - shadowing it would silently
+      // drop the caller's field changes (title, description, ...).
+      const existingTask = await tx.task.findUniqueOrThrow({
+        where: { id, deletedAt: null },
+        select: { isPublic: true, creatorId: true },
+      });
+
+      // A public task can be picked up by any teacher. Editing it changes
+      // their lesson under them - and drops the reference solutions that are
+      // no longer listed - which is at least as disruptive as deleting it, so
+      // it is refused for the same reason deleteById refuses the deletion.
+      if (existingTask.isPublic) {
+        const isInUseByOthers = await this.isTaskInUseByOtherUsersTx(
+          tx,
+          id,
+          existingTask.creatorId,
+        );
+        if (isInUseByOthers) {
+          this.logger.warn(
+            `Cannot update task (id: ${id}): public task is in use by other users`,
+          );
+          throw new TaskInOtherUsersLessonError();
+        }
+      }
+
       const isInUse = await this.isTaskInUseTx(tx, id);
       if (isInUse) {
         this.logger.warn(`Cannot update task (id: ${id}): task is in use`);


### PR DESCRIPTION
TasksService.deleteById refuses to delete a public task that another user's lesson uses (TASK_IN_OTHER_USERS_LESSON); TasksService.update had no equivalent guard, so the same task could be edited out from under that lesson - the other teacher's lesson silently starts serving a different exercise, and update also drops the reference solutions no longer listed. Apply the same guard on the update path and map it to 409 in the controller as delete already does; own lessons are unaffected. The frontend needs no change - it already has a translated message for the error code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents editing a public task if another teacher’s lesson depends on it, matching the delete rule. Returns 409 with TASK_IN_OTHER_USERS_LESSON; private tasks and own lessons are unaffected. Addresses CRT-445.

- **Bug Fixes**
  - Added guard in `TasksService.update` to throw `TaskInOtherUsersLessonError` for public tasks used by other users’ lessons.
  - Mapped the error to 409 Conflict in `TasksController.update` (`TASK_IN_OTHER_USERS_LESSON`).
  - Fixed a regression where a local `task` variable shadowed the update input; renamed to `existingTask` so field changes persist.
  - Added tests for service behavior (public vs private, check ordering, field persistence) and controller conflict mapping.

<sup>Written for commit 65c04856fcf5d50c7bd30337354a085c8ef1768d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

