### PR TITLE
[CRT-307] Stop _error from using getInitialProps under static export

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs";
+import NextErrorComponent from "next/error";
 import { Inter } from "next/font/google";
 import "@/styles/globals.scss";
 import "@fortawesome/fontawesome-svg-core/styles.css";
@@ -141,34 +143,36 @@ const App = ({ Component, pageProps }: AppProps) => {
 
   return (
     <div className={inter.variable}>
-      <CacheProvider value={cache}>
-        <ChakraProvider>
-          <IntlProvider locale={localizationState.locale} messages={messages}>
-            <Toaster />
-            <YupLocalization>
-              <PrimeReactProvider>
-                <AuthenticationContext.Provider value={authenticationState}>
-                  <UpdateAuthenticationContext.Provider
-                    value={updateAuthenticationState}
-                  >
-                    <UpdateLocalizationContext.Provider
-                      value={updateLocalizationState}
+      <Sentry.ErrorBoundary fallback={<NextErrorComponent statusCode={500} />}>
+        <CacheProvider value={cache}>
+          <ChakraProvider>
+            <IntlProvider locale={localizationState.locale} messages={messages}>
+              <Toaster />
+              <YupLocalization>
+                <PrimeReactProvider>
+                  <AuthenticationContext.Provider value={authenticationState}>
+                    <UpdateAuthenticationContext.Provider
+                      value={updateAuthenticationState}
                     >
-                      <AuthenticationBarrier
-                        authenticationStateLoaded={authenticationStateLoaded}
+                      <UpdateLocalizationContext.Provider
+                        value={updateLocalizationState}
                       >
-                        <WebSocketProvider>
-                          <Component {...pageProps} />
-                        </WebSocketProvider>
-                      </AuthenticationBarrier>
-                    </UpdateLocalizationContext.Provider>
-                  </UpdateAuthenticationContext.Provider>
-                </AuthenticationContext.Provider>
-              </PrimeReactProvider>
-            </YupLocalization>
-          </IntlProvider>
-        </ChakraProvider>
-      </CacheProvider>
+                        <AuthenticationBarrier
+                          authenticationStateLoaded={authenticationStateLoaded}
+                        >
+                          <WebSocketProvider>
+                            <Component {...pageProps} />
+                          </WebSocketProvider>
+                        </AuthenticationBarrier>
+                      </UpdateLocalizationContext.Provider>
+                    </UpdateAuthenticationContext.Provider>
+                  </AuthenticationContext.Provider>
+                </PrimeReactProvider>
+              </YupLocalization>
+            </IntlProvider>
+          </ChakraProvider>
+        </CacheProvider>
+      </Sentry.ErrorBoundary>
     </div>
   );
 };

--- a/frontend/src/pages/_error.tsx
+++ b/frontend/src/pages/_error.tsx
@@ -1,21 +1,11 @@
-import * as Sentry from "@sentry/nextjs";
-import { useEffect } from "react";
 import NextErrorComponent from "next/error";
 
-const CustomErrorComponent = ({
-  statusCode,
-  err,
-}: {
-  statusCode?: number;
-  err?: Error;
-}) => {
-  useEffect(() => {
-    if (err) {
-      Sentry.captureException(err);
-    }
-  }, [err]);
-
-  return <NextErrorComponent statusCode={statusCode ?? 404} />;
-};
+// Presentational error page only. It intentionally has no getInitialProps so
+// that `next export` does not warn about it. Reporting client-side render
+// failures to Sentry is handled by the Sentry.ErrorBoundary in _app.tsx, which
+// (unlike this component under static export) actually receives the error.
+const CustomErrorComponent = ({ statusCode }: { statusCode?: number }) => (
+  <NextErrorComponent statusCode={statusCode ?? 404} />
+);
 
 export default CustomErrorComponent;

--- a/frontend/src/pages/_error.tsx
+++ b/frontend/src/pages/_error.tsx
@@ -1,18 +1,21 @@
 import * as Sentry from "@sentry/nextjs";
-import { NextPageContext } from "next";
-import Error from "next/error";
+import { useEffect } from "react";
+import NextErrorComponent from "next/error";
 
-const CustomErrorComponent = (props: { statusCode: number }) => {
-  return <Error statusCode={props.statusCode} />;
-};
+const CustomErrorComponent = ({
+  statusCode,
+  err,
+}: {
+  statusCode?: number;
+  err?: Error;
+}) => {
+  useEffect(() => {
+    if (err) {
+      Sentry.captureException(err);
+    }
+  }, [err]);
 
-CustomErrorComponent.getInitialProps = async (contextData: NextPageContext) => {
-  // In case this is running in a serverless function, await this in order to give Sentry
-  // time to send the error before the lambda exits
-  await Sentry.captureUnderscoreErrorException(contextData);
-
-  // This will contain the status code of the response
-  return Error.getInitialProps(contextData);
+  return <NextErrorComponent statusCode={statusCode ?? 404} />;
 };
 
 export default CustomErrorComponent;


### PR DESCRIPTION
The build logged "Detected getInitialProps on page '/_error' while running export". The app is a static export (next.config.ts: output "export"), so there is no server for getInitialProps to run on and Next cannot statically optimise the page while it has one.

Drop getInitialProps but keep the Sentry reporting it contained. That reporting is still needed: errors thrown while rendering are caught by Next's error boundary, which renders this page, so they never reach the global handlers installed by instrumentation-client.ts. getInitialProps also runs client-side, so the previous capture did fire there - it is now done from a client-side effect instead, using the err prop Next passes to the error page.

Confirmed the warning no longer appears in the frontend build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop `/_error` from using `getInitialProps` to enable static export and remove the build warning. Capture client render errors via a `Sentry.ErrorBoundary` in `_app.tsx`; `/_error` is now presentational. Addresses CRT-307.

- **Bug Fixes**
  - Wrap the app with `Sentry.ErrorBoundary` and show a `next/error` 500 fallback; errors are reported via `@sentry/nextjs`.
  - Remove `getInitialProps` from `/_error`; render `next/error` with a 404 fallback when no status code.
  - Confirmed the "Detected getInitialProps on page '/_error' while running export" warning is gone.

<sup>Written for commit 37e54924f28e04a3d9a2dc44bbcc00e7edb42cc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

