### PR TITLE
[CRT-451] Surface an error when sign-in cannot be started

### DIFF
--- a/frontend/src/components/authentication/UserSignIn.tsx
+++ b/frontend/src/components/authentication/UserSignIn.tsx
@@ -15,6 +15,7 @@ import {
   UserType,
 } from "@/api/collimator/generated/models";
 import { TextComponent as Text } from "@/components/Text";
+import { getSafeInternalRedirectPath } from "@/utilities/authentication/safe-redirect";
 import UserSignInForm, { UserSignInFormValues } from "./UserSignInForm";
 
 const logModule = "[UserSignIn]";
@@ -220,7 +221,7 @@ const UserSignIn = ({
         keyPairId,
       });
 
-      await router.replace(redirectPath);
+      await router.replace(getSafeInternalRedirectPath(redirectPath));
     },
     [
       router,

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -9,6 +9,7 @@ import PageHeading from "@/components/PageHeading";
 import LoginCard from "@/components/login/LoginCard";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
+import { getSafeInternalRedirectPath } from "@/utilities/authentication/safe-redirect";
 
 const messages = defineMessages({
   title: {
@@ -57,9 +58,7 @@ const LoginPage = () => {
       // on success this navigates away, so the promise only rejects when the
       // redirect could not be started (e.g. OIDC discovery failed)
       await redirectToOpenIdConnectProvider(
-        // only redirect to the specified URI if it starts with a `/`
-        // this is to prevent open redirects
-        redirectUri?.startsWith(`/`) ? redirectUri : `/`,
+        getSafeInternalRedirectPath(redirectUri),
         registrationToken,
         false,
       );

--- a/frontend/src/pages/login/index.tsx
+++ b/frontend/src/pages/login/index.tsx
@@ -1,8 +1,9 @@
 import { useRouter } from "next/router";
 import { useCallback } from "react";
-import { defineMessages, FormattedMessage } from "react-intl";
+import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import { Center, Container } from "@chakra-ui/react";
 import Header from "@/components/header/Header";
+import { toaster } from "@/components/Toaster";
 import { redirectToOpenIdConnectProvider } from "@/utilities/authentication/openid-connect";
 import PageHeading from "@/components/PageHeading";
 import LoginCard from "@/components/login/LoginCard";
@@ -35,6 +36,11 @@ const messages = defineMessages({
     id: "LoginPage.authenticate.microsoft",
     defaultMessage: "Authenticate using Microsoft",
   },
+  authenticationError: {
+    id: "LoginPage.authenticate.error",
+    defaultMessage:
+      "Sign-in could not be started. Please check your connection and try again.",
+  },
 });
 
 const LoginPage = () => {
@@ -44,15 +50,29 @@ const LoginPage = () => {
     registrationToken?: string;
   };
 
-  const onAuthenticateWithMicrosoft = useCallback(() => {
-    redirectToOpenIdConnectProvider(
-      // only redirect to the specified URI if it starts with a `/`
-      // this is to prevent open redirects
-      redirectUri?.startsWith(`/`) ? redirectUri : `/`,
-      registrationToken,
-      false,
-    );
-  }, [redirectUri, registrationToken]);
+  const intl = useIntl();
+
+  const onAuthenticateWithMicrosoft = useCallback(async () => {
+    try {
+      // on success this navigates away, so the promise only rejects when the
+      // redirect could not be started (e.g. OIDC discovery failed)
+      await redirectToOpenIdConnectProvider(
+        // only redirect to the specified URI if it starts with a `/`
+        // this is to prevent open redirects
+        redirectUri?.startsWith(`/`) ? redirectUri : `/`,
+        registrationToken,
+        false,
+      );
+    } catch (error) {
+      // without this the rejection is unhandled and the user sees nothing
+      // happen after clicking the button
+      console.error("[LoginPage] Could not start authentication", error);
+      toaster.error({
+        id: "login-authentication-error",
+        title: intl.formatMessage(messages.authenticationError),
+      });
+    }
+  }, [redirectUri, registrationToken, intl]);
 
   return (
     <MaxScreenHeight>

--- a/frontend/src/pages/login/oidc-redirect.tsx
+++ b/frontend/src/pages/login/oidc-redirect.tsx
@@ -20,6 +20,7 @@ import UserSignIn from "@/components/authentication/UserSignIn";
 import PageHeading from "@/components/PageHeading";
 import MaxScreenHeight from "@/components/layout/MaxScreenHeight";
 import PageFooter from "@/components/PageFooter";
+import { getSafeInternalRedirectPath } from "@/utilities/authentication/safe-redirect";
 
 const messages = defineMessages({
   title: {
@@ -106,7 +107,7 @@ const OpenIdConnectRedirect = () => {
               name,
             });
 
-            await router.replace(redirectPath);
+            await router.replace(getSafeInternalRedirectPath(redirectPath));
             return;
           }
           // this is the cause of slightly increased risk of the student's identity being tracked
@@ -121,12 +122,18 @@ const OpenIdConnectRedirect = () => {
             registrationToken,
           });
 
-          setUserSignInState({ authResponse, idToken, redirectPath });
+          setUserSignInState({
+            authResponse,
+            idToken,
+            redirectPath: getSafeInternalRedirectPath(redirectPath),
+          });
         },
       )
       .catch((e) => {
         if (e instanceof AuthenticationError) {
-          setErrorRedirectPath(e.redirectPath);
+          setErrorRedirectPath(
+            getSafeInternalRedirectPath(e.redirectPath, "/login"),
+          );
         }
 
         console.error(`${logModule} Authentication failed`, e);

--- a/frontend/src/utilities/authentication/__tests__/jest/safe-redirect.spec.ts
+++ b/frontend/src/utilities/authentication/__tests__/jest/safe-redirect.spec.ts
@@ -1,0 +1,51 @@
+import { getSafeInternalRedirectPath } from "@/utilities/authentication/safe-redirect";
+
+describe("getSafeInternalRedirectPath", () => {
+  describe("accepts safe root-relative paths unchanged", () => {
+    it.each([
+      "/",
+      "/dashboard",
+      "/class/5/session/3/task/7",
+      "/dashboard?tab=classes&sort=name",
+      "/path#section",
+      "/search?q=%20quoted%20space",
+    ])("%p", (path) => {
+      expect(getSafeInternalRedirectPath(path)).toBe(path);
+    });
+  });
+
+  describe("rejects open-redirect attempts", () => {
+    it.each([
+      "//evil.com",
+      "///evil.com",
+      "https://evil.com",
+      "http://evil.com",
+      "javascript:alert(1)",
+      "/\\evil.com",
+      "\\\\evil.com",
+      // CR/LF/TAB tricks: pass a naive startsWith("//") check, but the browser
+      // strips the control char while parsing and collapses to "//evil.com".
+      "/%0A//evil.com",
+      "/%0d//evil.com",
+      "/%09//evil.com",
+      "/\t//evil.com",
+      "/\n//evil.com",
+    ])("%p -> fallback", (path) => {
+      expect(getSafeInternalRedirectPath(path)).toBe("/");
+    });
+  });
+
+  it("rejects malformed percent-encoding", () => {
+    expect(getSafeInternalRedirectPath("/%zz")).toBe("/");
+  });
+
+  it("rejects non-string input", () => {
+    expect(getSafeInternalRedirectPath(undefined)).toBe("/");
+    expect(getSafeInternalRedirectPath(null)).toBe("/");
+    expect(getSafeInternalRedirectPath(42)).toBe("/");
+  });
+
+  it("honours a custom fallback", () => {
+    expect(getSafeInternalRedirectPath("//evil.com", "/login")).toBe("/login");
+  });
+});

--- a/frontend/src/utilities/authentication/openid-connect.ts
+++ b/frontend/src/utilities/authentication/openid-connect.ts
@@ -6,6 +6,7 @@ import {
   openIdConnectMicrosoftClientId,
   openIdConnectMicrosoftServer,
 } from "../constants";
+import { getSafeInternalRedirectPath } from "./safe-redirect";
 
 interface OpenIdConnectTemporaryState {
   codeVerifier: string;
@@ -105,7 +106,7 @@ export const redirectToOpenIdConnectProvider = async (
     codeVerifier,
     nonce,
     isStudent,
-    redirectPath,
+    redirectPath: getSafeInternalRedirectPath(redirectPath),
     registrationToken,
   };
 

--- a/frontend/src/utilities/authentication/safe-redirect.ts
+++ b/frontend/src/utilities/authentication/safe-redirect.ts
@@ -1,16 +1,68 @@
 const defaultRedirectPath = "/";
 
+// True if the string contains a C0 (0x00-0x1F) or C1/DEL (0x7F-0x9F) control
+// character. Browsers strip these (notably CR, LF, TAB) while parsing a URL.
+const hasControlCharacter = (value: string): boolean => {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i);
+    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Returns `redirectPath` only when it is a safe, same-origin, root-relative
+ * path; otherwise returns `fallback`. Guards against open redirects.
+ *
+ * Following OWASP guidance, this does not rely on string-matching alone: it
+ * also rejects control characters (literal or percent-encoded) and validates
+ * that the path resolves to the current origin. A payload like `/%0A//evil.com`
+ * passes a naive `startsWith("//")` check, yet the browser strips the decoded
+ * newline while parsing and collapses it into a protocol-relative external URL.
+ */
 export const getSafeInternalRedirectPath = (
   redirectPath: unknown,
   fallback = defaultRedirectPath,
 ): string => {
+  if (typeof redirectPath !== "string") {
+    return fallback;
+  }
+
+  // Must be a root-relative path. Reject protocol-relative ("//host") and
+  // backslash forms ("\\host", "/\\host") that browsers treat as a network-path
+  // reference to an external host.
   if (
-    typeof redirectPath !== "string" ||
     !redirectPath.startsWith("/") ||
     redirectPath.startsWith("//") ||
     redirectPath.includes("\\")
   ) {
     return fallback;
+  }
+
+  // Reject control characters, whether literal or percent-encoded. Decode
+  // first so that e.g. "/%0A//evil.com" is caught by the decoded newline.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(redirectPath);
+  } catch {
+    return fallback; // malformed percent-encoding
+  }
+  if (hasControlCharacter(decoded)) {
+    return fallback;
+  }
+
+  // Defence in depth: resolve against a fixed origin and require the result to
+  // stay on it. Any absolute, protocol-relative or scheme-bearing URL resolves
+  // to a different origin and is rejected.
+  try {
+    const base = "https://collimator.invalid";
+    if (new URL(redirectPath, base).origin !== base) {
+      return fallback;
+    }
+  } catch {
+    return fallback; // not parseable as a URL
   }
 
   return redirectPath;

--- a/frontend/src/utilities/authentication/safe-redirect.ts
+++ b/frontend/src/utilities/authentication/safe-redirect.ts
@@ -1,26 +1,22 @@
 const defaultRedirectPath = "/";
 
-// True if the string contains a C0 (0x00-0x1F) or C1/DEL (0x7F-0x9F) control
-// character. Browsers strip these (notably CR, LF, TAB) while parsing a URL.
-const hasControlCharacter = (value: string): boolean => {
-  for (let i = 0; i < value.length; i++) {
-    const code = value.charCodeAt(i);
-    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
-      return true;
-    }
-  }
-  return false;
-};
+// Synthetic origin used only to resolve the (relative) redirect path. A path
+// that resolves to any other origin is not same-origin and gets rejected.
+const sameOriginBase = "https://collimator.invalid";
+
+// Any Unicode control character (C0, DEL and C1 — includes CR, LF and TAB).
+const controlCharacter = /\p{Cc}/u;
 
 /**
- * Returns `redirectPath` only when it is a safe, same-origin, root-relative
- * path; otherwise returns `fallback`. Guards against open redirects.
+ * Returns `redirectPath` when it is a safe, same-origin path; otherwise returns
+ * `fallback`. Guards against open redirects.
  *
- * Following OWASP guidance, this does not rely on string-matching alone: it
- * also rejects control characters (literal or percent-encoded) and validates
- * that the path resolves to the current origin. A payload like `/%0A//evil.com`
- * passes a naive `startsWith("//")` check, yet the browser strips the decoded
- * newline while parsing and collapses it into a protocol-relative external URL.
+ * Per OWASP, this validates the parsed URL rather than string-matching: an
+ * absolute URL, a protocol-relative `//host`, a backslash `\\host` or a `scheme:`
+ * all resolve to a different origin than `sameOriginBase` and are rejected. The
+ * only manual guard is for control characters, which `new URL` silently strips:
+ * `/%0A//evil.com` stays same-origin above, yet the browser collapses it into a
+ * protocol-relative jump once it decodes the newline.
  */
 export const getSafeInternalRedirectPath = (
   redirectPath: unknown,
@@ -30,39 +26,16 @@ export const getSafeInternalRedirectPath = (
     return fallback;
   }
 
-  // Must be a root-relative path. Reject protocol-relative ("//host") and
-  // backslash forms ("\\host", "/\\host") that browsers treat as a network-path
-  // reference to an external host.
-  if (
-    !redirectPath.startsWith("/") ||
-    redirectPath.startsWith("//") ||
-    redirectPath.includes("\\")
-  ) {
-    return fallback;
-  }
-
-  // Reject control characters, whether literal or percent-encoded. Decode
-  // first so that e.g. "/%0A//evil.com" is caught by the decoded newline.
-  let decoded: string;
   try {
-    decoded = decodeURIComponent(redirectPath);
-  } catch {
-    return fallback; // malformed percent-encoding
-  }
-  if (hasControlCharacter(decoded)) {
-    return fallback;
-  }
-
-  // Defence in depth: resolve against a fixed origin and require the result to
-  // stay on it. Any absolute, protocol-relative or scheme-bearing URL resolves
-  // to a different origin and is rejected.
-  try {
-    const base = "https://collimator.invalid";
-    if (new URL(redirectPath, base).origin !== base) {
+    if (new URL(redirectPath, sameOriginBase).origin !== sameOriginBase) {
+      return fallback;
+    }
+    if (controlCharacter.test(decodeURIComponent(redirectPath))) {
       return fallback;
     }
   } catch {
-    return fallback; // not parseable as a URL
+    // Unparseable URL reference or malformed percent-encoding.
+    return fallback;
   }
 
   return redirectPath;

--- a/frontend/src/utilities/authentication/safe-redirect.ts
+++ b/frontend/src/utilities/authentication/safe-redirect.ts
@@ -1,0 +1,17 @@
+const defaultRedirectPath = "/";
+
+export const getSafeInternalRedirectPath = (
+  redirectPath: unknown,
+  fallback = defaultRedirectPath,
+): string => {
+  if (
+    typeof redirectPath !== "string" ||
+    !redirectPath.startsWith("/") ||
+    redirectPath.startsWith("//") ||
+    redirectPath.includes("\\")
+  ) {
+    return fallback;
+  }
+
+  return redirectPath;
+};

--- a/frontend/src/utilities/authentication/safe-redirect.ts
+++ b/frontend/src/utilities/authentication/safe-redirect.ts
@@ -1,9 +1,5 @@
 const defaultRedirectPath = "/";
 
-// Synthetic origin used only to resolve the (relative) redirect path. A path
-// that resolves to any other origin is not same-origin and gets rejected.
-const sameOriginBase = "https://collimator.invalid";
-
 // Any Unicode control character (C0, DEL and C1 — includes CR, LF and TAB).
 const controlCharacter = /\p{Cc}/u;
 
@@ -13,7 +9,7 @@ const controlCharacter = /\p{Cc}/u;
  *
  * Per OWASP, this validates the parsed URL rather than string-matching: an
  * absolute URL, a protocol-relative `//host`, a backslash `\\host` or a `scheme:`
- * all resolve to a different origin than `sameOriginBase` and are rejected. The
+ * all resolve to a different origin than the page's own and are rejected. The
  * only manual guard is for control characters, which `new URL` silently strips:
  * `/%0A//evil.com` stays same-origin above, yet the browser collapses it into a
  * protocol-relative jump once it decodes the newline.
@@ -27,7 +23,7 @@ export const getSafeInternalRedirectPath = (
   }
 
   try {
-    if (new URL(redirectPath, sameOriginBase).origin !== sameOriginBase) {
+    if (new URL(redirectPath, window.origin).origin !== window.origin) {
       return fallback;
     }
     if (controlCharacter.test(decodeURIComponent(redirectPath))) {


### PR DESCRIPTION
The login button called redirectToOpenIdConnectProvider without awaiting or catching it. On success that function navigates away, but when it rejects - e.g. OIDC discovery or configuration fetch fails - the rejection was unhandled and the UI did nothing: the user clicked "Authenticate using Microsoft" and saw no change and no error.

Await the call and, on failure, log the technical error and show an error toast so the user knows the attempt failed and can retry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows an error when Microsoft sign-in cannot start and hardens auth redirects to prevent open-redirects. Fixes CRT-451.

- **Bug Fixes**
  - Await `redirectToOpenIdConnectProvider`; on rejection, log the error and show a localized `toaster.error` via `react-intl`.
  - Route all auth redirects through `getSafeInternalRedirectPath` in login, OIDC redirect, user sign-in, and `openid-connect`. Validate safety by resolving against `window.origin` with `new URL`, and reject control characters and malformed encodings. Added unit tests for safe paths and common bypass vectors.

<sup>Written for commit 1474fd5dd712c745ac9aa740d8224d647fb47678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

