### PR TITLE
[CRT-453] Restrict the User Manager pages to admins

### DIFF
--- a/frontend/src/components/authentication/AuthenticationBarrier.tsx
+++ b/frontend/src/components/authentication/AuthenticationBarrier.tsx
@@ -22,6 +22,12 @@ const allowedRoutesForStudents = [
   "/class/[classId]/session/[sessionId]/task/[taskId]/solve",
 ];
 
+// User management is admin-only: the navigation entry and the home-page card
+// are already hidden from teachers, but the pages themselves were reachable by
+// typing the URL, showing a teacher the whole User Manager and a Create User
+// button that then fails with a 403.
+const adminOnlyRoutes = ["/user", "/user/create", "/user/[userId]/detail"];
+
 const AuthenticationBarrier = ({
   authenticationStateLoaded,
   children,
@@ -50,6 +56,11 @@ const AuthenticationBarrier = ({
     [router.pathname],
   );
 
+  const isAdminPage = useMemo(
+    () => adminOnlyRoutes.includes(router.pathname),
+    [router.pathname],
+  );
+
   const isAllowedToSeePage = useMemo(() => {
     return (
       // either the route is allowed for unauthenticated users
@@ -57,22 +68,37 @@ const AuthenticationBarrier = ({
       // OR the user is authenticated
       (isAuthenticated &&
         // AND the page is allowed for students or the user is not a student
-        (isStudentPage || authenticationContext.role !== UserRole.student))
+        (isStudentPage || authenticationContext.role !== UserRole.student) &&
+        // AND admin-only pages are restricted to admins
+        (!isAdminPage || authenticationContext.role === UserRole.admin))
     );
   }, [
     isAuthenticated,
     isPublicPage,
     authenticationContext.role,
     isStudentPage,
+    isAdminPage,
   ]);
 
-  // redirect to login page if the user is not allowed to see the page
-  // but only do so once the authentication state has been loaded
+  // redirect if the user is not allowed to see the page, but only once the
+  // authentication state has been loaded. An authenticated non-admin on an
+  // admin page is sent home rather than to the login page: signing in again
+  // would not grant access and would just look like a broken login.
   useEffect(() => {
     if (authenticationStateLoaded && !isAllowedToSeePage) {
-      router.replace("/login?redirectUri=" + router.asPath);
+      router.replace(
+        isAuthenticated && isAdminPage
+          ? "/"
+          : "/login?redirectUri=" + router.asPath,
+      );
     }
-  }, [authenticationStateLoaded, router, isAllowedToSeePage]);
+  }, [
+    authenticationStateLoaded,
+    router,
+    isAllowedToSeePage,
+    isAuthenticated,
+    isAdminPage,
+  ]);
 
   if (isPublicPage) {
     // SSR may be performed for public pages

--- a/frontend/src/components/authentication/AuthenticationBarrier.tsx
+++ b/frontend/src/components/authentication/AuthenticationBarrier.tsx
@@ -5,7 +5,7 @@ import { UserRole } from "@/types/user/user-role";
 import { useAuthExpirationCheck } from "@/hooks/useAuthExpirationCheck";
 import DisableSSR from "../next/DisableSSR";
 
-const allowedRoutesForUnauthenticatedUsers = [
+const allowedRoutesForUnauthenticatedUsers = new Set<string>([
   "/_error",
   "/logout",
   "/login",
@@ -17,16 +17,21 @@ const allowedRoutesForUnauthenticatedUsers = [
   // in particular, an ephemeral key pair is generated for the session
   // and the student's authentication is completed by communicating with the teacher
   "/class/[classId]/session/[sessionId]/join",
-];
-const allowedRoutesForStudents = [
+]);
+
+const allowedRoutesForStudents = new Set<string>([
   "/class/[classId]/session/[sessionId]/task/[taskId]/solve",
-];
+]);
 
 // User management is admin-only: the navigation entry and the home-page card
 // are already hidden from teachers, but the pages themselves were reachable by
 // typing the URL, showing a teacher the whole User Manager and a Create User
 // button that then fails with a 403.
-const adminOnlyRoutes = ["/user", "/user/create", "/user/[userId]/detail"];
+const adminOnlyRoutes = new Set<string>([
+  "/user",
+  "/user/create",
+  "/user/[userId]/detail",
+]);
 
 const AuthenticationBarrier = ({
   authenticationStateLoaded,
@@ -47,17 +52,17 @@ const AuthenticationBarrier = ({
   const isPublicPage = useMemo(
     () =>
       // either the route is allowed for unauthenticated users
-      allowedRoutesForUnauthenticatedUsers.includes(router.pathname),
+      allowedRoutesForUnauthenticatedUsers.has(router.pathname),
     [router.pathname],
   );
 
   const isStudentPage = useMemo(
-    () => allowedRoutesForStudents.includes(router.pathname),
+    () => allowedRoutesForStudents.has(router.pathname),
     [router.pathname],
   );
 
   const isAdminPage = useMemo(
-    () => adminOnlyRoutes.includes(router.pathname),
+    () => adminOnlyRoutes.has(router.pathname),
     [router.pathname],
   );
 

--- a/frontend/src/components/authentication/__tests__/jest/AuthenticationBarrier.spec.tsx
+++ b/frontend/src/components/authentication/__tests__/jest/AuthenticationBarrier.spec.tsx
@@ -57,26 +57,27 @@ describe("AuthenticationBarrier — admin-only user management", () => {
   it.each(["/user", "/user/create", "/user/[userId]/detail"])(
     "keeps a teacher out of %s",
     (pathname) => {
-      const { queryByText } = renderAt(pathname, UserRole.teacher);
+      const { getByText } = renderAt(pathname, UserRole.teacher);
 
-      expect(queryByText("page content")).not.toBeInTheDocument();
+      expect(getByText("page content")).not.toBeInTheDocument();
       // sent home, not to the login page: signing in again would not help
       expect(replace).toHaveBeenCalledWith("/");
+      expect(replace).toHaveBeenCalledTimes(1);
     },
   );
 
   it("lets an admin into the user manager", () => {
-    const { queryByText } = renderAt("/user", UserRole.admin);
+    const { getByText } = renderAt("/user", UserRole.admin);
 
-    expect(queryByText("page content")).toBeInTheDocument();
-    expect(replace).not.toHaveBeenCalled();
+    expect(getByText("page content")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalledTimes(1);
   });
 
   // positive control: the new rule must not affect the pages teachers use
   it("still lets a teacher into the class manager", () => {
-    const { queryByText } = renderAt("/class", UserRole.teacher);
+    const { getByText } = renderAt("/class", UserRole.teacher);
 
-    expect(queryByText("page content")).toBeInTheDocument();
-    expect(replace).not.toHaveBeenCalled();
+    expect(getByText("page content")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/authentication/__tests__/jest/AuthenticationBarrier.spec.tsx
+++ b/frontend/src/components/authentication/__tests__/jest/AuthenticationBarrier.spec.tsx
@@ -1,0 +1,82 @@
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import { useRouter as useRouterMock } from "next/router";
+import { AuthenticationContext } from "@/contexts/AuthenticationContext";
+import { UserRole } from "@/types/user/user-role";
+import AuthenticationBarrier from "@/components/authentication/AuthenticationBarrier";
+
+jest.mock("next/router", () => ({
+  useRouter: jest.fn(),
+}));
+
+// the barrier only decides what to render/redirect; the expiration polling and
+// the SSR wrapper are irrelevant here
+jest.mock("@/hooks/useAuthExpirationCheck", () => ({
+  useAuthExpirationCheck: jest.fn(),
+}));
+jest.mock("@/components/next/DisableSSR", () => ({
+  __esModule: true,
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+const useRouter = useRouterMock as jest.Mock;
+const replace = jest.fn();
+
+const renderAt = (
+  pathname: string,
+  role: UserRole | undefined,
+): ReturnType<typeof render> => {
+  useRouter.mockReturnValue({ pathname, asPath: pathname, replace });
+
+  return render(
+    <AuthenticationContext.Provider
+      value={
+        {
+          version: "2",
+          authenticationToken: role === undefined ? undefined : "token",
+          role,
+        } as never
+      }
+    >
+      <AuthenticationBarrier authenticationStateLoaded>
+        <div>page content</div>
+      </AuthenticationBarrier>
+    </AuthenticationContext.Provider>,
+  );
+};
+
+// User management is admin-only. The navigation entry and home-page card are
+// already hidden from teachers, but the pages themselves were reachable by
+// typing the URL - a teacher saw the whole User Manager and a Create User
+// button that only failed with a 403 on submit.
+describe("AuthenticationBarrier — admin-only user management", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it.each(["/user", "/user/create", "/user/[userId]/detail"])(
+    "keeps a teacher out of %s",
+    (pathname) => {
+      const { queryByText } = renderAt(pathname, UserRole.teacher);
+
+      expect(queryByText("page content")).not.toBeInTheDocument();
+      // sent home, not to the login page: signing in again would not help
+      expect(replace).toHaveBeenCalledWith("/");
+    },
+  );
+
+  it("lets an admin into the user manager", () => {
+    const { queryByText } = renderAt("/user", UserRole.admin);
+
+    expect(queryByText("page content")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  // positive control: the new rule must not affect the pages teachers use
+  it("still lets a teacher into the class manager", () => {
+    const { queryByText } = renderAt("/class", UserRole.teacher);
+
+    expect(queryByText("page content")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/authentication/__tests__/jest/AuthenticationBarrier.spec.tsx
+++ b/frontend/src/components/authentication/__tests__/jest/AuthenticationBarrier.spec.tsx
@@ -57,9 +57,12 @@ describe("AuthenticationBarrier — admin-only user management", () => {
   it.each(["/user", "/user/create", "/user/[userId]/detail"])(
     "keeps a teacher out of %s",
     (pathname) => {
-      const { getByText } = renderAt(pathname, UserRole.teacher);
+      // queryByText, not getByText: the teacher is redirected so "page content"
+      // is absent, and getByText throws on a missing element instead of letting
+      // the .not.toBeInTheDocument() assertion run.
+      const { queryByText } = renderAt(pathname, UserRole.teacher);
 
-      expect(getByText("page content")).not.toBeInTheDocument();
+      expect(queryByText("page content")).not.toBeInTheDocument();
       // sent home, not to the login page: signing in again would not help
       expect(replace).toHaveBeenCalledWith("/");
       expect(replace).toHaveBeenCalledTimes(1);
@@ -70,7 +73,7 @@ describe("AuthenticationBarrier — admin-only user management", () => {
     const { getByText } = renderAt("/user", UserRole.admin);
 
     expect(getByText("page content")).toBeInTheDocument();
-    expect(replace).not.toHaveBeenCalledTimes(1);
+    expect(replace).not.toHaveBeenCalled();
   });
 
   // positive control: the new rule must not affect the pages teachers use
@@ -78,6 +81,6 @@ describe("AuthenticationBarrier — admin-only user management", () => {
     const { getByText } = renderAt("/class", UserRole.teacher);
 
     expect(getByText("page content")).toBeInTheDocument();
-    expect(replace).not.toHaveBeenCalledTimes(1);
+    expect(replace).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
User management is admin-only, but only the entry points enforced it: the navigation tab and the home-page card are hidden from teachers, while the pages themselves (/user, /user/create, /user/[userId]/detail) had no guard. Typing the URL showed a teacher the whole User Manager and a Create User button that only failed with a 403 on submit. The backend is not the leak - GET /users already scopes a teacher to their own record, and that scoped result is relied on by the class form's teacher picker, so the endpoint must stay reachable by teachers.

Gate the pages in AuthenticationBarrier, alongside the existing role rules, so the restriction is enforced centrally and on direct navigation. An authenticated non-admin is sent home rather than to the login page, since signing in again would not grant access.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locked down User Manager pages to admins by gating them in `AuthenticationBarrier`. Teachers who navigate directly to these URLs are sent home instead of the login page; tests updated to assert redirects without crashing. Addresses Linear CRT-453.

- **Bug Fixes**
  - Restricted `/user`, `/user/create`, and `/user/[userId]/detail` to `admin` (central check in `AuthenticationBarrier`).
  - Redirects: authenticated non-admins → `/`; unauthenticated users → `/login?redirectUri=...`. Tests use `queryByText` for absence and `not.toHaveBeenCalled()` to verify no unexpected redirects; teacher access to `/class` remains unchanged.

- **Refactors**
  - Replaced route arrays with `Set` and switched to `.has()` checks; added `adminOnlyRoutes`.

<sup>Written for commit 1075c803a7be8595aa1cad9fa4822f016635cf6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

