### PR TITLE
Document that the session status is unused

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -134,6 +134,13 @@ model Lesson {
   creator  User?        @relation(fields: [creatorId], references: [id], onDelete: SetNull)
 }
 
+/// Known limitation: the session (lesson) lifecycle is only partially built.
+/// This status is recorded and can be changed, but it does NOT gate student
+/// access: a FINISHED (or PAUSED) lesson still accepts new students joining and
+/// new solution submissions. Access is governed by the lesson's sharing type
+/// and enrolment, not by its status. Enforcing the status (and exposing
+/// start/pause/finish controls) is intended future work; until then, treat the
+/// status as informational only.
 enum SessionStatus {
   CREATED
   ONGOING


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documented in the Prisma schema that session/lesson status is informational only and does not gate joining or submissions. Access is controlled by sharing type and enrollment; enforcing start/pause/finish is future work.

<sup>Written for commit fbc0dfb669ddac296e1fcb2a757612ec0e55d4cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

