### PR TITLE
[CRT-304] Re-enable the reference-solutions tests

### DIFF
--- a/e2e/tests/task/task-edit-modal-page-model.ts
+++ b/e2e/tests/task/task-edit-modal-page-model.ts
@@ -25,7 +25,6 @@ export class TaskEditModalPageModel {
     return this.page.getByTestId("confirm-button");
   }
 
-
   async import(): Promise<void> {
     await this.importButton.click();
   }
@@ -44,6 +43,26 @@ export class TaskEditModalPageModel {
   async cancel(): Promise<void> {
     await this.waitForModal();
     await this.cancelButton.click();
+
+    // Cancelling is not a plain close: warnBeforeClose only closes the modal
+    // outright while the embedded editor has not loaded yet, and asks to
+    // confirm quitting without saving once it has. Which branch is taken
+    // therefore depends on whether the iframe happened to finish loading
+    // before the click - so handle the confirmation when it appears, and wait
+    // for the modal to be gone either way rather than leaving the caller to
+    // race the same timing.
+    const confirmation = this.page.getByTestId("confirmation-modal");
+
+    await Promise.race([
+      confirmation.waitFor({ state: "visible", timeout: 30_000 }),
+      this.modal.waitFor({ state: "detached", timeout: 30_000 }),
+    ]);
+
+    if (await confirmation.isVisible()) {
+      await this.modalConfirmButton.click();
+    }
+
+    await this.modal.waitFor({ state: "detached", timeout: 30_000 });
   }
 
   async waitForModal(): Promise<void> {

--- a/e2e/tests/task/task-edit-modal-page-model.ts
+++ b/e2e/tests/task/task-edit-modal-page-model.ts
@@ -32,11 +32,7 @@ export class TaskEditModalPageModel {
   async save(): Promise<void> {
     await this.saveButton.click();
     // The save handler runs an async round-trip to the embedded editor and only
-    // then closes the modal (setIsShown(false) after onSave resolves). Wait for
-    // the modal — and the embedded scratch iframe it contains — to detach before
-    // returning. Otherwise the caller's next interaction with the underlying
-    // task form (e.g. clicking its submit button) races the still-mounted iframe,
-    // which sits over the form and intercepts the pointer events until timeout.
+    // then closes the modal (setIsShown(false) after onSave resolves).
     await this.modal.waitFor({ state: "detached", timeout: 60_000 });
   }
 
@@ -44,13 +40,9 @@ export class TaskEditModalPageModel {
     await this.waitForModal();
     await this.cancelButton.click();
 
-    // Cancelling is not a plain close: warnBeforeClose only closes the modal
-    // outright while the embedded editor has not loaded yet, and asks to
-    // confirm quitting without saving once it has. Which branch is taken
-    // therefore depends on whether the iframe happened to finish loading
-    // before the click - so handle the confirmation when it appears, and wait
-    // for the modal to be gone either way rather than leaving the caller to
-    // race the same timing.
+    // Cancelling does not always close the modal immediately: before the embedded
+    // editor loads, warnBeforeClose closes it directly, once loaded, it asks the
+    // user to confirm quitting without saving.
     const confirmation = this.page.getByTestId("confirmation-modal");
 
     await Promise.race([

--- a/e2e/tests/task/task-management.spec.ts
+++ b/e2e/tests/task/task-management.spec.ts
@@ -91,7 +91,7 @@ test.describe.serial("task management", () => {
       await expect(page.locator(taskList).locator("tbody tr")).toHaveCount(1);
     });
 
-    test.describe.skip("/task/{id}/reference-solutions", () => {
+    test.describe("/task/{id}/reference-solutions", () => {
       let page: TaskFormReferenceSolutionsPageModel;
 
       test.beforeEach(async ({ baseURL, page: pwPage }) => {


### PR DESCRIPTION
The whole /task/{id}/reference-solutions suite was skipped as flaky in CRT-280 without a recorded cause. The cause is a race in the modal's cancel path rather than anything about the tests themselves.

TaskModal's cancel button calls warnBeforeClose, which closes the modal outright while the embedded editor has not loaded yet, but asks to confirm quitting without saving once it has. The page model clicked cancel as soon as the modal existed, so which of the two branches was taken depended on whether the iframe happened to finish loading first - leaving the modal open often enough to make "editing solution but not pressing save" fail intermittently on its toBeHidden assertion.

Handle both branches in the page model: confirm the quit dialog when it appears and wait for the modal to be gone either way, the same treatment save() already had for its own async close.

The whole suite is re-enabled, including the two tests that switch a task to JUPYTER - converting an existing Scratch task does not run the otter pipeline, so they do not hit the Jupyter save path. Seven consecutive runs of the file were green (13 passed each).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-enabled the /task/{id}/reference-solutions E2E suite by fixing a race in the Task Edit modal cancel flow. Addresses CRT-304 and stabilizes these tests.

- **Bug Fixes**
  - Updated cancel() in the Task Edit modal page model to handle both paths (immediate close or confirm-to-quit) and always wait for the modal to fully close.
  - Unskipped the /task/{id}/reference-solutions tests (including JUPYTER conversion); verified with multiple green runs. Trimmed redundant comments in the page model for clarity.

<sup>Written for commit db8113e5785b01f38a922a1c5e5a7c8b90bb2ccc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

