### PR TITLE
[CRT-446] Fix uncaught TypeError

### DIFF
--- a/frontend/src/hooks/__tests__/jest/useStudentName.spec.tsx
+++ b/frontend/src/hooks/__tests__/jest/useStudentName.spec.tsx
@@ -1,0 +1,36 @@
+// iframe-rpc-react/src pulls in react through its hooks, which jest cannot
+// resolve through the portal symlink. Only the language helpers re-exported
+// from iframe-rpc are needed here, so we substitute those.
+jest.mock("iframe-rpc-react/src", () => jest.requireActual("iframe-rpc/src"));
+
+import { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { useStudentName } from "@/hooks/useStudentName";
+import { getStudentNickname } from "@/utilities/student-name";
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <IntlProvider locale="en">{children}</IntlProvider>
+);
+
+describe("useStudentName", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("returns the nickname of an anonymized student", () => {
+    const { result } = renderHook(() => useStudentName({ studentId: 42 }), {
+      wrapper,
+    });
+
+    expect(result.current.name).toBe(getStudentNickname(42));
+  });
+
+  it("returns no name while the student id is not resolved yet", () => {
+    const { result } = renderHook(() => useStudentName({ studentId: NaN }), {
+      wrapper,
+    });
+
+    expect(result.current.name).toBeNull();
+  });
+});

--- a/frontend/src/hooks/__tests__/jest/useStudentName.spec.tsx
+++ b/frontend/src/hooks/__tests__/jest/useStudentName.spec.tsx
@@ -34,6 +34,18 @@ describe("useStudentName", () => {
     expect(result.current.name).toBeNull();
   });
 
+  it("returns no name for a non-numeric (unresolved) student id", () => {
+    // A direct load can hand the hook a non-numeric value before the router
+    // resolves the dynamic param. The global isNaN coerces and rejects it;
+    // Number.isNaN would let it through, so this locks in the isNaN semantics.
+    const { result } = renderHook(
+      () => useStudentName({ studentId: undefined as unknown as number }),
+      { wrapper },
+    );
+
+    expect(result.current.name).toBeNull();
+  });
+
   it("returns a nickname once the unresolved student id becomes available", () => {
     let studentId = NaN;
 

--- a/frontend/src/hooks/__tests__/jest/useStudentName.spec.tsx
+++ b/frontend/src/hooks/__tests__/jest/useStudentName.spec.tsx
@@ -33,4 +33,20 @@ describe("useStudentName", () => {
 
     expect(result.current.name).toBeNull();
   });
+
+  it("returns a nickname once the unresolved student id becomes available", () => {
+    let studentId = NaN;
+
+    const { result, rerender } = renderHook(
+      () => useStudentName({ studentId }),
+      { wrapper },
+    );
+
+    expect(result.current.name).toBeNull();
+
+    studentId = 42;
+    rerender();
+
+    expect(result.current.name).toBe(getStudentNickname(42));
+  });
 });

--- a/frontend/src/hooks/useStudentName.ts
+++ b/frontend/src/hooks/useStudentName.ts
@@ -89,7 +89,7 @@ export const useStudentName = ({
       return decryptedName;
     }
 
-    if (isNaN(studentId)) {
+    if (Number.isNaN(studentId)) {
       // On a direct load the router has not populated the dynamic route params
       // during the first render, so the student id is NaN and there is no
       // nickname to derive from it yet.

--- a/frontend/src/hooks/useStudentName.ts
+++ b/frontend/src/hooks/useStudentName.ts
@@ -85,9 +85,18 @@ export const useStudentName = ({
   const locale = isLanguage(intl.locale) ? intl.locale : undefined;
 
   const name = useMemo(() => {
-    return !anonymizationState.showActualName
-      ? getStudentNickname(studentId, locale)
-      : decryptedName;
+    if (anonymizationState.showActualName) {
+      return decryptedName;
+    }
+
+    if (isNaN(studentId)) {
+      // On a direct load the router has not populated the dynamic route params
+      // during the first render, so the student id is NaN and there is no
+      // nickname to derive from it yet.
+      return null;
+    }
+
+    return getStudentNickname(studentId, locale);
   }, [anonymizationState.showActualName, decryptedName, studentId, locale]);
 
   return {

--- a/frontend/src/hooks/useStudentName.ts
+++ b/frontend/src/hooks/useStudentName.ts
@@ -89,10 +89,11 @@ export const useStudentName = ({
       return decryptedName;
     }
 
-    if (Number.isNaN(studentId)) {
-      // On a direct load the router has not populated the dynamic route params
-      // during the first render, so the student id is NaN and there is no
-      // nickname to derive from it yet.
+    // Use the global isNaN, not Number.isNaN, on purpose: it coerces, so it
+    // also rejects a non-numeric studentId (e.g. undefined before the router
+    // has populated the dynamic route params on a direct load), for which there
+    // is no nickname to derive yet. Number.isNaN would let such a value through.
+    if (isNaN(studentId)) {
       return null;
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a crash on direct loads of the student-solution detail page by guarding unresolved `studentId` in `useStudentName` (CRT-446). The hook now uses the global `isNaN` to treat `NaN` and non-numeric IDs as unresolved and return null until the ID resolves, then derives the nickname; tests cover valid, `NaN`, non-numeric, and recovery cases, and mock `iframe-rpc-react/src` to `iframe-rpc/src`.

<sup>Written for commit 7d6522734fca456973c9db141c7c73d566a4585c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

