### PR TITLE
[CRT-449] Show load errors on later SWR sources instead of a blank panel

### DIFF
--- a/frontend/src/components/MultiSwrContent.tsx
+++ b/frontend/src/components/MultiSwrContent.tsx
@@ -31,8 +31,14 @@ const MultiSwrContent = <TData extends readonly unknown[] | []>({
     (error, index) => error !== undefined && !isLoading[index],
   );
 
-  const nonLoadingErrorsWithoutStaleData = nonLoadingErrors.filter(
-    (_error, index) => data[index] === undefined,
+  // Derive this from the original arrays, not from nonLoadingErrors: filtering
+  // there produces a compacted array whose indices no longer line up with data
+  // and isLoading, so an error on a later source (after an earlier one has
+  // resolved) would be matched against the wrong data slot and silently
+  // dropped - leaving the page blank instead of showing the error.
+  const nonLoadingErrorsWithoutStaleData = errors.filter(
+    (error, index) =>
+      error !== undefined && !isLoading[index] && data[index] === undefined,
   );
 
   const renderedChildren = useMemo(() => {

--- a/frontend/src/components/__tests__/jest/MultiSwrContent.spec.tsx
+++ b/frontend/src/components/__tests__/jest/MultiSwrContent.spec.tsx
@@ -1,0 +1,75 @@
+import "@testing-library/jest-dom";
+import { screen } from "@testing-library/react";
+import { renderWithProviders } from "@/__tests__/helpers/render-with-providers";
+import MultiSwrContent from "@/components/MultiSwrContent";
+
+// MultiSwrContent renders several SWR sources at once. When one of them fails
+// with no cached data it must surface the error - otherwise the page renders
+// nothing at all and the user (a teacher looking at student data) cannot tell
+// "there is no data" from "the data failed to load".
+describe("MultiSwrContent", () => {
+  let consoleError: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleError = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  const renderChild = (): React.ReactNode => <div>the loaded content</div>;
+
+  it("shows the error when the FIRST source fails", () => {
+    renderWithProviders(
+      <MultiSwrContent
+        data={[undefined, "second"]}
+        isLoading={[false, false]}
+        errors={[new Error("first source failed"), undefined]}
+      >
+        {renderChild}
+      </MultiSwrContent>,
+    );
+
+    expect(screen.getByText("first source failed")).toBeInTheDocument();
+    expect(screen.queryByText("the loaded content")).not.toBeInTheDocument();
+  });
+
+  // The regression: an error on a LATER source, once an earlier source has
+  // already resolved, was matched against the wrong data slot (the compacted
+  // error array was indexed into the original data array), so the error was
+  // dropped and the component rendered null - a blank panel. This is the exact
+  // shape of the teacher progress view: data={[klass, session, solutions]},
+  // where klass and session resolve but the student solutions fail.
+  it("shows the error when a LATER source fails after earlier ones resolved", () => {
+    renderWithProviders(
+      <MultiSwrContent
+        data={["klass", "session", undefined]}
+        isLoading={[false, false, false]}
+        errors={[undefined, undefined, new Error("solutions failed to load")]}
+      >
+        {renderChild}
+      </MultiSwrContent>,
+    );
+
+    expect(screen.getByText("solutions failed to load")).toBeInTheDocument();
+    expect(screen.queryByText("the loaded content")).not.toBeInTheDocument();
+  });
+
+  // Guard the intended behaviour: when the failed source still has stale cached
+  // data, the error is deliberately suppressed and the children render.
+  it("keeps rendering children when the failed source has stale data", () => {
+    renderWithProviders(
+      <MultiSwrContent
+        data={["klass", "stale session"]}
+        isLoading={[false, false]}
+        errors={[undefined, new Error("refresh failed")]}
+      >
+        {renderChild}
+      </MultiSwrContent>,
+    );
+
+    expect(screen.getByText("the loaded content")).toBeInTheDocument();
+    expect(screen.queryByText("refresh failed")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/__tests__/jest/MultiSwrContent.spec.tsx
+++ b/frontend/src/components/__tests__/jest/MultiSwrContent.spec.tsx
@@ -72,4 +72,24 @@ describe("MultiSwrContent", () => {
     expect(screen.getByText("the loaded content")).toBeInTheDocument();
     expect(screen.queryByText("refresh failed")).not.toBeInTheDocument();
   });
+
+  it("keeps showing the spinner while the failed source is still loading", () => {
+    const { container } = renderWithProviders(
+      <MultiSwrContent
+        data={["klass", undefined]}
+        isLoading={[false, true]}
+        errors={[undefined, new Error("request still retrying")]}
+      >
+        {renderChild}
+      </MultiSwrContent>,
+    );
+
+    expect(
+      screen.queryByText("request still retrying"),
+    ).not.toBeInTheDocument();
+
+    expect(screen.queryByText("the loaded content")).not.toBeInTheDocument();
+
+    expect(container.querySelector(".p-progress-spinner")).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show load errors from later SWR sources in `MultiSwrContent` instead of rendering a blank panel. Fixes CRT-449 and restores visible errors in teacher progress and analysis views.

- **Bug Fixes**
  - Compute “non-loading errors without stale data” from the original `errors` array to keep indices aligned with `data` and `isLoading`.
  - Added Jest tests for first-source failure, later-source failure regression, stale-data suppression, and spinner display while the failing source is still loading.

<sup>Written for commit 2de6ddfcddd9222173856228c34390109601e393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

