### PR TITLE
[CRT-447] Strip IPython magics before analysing a Jupyter cell

### DIFF
--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -103,4 +103,62 @@ describe("Jupyter converter — IPython magics", () => {
     expect(referencesVariable(statements, "b")).toBe(true);
     expect(JSON.stringify(statements)).toContain('"operator":"!="');
   });
+
+  it("strips several line magics and a shell escape interleaved with code in one cell", () => {
+    // A single cell may freely mix multiple magics with real Python. Each
+    // magic / shell-escape line is dropped independently; every surrounding
+    // code line survives untouched.
+    const statements = statementsOf(
+      [
+        "%pip install -q pandas numpy",
+        "import numpy as np",
+        "%matplotlib inline",
+        "arr = np.array([1, 2, 3])",
+        "!echo done",
+        "total = arr.sum()",
+      ].join("\n"),
+    );
+
+    // all the real code survives
+    expect(referencesVariable(statements, "np")).toBe(true);
+    expect(referencesVariable(statements, "arr")).toBe(true);
+    expect(referencesVariable(statements, "total")).toBe(true);
+    // none of the magic / shell tokens leak in as phantom variables
+    expect(referencesVariable(statements, "pip")).toBe(false);
+    expect(referencesVariable(statements, "matplotlib")).toBe(false);
+    expect(referencesVariable(statements, "inline")).toBe(false);
+    expect(referencesVariable(statements, "echo")).toBe(false);
+  });
+
+  it("converts the real task-template setup cell (two magics + two imports) correctly", () => {
+    // The exact setup cell shipped in apps/jupyter/files/task.ipynb: two line
+    // magics interleaved with two imports in one cell.
+    const statements = statementsOf(
+      [
+        "%pip install -q pandas numpy matplotlib",
+        "import pandas as pd",
+        "import numpy as np",
+        "%matplotlib inline",
+      ].join("\n"),
+    );
+
+    // both imports are kept
+    expect(JSON.stringify(statements)).toContain("@import");
+    // the two magics leave no phantom variables behind
+    expect(referencesVariable(statements, "pip")).toBe(false);
+    expect(referencesVariable(statements, "matplotlib")).toBe(false);
+    expect(referencesVariable(statements, "inline")).toBe(false);
+  });
+
+  it("keeps code lines that sit before, between and after magic lines", () => {
+    // Magics need not be at the top of the cell; code interleaved with them is
+    // preserved in order.
+    const statements = statementsOf(
+      ["a = 1", "%time", "b = a + 1", "%reset -f", "c = b + 1"].join("\n"),
+    );
+
+    expect(referencesVariable(statements, "a")).toBe(true);
+    expect(referencesVariable(statements, "b")).toBe(true);
+    expect(referencesVariable(statements, "c")).toBe(true);
+  });
 });

--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -199,6 +199,88 @@ describe("Jupyter converter — IPython magics", () => {
         expect(statements).toHaveLength(0);
       },
     );
+
+    it("keeps the first-line setup statement of a %%timeit cell", () => {
+      // %%timeit executes the statement on its own line as setup code; the
+      // body then uses what it defined.
+      const statements = statementsOf(
+        ["%%timeit -n 100 x = 5", "x + 1"].join("\n"),
+      );
+
+      const expected = statementsOf(["x = 5", "x + 1"].join("\n"));
+
+      expect(statements).toEqual(expected);
+    });
+  });
+
+  describe("line magics with a Python payload", () => {
+    // In line mode, %time/%timeit/%prun/%debug execute the rest of the line
+    // as ordinary Python; only the magic (and its options) must be removed.
+    it.each(["%time", "%timeit", "%prun", "%debug"])(
+      "keeps the inline statement of %s",
+      (magic) => {
+        const statements = statementsOf(
+          ["a = 2", `${magic} total = sum(range(a))`].join("\n"),
+        );
+
+        const expected = statementsOf(
+          ["a = 2", "total = sum(range(a))"].join("\n"),
+        );
+
+        expect(statements).toEqual(expected);
+      },
+    );
+
+    it("consumes option flags before the payload", () => {
+      const statements = statementsOf("%timeit -n 100 -r 5 sum(range(10))\n");
+
+      const expected = statementsOf("sum(range(10))\n");
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("consumes an option with a separate value before the payload", () => {
+      const statements = statementsOf("%prun -s cumulative compute()\n");
+
+      const expected = statementsOf("compute()\n");
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("drops the line when there is no payload", () => {
+      const statements = statementsOf(
+        ["a = 1", "%timeit -n 100", "b = a + 1"].join("\n"),
+      );
+
+      const expected = statementsOf(["a = 1", "b = a + 1"].join("\n"));
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("preserves the indentation of an indented magic's payload", () => {
+      // IPython allows line magics inside indented blocks; the payload must
+      // keep the indentation to stay syntactically part of the block.
+      const statements = statementsOf(
+        ["for i in range(3):", "    %time run(i)", ""].join("\n"),
+      );
+
+      const expected = statementsOf(
+        ["for i in range(3):", "    run(i)", ""].join("\n"),
+      );
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("still drops a non-payload line magic with arguments entirely", () => {
+      // `inline` is an argument of %matplotlib, not Python to execute.
+      const statements = statementsOf(
+        ["%matplotlib inline", "x = 1"].join("\n"),
+      );
+
+      const expected = statementsOf("x = 1\n");
+
+      expect(statements).toEqual(expected);
+    });
   });
 
   it("keeps code lines that sit before, between and after magic lines", () => {

--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -81,4 +81,26 @@ describe("Jupyter converter — IPython magics", () => {
     expect(asJson).toContain("@import");
     expect(referencesVariable(statements, "x")).toBe(true);
   });
+
+  it("keeps a modulo operator that leads a bracketed continuation line", () => {
+    // `% 3` begins the continuation line of `(10 % 3)`. It is Python, not a
+    // line magic (a magic name is an identifier, never a space or digit). A
+    // naive `startsWith("%")` filter drops it, leaving the broken `x = (10`.
+    const statements = statementsOf("x = (10\n% 3)\n");
+
+    expect(referencesVariable(statements, "x")).toBe(true);
+    // the modulo operation must survive
+    expect(JSON.stringify(statements)).toContain('"operator":"%"');
+  });
+
+  it("keeps a `!=` comparison that leads a continuation line", () => {
+    // `!= b` begins the continuation line of `(a != b)`. `!=` is the inequality
+    // operator, not a shell escape. A naive `startsWith("!")` filter drops it,
+    // leaving `x = (a` (recovered as `x = a`) and losing `b` entirely.
+    const statements = statementsOf("x = (a\n!= b)\n");
+
+    expect(referencesVariable(statements, "a")).toBe(true);
+    expect(referencesVariable(statements, "b")).toBe(true);
+    expect(JSON.stringify(statements)).toContain('"operator":"!="');
+  });
 });

--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -1,0 +1,84 @@
+import { AstNodeType } from "src/ast/types/general-ast";
+import { ExpressionNodeType } from "src/ast/types/general-ast/ast-nodes/expression-node";
+import { convertJupyterToGeneralAst } from "..";
+
+const notebookWithCell = (
+  source: string,
+): Parameters<typeof convertJupyterToGeneralAst>[0] => ({
+  nbformat: 4,
+  nbformat_minor: 0,
+  metadata: { language_info: { name: "python", version: "3.10.4" } },
+  cells: [
+    {
+      id: "c1",
+      cell_type: "code",
+      source,
+      outputs: [],
+      execution_count: 0,
+      metadata: {},
+    },
+  ],
+});
+
+// The statements the converter produced for the single code cell.
+const statementsOf = (source: string): unknown[] => {
+  const ast = convertJupyterToGeneralAst(
+    notebookWithCell(source),
+  ) as unknown as [
+    {
+      eventListeners?: {
+        action: { statements?: unknown[] } & Record<string, unknown>;
+      }[];
+    },
+  ];
+
+  const actor = ast[0];
+
+  if (!actor?.eventListeners?.length) {
+    return [];
+  }
+
+  const action = actor.eventListeners[0].action;
+
+  return action.statements ?? [action];
+};
+
+const referencesVariable = (statements: unknown[], name: string): boolean =>
+  JSON.stringify(statements).includes(
+    `"expressionType":"${ExpressionNodeType.variable}","name":"${name}"`,
+  );
+
+describe("Jupyter converter — IPython magics", () => {
+  it("drops a line magic instead of turning it into a phantom variable", () => {
+    const statements = statementsOf("%matplotlib inline\nx = 1\ny = x + 2\n");
+
+    // the real code survives
+    expect(referencesVariable(statements, "x")).toBe(true);
+    expect(referencesVariable(statements, "y")).toBe(true);
+    // the magic must NOT have leaked in as a `matplotlib` reference
+    expect(referencesVariable(statements, "matplotlib")).toBe(false);
+  });
+
+  it("drops a shell escape line", () => {
+    const statements = statementsOf("!pip install numpy\nz = 3\n");
+
+    expect(referencesVariable(statements, "z")).toBe(true);
+    expect(referencesVariable(statements, "pip")).toBe(false);
+    expect(referencesVariable(statements, "numpy")).toBe(false);
+  });
+
+  it("skips a whole cell that is a cell magic", () => {
+    const statements = statementsOf("%%bash\necho hello\nls -la\n");
+
+    expect(statements).toHaveLength(0);
+  });
+
+  it("keeps a real multi-target import (not a magic)", () => {
+    const statements = statementsOf("import os, sys\nx = 1\n");
+
+    const asJson = JSON.stringify(statements);
+    expect(asJson).toContain(AstNodeType.statement);
+    expect(asJson).toContain("@import");
+    expect(referencesVariable(statements, "x")).toBe(true);
+  });
+});

--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -247,6 +247,26 @@ describe("Jupyter converter — IPython magics", () => {
       expect(statements).toEqual(expected);
     });
 
+    it("treats %prun's -r as a flag, not a value-taking option", () => {
+      // -r takes a value for %timeit (repeat count) but is a standalone
+      // return-Stats flag for %prun; it must not swallow the statement.
+      const statements = statementsOf("%prun -r compute()\n");
+
+      const expected = statementsOf("compute()\n");
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("consumes a quoted option value containing spaces", () => {
+      const statements = statementsOf(
+        '%prun -T "profile output.txt" compute()\n',
+      );
+
+      const expected = statementsOf("compute()\n");
+
+      expect(statements).toEqual(expected);
+    });
+
     it("drops the line when there is no payload", () => {
       const statements = statementsOf(
         ["a = 1", "%timeit -n 100", "b = a + 1"].join("\n"),
@@ -295,5 +315,36 @@ describe("Jupyter converter — IPython magics", () => {
     );
 
     expect(statements).toEqual(expected);
+  });
+
+  describe("documented limitations", () => {
+    // Deliberate trade-offs for classroom-scale code: handling these would
+    // require a Python tokenizer / per-magic argument parser, whose own bugs
+    // would be worse than the limitation.
+    it("a magic-looking line inside a multi-line string is still stripped", () => {
+      // The stripping is line-local: it cannot know the line sits inside a
+      // string literal. Only the literal's text changes; the code structure
+      // the similarity analysis compares is unaffected.
+      const statements = statementsOf(
+        ['doc = """usage:', "%matplotlib inline", '"""', "x = 1"].join("\n"),
+      );
+
+      const expected = statementsOf(
+        ['doc = """usage:', '"""', "x = 1"].join("\n"),
+      );
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("%%script cells are skipped even for a python interpreter", () => {
+      // `%%script python` is an alias of %%python, but recognizing it would
+      // special-case one argument of the generic %%script family; skipping
+      // the whole family is the conservative default.
+      const statements = statementsOf(
+        ["%%script python", "a = 1", "b = a + 1"].join("\n"),
+      );
+
+      expect(statements).toHaveLength(0);
+    });
   });
 });

--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -1,5 +1,3 @@
-import { AstNodeType } from "src/ast/types/general-ast";
-import { ExpressionNodeType } from "src/ast/types/general-ast/ast-nodes/expression-node";
 import { convertJupyterToGeneralAst } from "..";
 
 const notebookWithCell = (
@@ -43,43 +41,38 @@ const statementsOf = (source: string): unknown[] => {
   return action.statements ?? [action];
 };
 
-const referencesVariable = (statements: unknown[], name: string): boolean =>
-  JSON.stringify(statements).includes(
-    `"expressionType":"${ExpressionNodeType.variable}","name":"${name}"`,
-  );
-
 describe("Jupyter converter — IPython magics", () => {
   it("drops a line magic instead of turning it into a phantom variable", () => {
     const statements = statementsOf("%matplotlib inline\nx = 1\ny = x + 2\n");
 
+    const expected = statementsOf("x = 1\ny = x + 2\n");
+
     // the real code survives
-    expect(referencesVariable(statements, "x")).toBe(true);
-    expect(referencesVariable(statements, "y")).toBe(true);
-    // the magic must NOT have leaked in as a `matplotlib` reference
-    expect(referencesVariable(statements, "matplotlib")).toBe(false);
+    expect(statements).toEqual(expected);
   });
 
   it("drops a shell escape line", () => {
     const statements = statementsOf("!pip install numpy\nz = 3\n");
 
-    expect(referencesVariable(statements, "z")).toBe(true);
-    expect(referencesVariable(statements, "pip")).toBe(false);
-    expect(referencesVariable(statements, "numpy")).toBe(false);
+    const expected = statementsOf("z = 3\n");
+
+    expect(statements).toEqual(expected);
   });
 
   it("skips a whole cell that is a cell magic", () => {
     const statements = statementsOf("%%bash\necho hello\nls -la\n");
 
-    expect(statements).toHaveLength(0);
+    const expected = statementsOf("");
+
+    expect(statements).toEqual(expected);
   });
 
   it("keeps a real multi-target import (not a magic)", () => {
     const statements = statementsOf("import os, sys\nx = 1\n");
 
-    const asJson = JSON.stringify(statements);
-    expect(asJson).toContain(AstNodeType.statement);
-    expect(asJson).toContain("@import");
-    expect(referencesVariable(statements, "x")).toBe(true);
+    const expected = statementsOf("import os, sys\nx = 1\n");
+
+    expect(statements).toEqual(expected);
   });
 
   it("keeps a modulo operator that leads a bracketed continuation line", () => {
@@ -88,20 +81,21 @@ describe("Jupyter converter — IPython magics", () => {
     // naive `startsWith("%")` filter drops it, leaving the broken `x = (10`.
     const statements = statementsOf("x = (10\n% 3)\n");
 
-    expect(referencesVariable(statements, "x")).toBe(true);
     // the modulo operation must survive
-    expect(JSON.stringify(statements)).toContain('"operator":"%"');
+    const expected = statementsOf("x = (10 % 3)\n");
+
+    expect(statements).toEqual(expected);
   });
 
   it("keeps a `!=` comparison that leads a continuation line", () => {
     // `!= b` begins the continuation line of `(a != b)`. `!=` is the inequality
-    // operator, not a shell escape. A naive `startsWith("!")` filter drops it,
-    // leaving `x = (a` (recovered as `x = a`) and losing `b` entirely.
+    // operator, not a shell escape.
     const statements = statementsOf("x = (a\n!= b)\n");
 
-    expect(referencesVariable(statements, "a")).toBe(true);
-    expect(referencesVariable(statements, "b")).toBe(true);
-    expect(JSON.stringify(statements)).toContain('"operator":"!="');
+    // the inequality operation must survive
+    const expected = statementsOf("x = (a != b)\n");
+
+    expect(statements).toEqual(expected);
   });
 
   it("strips several line magics and a shell escape interleaved with code in one cell", () => {
@@ -119,15 +113,15 @@ describe("Jupyter converter — IPython magics", () => {
       ].join("\n"),
     );
 
-    // all the real code survives
-    expect(referencesVariable(statements, "np")).toBe(true);
-    expect(referencesVariable(statements, "arr")).toBe(true);
-    expect(referencesVariable(statements, "total")).toBe(true);
-    // none of the magic / shell tokens leak in as phantom variables
-    expect(referencesVariable(statements, "pip")).toBe(false);
-    expect(referencesVariable(statements, "matplotlib")).toBe(false);
-    expect(referencesVariable(statements, "inline")).toBe(false);
-    expect(referencesVariable(statements, "echo")).toBe(false);
+    const expected = statementsOf(
+      [
+        "import numpy as np",
+        "arr = np.array([1, 2, 3])",
+        "total = arr.sum()",
+      ].join("\n"),
+    );
+
+    expect(statements).toEqual(expected);
   });
 
   it("converts the real task-template setup cell (two magics + two imports) correctly", () => {
@@ -142,12 +136,11 @@ describe("Jupyter converter — IPython magics", () => {
       ].join("\n"),
     );
 
-    // both imports are kept
-    expect(JSON.stringify(statements)).toContain("@import");
-    // the two magics leave no phantom variables behind
-    expect(referencesVariable(statements, "pip")).toBe(false);
-    expect(referencesVariable(statements, "matplotlib")).toBe(false);
-    expect(referencesVariable(statements, "inline")).toBe(false);
+    const expected = statementsOf(
+      ["import pandas as pd", "import numpy as np"].join("\n"),
+    );
+
+    expect(statements).toEqual(expected);
   });
 
   it("keeps code lines that sit before, between and after magic lines", () => {
@@ -157,8 +150,10 @@ describe("Jupyter converter — IPython magics", () => {
       ["a = 1", "%time", "b = a + 1", "%reset -f", "c = b + 1"].join("\n"),
     );
 
-    expect(referencesVariable(statements, "a")).toBe(true);
-    expect(referencesVariable(statements, "b")).toBe(true);
-    expect(referencesVariable(statements, "c")).toBe(true);
+    const expected = statementsOf(
+      ["a = 1", "b = a + 1", "c = b + 1"].join("\n"),
+    );
+
+    expect(statements).toEqual(expected);
   });
 });

--- a/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
+++ b/backend/src/ast/converters/jupyter/__tests__/jupyter-magics.spec.ts
@@ -143,6 +143,64 @@ describe("Jupyter converter — IPython magics", () => {
     expect(statements).toEqual(expected);
   });
 
+  describe("cell magics with a Python body", () => {
+    // Per https://ipython.readthedocs.io/en/stable/interactive/magics.html
+    // these cell magics execute the cell body as ordinary Python; only the
+    // magic line itself must be removed, not the whole cell.
+    it.each([
+      "%%capture",
+      "%%debug",
+      "%%prun",
+      "%%pypy",
+      "%%python",
+      "%%python2",
+      "%%python3",
+      "%%time",
+      "%%timeit",
+    ])("keeps the body of a %s cell", (magic) => {
+      const statements = statementsOf(
+        [magic, "a = 1", "b = a + 1", "c = b + 1"].join("\n"),
+      );
+
+      const expected = statementsOf(
+        ["a = 1", "b = a + 1", "c = b + 1"].join("\n"),
+      );
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("keeps the body when the magic line carries arguments", () => {
+      const statements = statementsOf(
+        ["%%timeit -n 100 -r 5", "total = sum(range(10))"].join("\n"),
+      );
+
+      const expected = statementsOf("total = sum(range(10))\n");
+
+      expect(statements).toEqual(expected);
+    });
+
+    it("still strips line magics inside the kept body", () => {
+      const statements = statementsOf(
+        ["%%capture out", "%matplotlib inline", "x = 1"].join("\n"),
+      );
+
+      const expected = statementsOf("x = 1\n");
+
+      expect(statements).toEqual(expected);
+    });
+
+    it.each(["%%bash", "%%html", "%%writefile out.txt", "%%javascript"])(
+      "still skips the whole cell for the non-Python %s magic",
+      (magic) => {
+        const statements = statementsOf(
+          [magic, "a = 1", "b = a + 1"].join("\n"),
+        );
+
+        expect(statements).toHaveLength(0);
+      },
+    );
+  });
+
   it("keeps code lines that sit before, between and after magic lines", () => {
     // Magics need not be at the top of the cell; code interleaved with them is
     // preserved in order.

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -35,6 +35,29 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   const getCellSource = (cell: { source: string | string[] }): string =>
     Array.isArray(cell.source) ? cell.source.join("\n") : cell.source;
 
+  // IPython magics (`%matplotlib inline`, `%pip install ...`) and shell escapes
+  // (`!pip install ...`) are not Python. The parser does not reject them - it
+  // error-recovers, turning e.g. `%matplotlib inline` into a phantom reference
+  // to a variable `matplotlib` that pollutes the structural representation used
+  // for the similarity analysis. Strip them the way Jupyter itself does before
+  // handing a cell to Python: a `%%` cell magic makes the whole cell non-Python
+  // (skip it entirely), and a leading `%` or `!` line is dropped.
+  const isCellMagic = (source: string): boolean =>
+    source
+      .split("\n")
+      .find((line) => line.trim() !== "")
+      ?.trimStart()
+      .startsWith("%%") ?? false;
+
+  const stripLineMagics = (source: string): string =>
+    source
+      .split("\n")
+      .filter((line) => {
+        const trimmed = line.trimStart();
+        return !trimmed.startsWith("%") && !trimmed.startsWith("!");
+      })
+      .join("\n");
+
   const hasExecutableCode = (source: string): boolean =>
     source
       .split("\n")
@@ -42,9 +65,12 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
       .map((line) => line.trim())
       .some((line) => !!line && !line.startsWith("#"));
 
-  const codeCells = input.cells.filter(
-    (c) => c.cell_type === "code" && hasExecutableCode(getCellSource(c)),
-  );
+  const codeCells = input.cells
+    .filter((c) => c.cell_type === "code")
+    // a `%%` cell magic (e.g. %%bash, %%html) is not Python at all
+    .filter((c) => !isCellMagic(getCellSource(c)))
+    .map((c) => ({ ...c, source: stripLineMagics(getCellSource(c)) }))
+    .filter((c) => hasExecutableCode(c.source));
 
   const conversionFunction = match(language)
     .returnType<(input: string, version?: string) => StatementWithFunctions>()

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -89,10 +89,66 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   const isLineMagic = (line: string): boolean => /^\s*%%?[A-Za-z_]/.test(line);
   const isShellEscape = (line: string): boolean => /^\s*!(?!=)/.test(line);
 
+  // Magics whose argument is itself Python that IPython executes: in line mode
+  // (`%timeit expr` times expr) and equally on the first line of their cell
+  // form (`%%timeit x = 5` runs `x = 5` as setup code, `%%prun stmt` appends
+  // stmt to the profiled code). For these, only the magic and its option flags
+  // are removed; the trailing Python payload is kept. Not %capture: its
+  // argument is the name of a variable to bind, not code to run.
+  const pythonPayloadMagics = new Set(["time", "timeit", "prun", "debug"]);
+
+  // Options of the above magics that consume a separate value token
+  // (e.g. `-n 100`, `-s cumulative`); flags like -q or -o stand alone.
+  const valueTakingOptions = new Set([
+    "-n",
+    "-r",
+    "-p",
+    "-l",
+    "-s",
+    "-T",
+    "-D",
+    "-b",
+    "--breakpoint",
+  ]);
+
+  // For a `%name ...` / `%%name ...` line of a payload magic, returns the
+  // Python payload (keeping the line's indentation, so a magic inside an
+  // indented block stays part of it); null if the line carries no payload or
+  // is not a payload magic.
+  const extractPythonPayload = (magicLine: string): string | null => {
+    const match = /^(\s*)%%?([A-Za-z_]\w*)\s*(.*)$/.exec(magicLine);
+
+    if (!match || !pythonPayloadMagics.has(match[2])) {
+      return null;
+    }
+
+    const [, indentation, , argument] = match;
+    let rest = argument;
+
+    for (let option = /^(-\S+)\s*/.exec(rest); option !== null; ) {
+      rest = rest.slice(option[0].length);
+
+      if (valueTakingOptions.has(option[1])) {
+        rest = rest.replace(/^\S+\s*/, "");
+      }
+
+      option = /^(-\S+)\s*/.exec(rest);
+    }
+
+    return rest.trim() === "" ? null : indentation + rest;
+  };
+
   const stripLineMagics = (source: string): string =>
     source
       .split("\n")
-      .filter((line) => !isLineMagic(line) && !isShellEscape(line))
+      .flatMap((line) => {
+        if (!isLineMagic(line) && !isShellEscape(line)) {
+          return [line];
+        }
+
+        const payload = extractPythonPayload(line);
+        return payload === null ? [] : [payload];
+      })
       .join("\n");
 
   const hasExecutableCode = (source: string): boolean =>

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -40,14 +40,42 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   // error-recovers, turning e.g. `%matplotlib inline` into a phantom reference
   // to a variable `matplotlib` that pollutes the structural representation used
   // for the similarity analysis. Strip them the way Jupyter itself does before
-  // handing a cell to Python: a `%%` cell magic makes the whole cell non-Python
-  // (skip it entirely), and a leading line magic or shell escape is dropped.
-  const isCellMagic = (source: string): boolean =>
-    source
+  // handing a cell to Python: a `%%` cell magic replaces the cell's language
+  // (skip the cell entirely) unless it merely wraps a Python body, and a
+  // leading line magic or shell escape is dropped.
+
+  // Cell magics whose body IPython executes as ordinary Python (timed,
+  // profiled, captured, run under a debugger or a separate interpreter); see
+  // https://ipython.readthedocs.io/en/stable/interactive/magics.html. For
+  // these, only the magic line is removed. Every other cell magic (%%bash,
+  // %%html, %%writefile, ...) turns the cell into something that is not
+  // Python, so such cells are skipped wholesale.
+  const pythonBodyCellMagics = new Set([
+    "capture",
+    "debug",
+    "prun",
+    "pypy",
+    "python",
+    "python2",
+    "python3",
+    "time",
+    "timeit",
+  ]);
+
+  const isNonPythonCellMagic = (source: string): boolean => {
+    const firstLine = source
       .split("\n")
       .find((line) => line.trim() !== "")
-      ?.trimStart()
-      .startsWith("%%") ?? false;
+      ?.trimStart();
+
+    if (!firstLine?.startsWith("%%")) {
+      return false;
+    }
+
+    const name = /^%%([A-Za-z_]\w*)/.exec(firstLine)?.[1];
+
+    return name === undefined || !pythonBodyCellMagics.has(name);
+  };
 
   // A line magic (`%name`) or shell escape (`!cmd`) has its sigil immediately
   // followed by the magic/command name. That is what separates it from real
@@ -76,8 +104,10 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
 
   const codeCells = input.cells
     .filter((c) => c.cell_type === "code")
-    // a `%%` cell magic (e.g. %%bash, %%html) is not Python at all
-    .filter((c) => !isCellMagic(getCellSource(c)))
+    // a non-Python `%%` cell magic (e.g. %%bash, %%html) is not Python at all;
+    // a Python-body one (e.g. %%timeit) only loses its magic line via
+    // stripLineMagics below
+    .filter((c) => !isNonPythonCellMagic(getCellSource(c)))
     .map((c) => ({ ...c, source: stripLineMagics(getCellSource(c)) }))
     .filter((c) => hasExecutableCode(c.source));
 

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -49,7 +49,10 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   // https://ipython.readthedocs.io/en/stable/interactive/magics.html. For
   // these, only the magic line is removed. Every other cell magic (%%bash,
   // %%html, %%writefile, ...) turns the cell into something that is not
-  // Python, so such cells are skipped wholesale.
+  // Python, so such cells are skipped wholesale. That deliberately includes
+  // `%%script python` (an alias of %%python): special-casing one argument of
+  // the generic %%script family isn't worth it for code we expect to see in
+  // a classroom, and skipping is the conservative default.
   const pythonBodyCellMagics = new Set([
     "capture",
     "debug",
@@ -84,8 +87,10 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   // recommends wrapping to the start of a continuation line. Matching only the
   // sigil form keeps such continuations from being mistaken for magics. The
   // check is line-local, so a `%name`/`!cmd` line inside a multi-line string is
-  // still dropped - but that only edits a string literal's text, not the code
-  // structure the similarity analysis compares.
+  // still dropped - a documented trade-off: it only edits a string literal's
+  // text, never the code structure the similarity analysis compares, whereas
+  // tracking string state would need a real tokenizer whose own mistakes would
+  // let magics through as phantom variables - a worse failure mode.
   const isLineMagic = (line: string): boolean => /^\s*%%?[A-Za-z_]/.test(line);
   const isShellEscape = (line: string): boolean => /^\s*!(?!=)/.test(line);
 
@@ -95,21 +100,19 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   // stmt to the profiled code). For these, only the magic and its option flags
   // are removed; the trailing Python payload is kept. Not %capture: its
   // argument is the name of a variable to bind, not code to run.
-  const pythonPayloadMagics = new Set(["time", "timeit", "prun", "debug"]);
-
-  // Options of the above magics that consume a separate value token
-  // (e.g. `-n 100`, `-s cumulative`); flags like -q or -o stand alone.
-  const valueTakingOptions = new Set([
-    "-n",
-    "-r",
-    "-p",
-    "-l",
-    "-s",
-    "-T",
-    "-D",
-    "-b",
-    "--breakpoint",
+  // Per magic, the options that consume a separate value token (e.g. `-n 100`,
+  // `-s cumulative`); every other option is a standalone flag. The arity
+  // differs between magics: -r takes a repeat count for %timeit but is a
+  // return-Stats flag for %prun.
+  const pythonPayloadMagics = new Map<string, Set<string>>([
+    ["time", new Set()],
+    ["timeit", new Set(["-n", "-r", "-p"])],
+    ["prun", new Set(["-l", "-s", "-T", "-D"])],
+    ["debug", new Set(["-b", "--breakpoint"])],
   ]);
+
+  // A value token may be shell-quoted to contain spaces (`-T "profile out.txt"`).
+  const optionValue = /^(?:"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\S+)\s*/;
 
   // For a `%name ...` / `%%name ...` line of a payload magic, returns the
   // Python payload (keeping the line's indentation, so a magic inside an
@@ -117,8 +120,9 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   // is not a payload magic.
   const extractPythonPayload = (magicLine: string): string | null => {
     const match = /^(\s*)%%?([A-Za-z_]\w*)\s*(.*)$/.exec(magicLine);
+    const valueTakingOptions = match && pythonPayloadMagics.get(match[2]);
 
-    if (!match || !pythonPayloadMagics.has(match[2])) {
+    if (!match || !valueTakingOptions) {
       return null;
     }
 
@@ -129,7 +133,7 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
       rest = rest.slice(option[0].length);
 
       if (valueTakingOptions.has(option[1])) {
-        rest = rest.replace(/^\S+\s*/, "");
+        rest = rest.replace(optionValue, "");
       }
 
       option = /^(-\S+)\s*/.exec(rest);

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -41,7 +41,7 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   // to a variable `matplotlib` that pollutes the structural representation used
   // for the similarity analysis. Strip them the way Jupyter itself does before
   // handing a cell to Python: a `%%` cell magic makes the whole cell non-Python
-  // (skip it entirely), and a leading `%` or `!` line is dropped.
+  // (skip it entirely), and a leading line magic or shell escape is dropped.
   const isCellMagic = (source: string): boolean =>
     source
       .split("\n")
@@ -49,13 +49,22 @@ export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
       ?.trimStart()
       .startsWith("%%") ?? false;
 
+  // A line magic (`%name`) or shell escape (`!cmd`) has its sigil immediately
+  // followed by the magic/command name. That is what separates it from real
+  // Python that merely begins a line with the same character: the modulo
+  // operator (`% 3`) or the inequality operator (`!= b`), which PEP 8 even
+  // recommends wrapping to the start of a continuation line. Matching only the
+  // sigil form keeps such continuations from being mistaken for magics. The
+  // check is line-local, so a `%name`/`!cmd` line inside a multi-line string is
+  // still dropped - but that only edits a string literal's text, not the code
+  // structure the similarity analysis compares.
+  const isLineMagic = (line: string): boolean => /^\s*%%?[A-Za-z_]/.test(line);
+  const isShellEscape = (line: string): boolean => /^\s*!(?!=)/.test(line);
+
   const stripLineMagics = (source: string): string =>
     source
       .split("\n")
-      .filter((line) => {
-        const trimmed = line.trimStart();
-        return !trimmed.startsWith("%") && !trimmed.startsWith("!");
-      })
+      .filter((line) => !isLineMagic(line) && !isShellEscape(line))
       .join("\n");
 
   const hasExecutableCode = (source: string): boolean =>


### PR DESCRIPTION
The Jupyter-to-AST converter fed each code cell straight to the Python parser. IPython magics (%matplotlib inline, %pip install ...) and shell escapes (!pip install ...) are not Python, and the parser does not reject them - it error-recovers, turning `%matplotlib inline` into a phantom reference to a variable named `matplotlib`. That phantom node then enters the structural representation the similarity analysis runs on, so every notebook carrying the same magic gains the same spurious node and the teacher's analysis is computed against artefacts that are not the student's code. Magics are ubiquitous in teaching notebooks, so this hits common submissions, not edge cases.

Strip them the way Jupyter itself does before compiling a cell: a `%%` cell magic (%%bash, %%html, ...) makes the whole cell non-Python, so skip it; a leading `%` or `!` line is dropped. Real Python is untouched - including multi-target imports like `import os, sys`, which parse fine and were never the problem.

Covered by a jest unit test of the converter (a line magic is dropped instead of becoming a phantom variable, a shell escape is dropped, a `%%` cell is skipped entirely, and a real multi-import is kept).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strip IPython magics and shell escapes from Jupyter code cells before AST conversion to remove phantom identifiers and fix similarity matches (CRT-447). Keep real Python intact, including operator-led continuations and the bodies/payloads of Python-executing magics; skip only non‑Python magics.

- **Bug Fixes**
  - Skip only non-Python `%%` magics (e.g., `%%bash`, `%%html`); for Python-body magics (`%%time*`, `%%prun`, `%%capture`, `%%debug`, `%%python*`), drop the `%%name` line and keep the body; keep first-line setup for `%%timeit/%%prun`.
  - Strip `%name`/`%%name` and `!cmd` lines, but for payload line magics (`%time`, `%timeit`, `%prun`, `%debug`) remove only the magic and its options with per‑magic arity and shell‑quoted values; keep the trailing Python and indentation, and drop the line if there’s no payload.
  - Support cells mixing magics and code (including the task-template); tests cover interleaving, quoted option values, indented magics, shell escapes, `%`/`!=` continuations, and document two conservative limits: magic-looking lines inside multi-line strings are stripped; `%%script python` cells are skipped.

<sup>Written for commit 85ca215783addb8467c6f409eacc2f51c0dc3518. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

