### PR TITLE
[CRT-448] Show a friendly message instead of the raw fetch error

### DIFF
--- a/e2e/tests/robustness/friendly-fetch-error.spec.ts
+++ b/e2e/tests/robustness/friendly-fetch-error.spec.ts
@@ -1,0 +1,62 @@
+import { useAdminUser } from "../../authentication-helpers";
+import { expect, test } from "../../helpers";
+
+// When a data request fails because the backend cannot be reached, the app must
+// show a friendly, translated message rather than the raw browser error string
+// ("Failed to fetch" / "NetworkError ..."), while keeping the technical detail
+// in the console for developers.
+//
+// MultiSwrContent renders a failed request through <ErrorMessage error={error}>.
+// This aborts every data API call on the class-list page and asserts that the
+// predefined connectivity message is shown, that the underlying error is logged
+// to the console, and that the raw browser string never reaches the user.
+const friendlyMessage =
+  "The server could not be reached. Please check your internet connection and try again.";
+
+test.describe("data-load failure shows a friendly message", () => {
+  test.beforeEach(async ({ context }) => {
+    await useAdminUser(context);
+  });
+
+  test("shows a friendly message and logs the technical error", async ({
+    page,
+    baseURL,
+  }) => {
+    // capture console errors before navigating so the ErrorMessage log is seen
+    const consoleErrors: string[] = [];
+    page.on("console", (message) => {
+      if (message.type() === "error") {
+        consoleErrors.push(message.text());
+      }
+    });
+
+    // fail every data API call (auth state is already established via the admin
+    // user context, so the page loads but its data requests fail)
+    await page.route("**/api/v0/**", (route) => route.abort("failed"));
+
+    await page.goto(`${baseURL}/class`);
+
+    // the predefined, translated connectivity message is shown to the user
+    // (first(): the page may render one ErrorMessage per failed data source)
+    await expect(
+      page.getByText(friendlyMessage).first(),
+      "the friendly connectivity message is not shown",
+    ).toBeVisible();
+
+    // the underlying technical error is logged for developers (ErrorMessage
+    // logs `[ErrorMessage] <name>: <message>`)
+    expect(
+      consoleErrors.some((line) => line.includes("[ErrorMessage]")),
+      "the underlying error was not logged to the console",
+    ).toBe(true);
+
+    // the raw browser fetch-failure strings must never be shown to the user
+    const bodyText = (await page.locator("body").innerText()).toLowerCase();
+    expect(
+      bodyText,
+      "the raw browser fetch error is shown to the user instead of a friendly message",
+    ).not.toContain("failed to fetch");
+    expect(bodyText).not.toContain("networkerror");
+    expect(bodyText).not.toContain("load failed");
+  });
+});

--- a/frontend/content/compiled-locales/en.json
+++ b/frontend/content/compiled-locales/en.json
@@ -965,6 +965,18 @@
       "value": "Failed to load the app. Please try again later."
     }
   ],
+  "ErrorMessage.genericError": [
+    {
+      "type": 0,
+      "value": "An error occurred while loading this content. Please try again later."
+    }
+  ],
+  "ErrorMessage.networkError": [
+    {
+      "type": 0,
+      "value": "The server could not be reached. Please check your internet connection and try again."
+    }
+  ],
   "ExpressionCriterionFilterForm.count": [
     {
       "type": 0,

--- a/frontend/content/compiled-locales/fr.json
+++ b/frontend/content/compiled-locales/fr.json
@@ -1428,6 +1428,18 @@
       "value": "Échec du chargement de l’application. Veuillez réessayer plus tard."
     }
   ],
+  "ErrorMessage.genericError": [
+    {
+      "type": 0,
+      "value": "Une erreur est survenue lors du chargement de ce contenu. Veuillez réessayer plus tard."
+    }
+  ],
+  "ErrorMessage.networkError": [
+    {
+      "type": 0,
+      "value": "Impossible de contacter le serveur. Veuillez vérifier votre connexion internet et réessayer."
+    }
+  ],
   "ExpressionCriterionFilterForm.count": [
     {
       "type": 0,

--- a/frontend/content/locales/en.json
+++ b/frontend/content/locales/en.json
@@ -455,6 +455,12 @@
   "EmbeddedApp.errorMessage": {
     "message": "Failed to load the app. Please try again later."
   },
+  "ErrorMessage.genericError": {
+    "message": "An error occurred while loading this content. Please try again later."
+  },
+  "ErrorMessage.networkError": {
+    "message": "The server could not be reached. Please check your internet connection and try again."
+  },
   "ExpressionCriterionFilterForm.count": {
     "message": "Number of expressions"
   },

--- a/frontend/content/locales/fr.json
+++ b/frontend/content/locales/fr.json
@@ -695,6 +695,12 @@
   "EmbeddedApp.errorMessage": {
     "message": "Échec du chargement de l’application. Veuillez réessayer plus tard."
   },
+  "ErrorMessage.genericError": {
+    "message": "Une erreur est survenue lors du chargement de ce contenu. Veuillez réessayer plus tard."
+  },
+  "ErrorMessage.networkError": {
+    "message": "Impossible de contacter le serveur. Veuillez vérifier votre connexion internet et réessayer."
+  },
   "ExpressionCriterionFilterForm.count": {
     "message": "Nombre d'expressions"
   },

--- a/frontend/src/api/fetch.ts
+++ b/frontend/src/api/fetch.ts
@@ -1,12 +1,25 @@
-import { ApiError, ConflictError } from "@/errors/api";
+import { ApiError, ConflictError, NetworkError } from "@/errors/api";
 import { authenticationStateKey, backendHostName } from "@/utilities/constants";
+
+/**
+ * `fetch` only rejects when the request never made it to the server. Translate
+ * that into our own error type so callers never have to deal with the raw,
+ * browser-specific failure message.
+ */
+const sendRequest = async (request: Request): Promise<Response> => {
+  try {
+    return await fetch(request);
+  } catch (error) {
+    throw new NetworkError(error);
+  }
+};
 
 export const fetchApi = async <T>(
   url: string,
   options: RequestInit,
 ): Promise<T> => {
   const request = new Request(`${backendHostName}${url}`, options);
-  const response = await fetch(request);
+  const response = await sendRequest(request);
 
   if (response.status === 401) {
     // properly sign out the user
@@ -52,7 +65,7 @@ export const fetchFile = async (
   options: RequestInit,
 ): Promise<Blob> => {
   const request = new Request(`${backendHostName}${url}`, options);
-  const response = await fetch(request);
+  const response = await sendRequest(request);
 
   if (response.status !== 200) {
     throw new Error("Could not fetch file");

--- a/frontend/src/components/ErrorMessage.stories.tsx
+++ b/frontend/src/components/ErrorMessage.stories.tsx
@@ -1,3 +1,4 @@
+import { NetworkError } from "@/errors/api";
 import ErrorMessage from "./ErrorMessage";
 
 type Args = Parameters<typeof ErrorMessage>[0];
@@ -10,5 +11,11 @@ export default {
 export const Default = {
   args: {
     error: new Error("An error occurred"),
+  } as Args,
+};
+
+export const WhenTheServerIsUnreachable = {
+  args: {
+    error: new NetworkError(new TypeError("Failed to fetch")),
   } as Args,
 };

--- a/frontend/src/components/ErrorMessage.tsx
+++ b/frontend/src/components/ErrorMessage.tsx
@@ -1,11 +1,43 @@
 import styled from "@emotion/styled";
+import { useEffect } from "react";
+import { defineMessages, FormattedMessage } from "react-intl";
+import { NetworkError } from "@/errors/api";
+
+const logModule = "[ErrorMessage]";
+
+const messages = defineMessages({
+  networkError: {
+    id: "ErrorMessage.networkError",
+    defaultMessage:
+      "The server could not be reached. Please check your internet connection and try again.",
+  },
+  genericError: {
+    id: "ErrorMessage.genericError",
+    defaultMessage:
+      "An error occurred while loading this content. Please try again later.",
+  },
+});
 
 const ErrorMessageWrapper = styled.div`
   color: var(--error-color);
 `;
 
 const ErrorMessage = ({ error }: { error: Error }) => {
-  return <ErrorMessageWrapper>{error.message}</ErrorMessageWrapper>;
+  // The underlying message is technical and untranslated, so it is kept for
+  // developers in the console rather than being shown to the user.
+  useEffect(() => {
+    console.error(`${logModule} ${error.name}: ${error.message}`, error);
+  }, [error]);
+
+  return (
+    <ErrorMessageWrapper>
+      <FormattedMessage
+        {...(error instanceof NetworkError
+          ? messages.networkError
+          : messages.genericError)}
+      />
+    </ErrorMessageWrapper>
+  );
 };
 
 export default ErrorMessage;

--- a/frontend/src/components/__tests__/jest/ErrorMessage.spec.tsx
+++ b/frontend/src/components/__tests__/jest/ErrorMessage.spec.tsx
@@ -1,0 +1,62 @@
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/__tests__/helpers/render-with-providers";
+import ErrorMessage from "@/components/ErrorMessage";
+import { ApiError, NetworkError } from "@/errors/api";
+
+describe("ErrorMessage", () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it("shows a connectivity message when the backend is unreachable", () => {
+    renderWithProviders(
+      <ErrorMessage
+        error={new NetworkError(new TypeError("Failed to fetch"))}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "The server could not be reached. Please check your internet connection and try again.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("shows a generic message for errors answered by the server", () => {
+    renderWithProviders(
+      <ErrorMessage error={new ApiError(500, "Internal server error")} />,
+    );
+
+    expect(
+      screen.getByText(
+        "An error occurred while loading this content. Please try again later.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("never renders the raw error message", () => {
+    renderWithProviders(
+      <ErrorMessage error={new TypeError("Failed to fetch")} />,
+    );
+
+    expect(screen.queryByText(/failed to fetch/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps the technical detail available to developers in the console", () => {
+    const error = new NetworkError(new TypeError("Failed to fetch"));
+
+    renderWithProviders(<ErrorMessage error={error} />);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      "[ErrorMessage] NetworkError: The backend could not be reached",
+      error,
+    );
+  });
+});

--- a/frontend/src/components/__tests__/jest/MultiSwrContent.spec.tsx
+++ b/frontend/src/components/__tests__/jest/MultiSwrContent.spec.tsx
@@ -3,6 +3,14 @@ import { screen } from "@testing-library/react";
 import { renderWithProviders } from "@/__tests__/helpers/render-with-providers";
 import MultiSwrContent from "@/components/MultiSwrContent";
 
+// ErrorMessage deliberately hides technical error messages from users. Mock it
+// here because these tests verify which source error MultiSwrContent forwards,
+// not the translated presentation covered by ErrorMessage's own tests.
+jest.mock("@/components/ErrorMessage", () => ({
+  __esModule: true,
+  default: ({ error }: { error: Error }) => <div>{error.message}</div>,
+}));
+
 // MultiSwrContent renders several SWR sources at once. When one of them fails
 // with no cached data it must surface the error - otherwise the page renders
 // nothing at all and the user (a teacher looking at student data) cannot tell

--- a/frontend/src/errors/api.ts
+++ b/frontend/src/errors/api.ts
@@ -14,6 +14,13 @@ export class ApiError extends Error {
   }
 }
 
+export class NetworkError extends Error {
+  constructor(cause: unknown) {
+    super("The backend could not be reached", { cause });
+    this.name = "NetworkError";
+  }
+}
+
 export class ConflictError extends ApiError {
   constructor(message: string = "Conflict", errorCode?: string) {
     super(409, message, errorCode);


### PR DESCRIPTION
When a data request failed because the backend could not be reached, MultiSwrContent rendered the failure through ErrorMessage, which was just `{error.message}` - so the raw, untranslated browser string ("Failed to fetch", "NetworkError ...", "Load failed") was shown directly to teachers and to French users, on every data-loading page.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a friendly, translated message instead of raw browser fetch errors when the backend is unreachable. Adds `NetworkError`, updates `ErrorMessage`, and adjusts the fetch layer to separate network vs server errors (CRT-448).

- **Bug Fixes**
  - Introduced `NetworkError` in `@/errors/api`; rejected `fetch` calls are wrapped via a shared `sendRequest` used by `fetchApi` and `fetchFile`.
  - `ErrorMessage` now renders a connectivity or generic i18n message and logs details to the console.
  - Added EN/FR strings for `ErrorMessage.networkError` and `ErrorMessage.genericError`.
  - Tests: Playwright e2e for connectivity failures, Jest unit tests for `ErrorMessage`, and `MultiSwrContent` tests mocking `ErrorMessage` to assert forwarded errors.

<sup>Written for commit abab31e14360f809ef487538766d03f5d45f607b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

