### PR TITLE
[CRT-455] Add timestamp to create solution dto and store it

### DIFF
--- a/backend/prisma/migrations/20260728180000_add_happened_at_to_student_solution/migration.sql
+++ b/backend/prisma/migrations/20260728180000_add_happened_at_to_student_solution/migration.sql
@@ -1,0 +1,8 @@
+-- AlterTable
+ALTER TABLE "StudentSolution" ADD COLUMN "happenedAt" TIMESTAMP(3);
+
+-- Backfill existing rows with server createdAt so the column can be NOT NULL
+UPDATE "StudentSolution" SET "happenedAt" = "createdAt" WHERE "happenedAt" IS NULL;
+
+-- AlterTable
+ALTER TABLE "StudentSolution" ALTER COLUMN "happenedAt" SET NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -257,6 +257,8 @@ model ReferenceSolution {
 model StudentSolution {
   id           Int       @id @default(autoincrement())
   createdAt    DateTime  @default(now())
+  // measured by the client and may therefore be completely different from createdAt
+  happenedAt   DateTime
   taskId       Int
   solutionHash Bytes
   studentId    Int

--- a/backend/prisma/sql/getCurrentAnalyses.sql
+++ b/backend/prisma/sql/getCurrentAnalyses.sql
@@ -12,7 +12,7 @@ WITH studentSolutions AS (
     AND studentSolution."deletedAt" IS NULL
     ORDER BY
       studentSolution."studentId",
-      studentSolution."createdAt" DESC
+      studentSolution."happenedAt" DESC
     )
 SELECT
   analysis.*,

--- a/backend/prisma/sql/getCurrentAnalyses.sql
+++ b/backend/prisma/sql/getCurrentAnalyses.sql
@@ -12,7 +12,10 @@ WITH studentSolutions AS (
     AND studentSolution."deletedAt" IS NULL
     ORDER BY
       studentSolution."studentId",
-      studentSolution."happenedAt" DESC
+      studentSolution."happenedAt" DESC,
+      -- The id is unique, so it is enough to break ties when two client
+      -- timestamps are exactly the same.
+      studentSolution."id" DESC
     )
 SELECT
   analysis.*,

--- a/backend/prisma/sql/getCurrentAnalysesWithActivities.sql
+++ b/backend/prisma/sql/getCurrentAnalysesWithActivities.sql
@@ -8,7 +8,13 @@ WITH allStudentSolutions AS (
       studentSolution."sessionId",
       studentSolution."taskId",
       studentSolution."solutionHash",
-      studentSolution."happenedAt" AS "createdAt",
+      studentSolution."happenedAt",
+      studentSolution."createdAt",
+      -- Keep this priority in sync with
+      -- SolutionsService.downloadLatestStudentSolutionOrThrow, which prefers a
+      -- StudentSolution when client and server timestamps are equal
+      1 AS "sourcePriority",
+      studentSolution."id" AS "sourceId",
       studentSolution."id" AS "studentSolutionId",
       studentSolution."isReference"
     FROM "StudentSolution" studentSolution
@@ -24,7 +30,11 @@ WITH allStudentSolutions AS (
       studentActivity."sessionId",
       studentActivity."taskId",
       studentActivity."solutionHash",
-      studentActivity."happenedAt" AS "createdAt",
+      studentActivity."happenedAt",
+      studentActivity."createdAt",
+      -- See the corresponding StudentSolution sourcePriority above.
+      0 AS "sourcePriority",
+      studentActivity."id" AS "sourceId",
       NULL::int AS "studentSolutionId",
       studentActivity."isReference"
     FROM "StudentActivity" studentActivity
@@ -46,7 +56,10 @@ studentSolutions AS (
       AND analysis."deletedAt" IS NULL
     ORDER BY
       allStudentSolutions."studentId",
-      allStudentSolutions."createdAt" DESC
+      allStudentSolutions."happenedAt" DESC,
+      allStudentSolutions."createdAt" DESC,
+      allStudentSolutions."sourcePriority" DESC,
+      allStudentSolutions."sourceId" DESC
     )
 SELECT
   analysis.*,

--- a/backend/prisma/sql/getCurrentAnalysesWithActivities.sql
+++ b/backend/prisma/sql/getCurrentAnalysesWithActivities.sql
@@ -8,7 +8,7 @@ WITH allStudentSolutions AS (
       studentSolution."sessionId",
       studentSolution."taskId",
       studentSolution."solutionHash",
-      studentSolution."createdAt",
+      studentSolution."happenedAt" AS "createdAt",
       studentSolution."id" AS "studentSolutionId",
       studentSolution."isReference"
     FROM "StudentSolution" studentSolution
@@ -24,7 +24,7 @@ WITH allStudentSolutions AS (
       studentActivity."sessionId",
       studentActivity."taskId",
       studentActivity."solutionHash",
-      studentActivity."createdAt",
+      studentActivity."happenedAt" AS "createdAt",
       NULL::int AS "studentSolutionId",
       studentActivity."isReference"
     FROM "StudentActivity" studentActivity

--- a/backend/prisma/sql/getCurrentStudentSolutions.sql
+++ b/backend/prisma/sql/getCurrentStudentSolutions.sql
@@ -18,4 +18,4 @@ WHERE sessionTask."sessionId" = $1
 AND sessionTask."deletedAt" IS NULL
 AND studentSolution."studentId" = $2
 GROUP BY studentSolution."taskId", studentSolution."id"
-ORDER BY studentSolution."taskId", studentSolution."createdAt" DESC;
+ORDER BY studentSolution."taskId", studentSolution."happenedAt" DESC;

--- a/backend/prisma/sql/getCurrentStudentSolutions.sql
+++ b/backend/prisma/sql/getCurrentStudentSolutions.sql
@@ -18,4 +18,9 @@ WHERE sessionTask."sessionId" = $1
 AND sessionTask."deletedAt" IS NULL
 AND studentSolution."studentId" = $2
 GROUP BY studentSolution."taskId", studentSolution."id"
-ORDER BY studentSolution."taskId", studentSolution."happenedAt" DESC;
+ORDER BY
+  studentSolution."taskId",
+  studentSolution."happenedAt" DESC,
+  -- The id is unique, so it is enough to break ties when two client
+  -- timestamps are exactly the same.
+  studentSolution."id" DESC;

--- a/backend/prisma/sql/getSoftDeletedCurrentAnalyses.sql
+++ b/backend/prisma/sql/getSoftDeletedCurrentAnalyses.sql
@@ -12,7 +12,7 @@ WITH studentSolutions AS (
     AND studentSolution."deletedAt" IS NOT NULL
     ORDER BY
       studentSolution."studentId",
-      studentSolution."createdAt" DESC
+      studentSolution."happenedAt" DESC
     )
 SELECT
   analysis.*,

--- a/backend/prisma/sql/getSoftDeletedCurrentAnalyses.sql
+++ b/backend/prisma/sql/getSoftDeletedCurrentAnalyses.sql
@@ -12,7 +12,10 @@ WITH studentSolutions AS (
     AND studentSolution."deletedAt" IS NOT NULL
     ORDER BY
       studentSolution."studentId",
-      studentSolution."happenedAt" DESC
+      studentSolution."happenedAt" DESC,
+      -- The id is unique, so it is enough to tie break when two client
+      -- timestamps are exactly the same
+      studentSolution."id" DESC
     )
 SELECT
   analysis.*,

--- a/backend/prisma/sql/getSoftDeletedCurrentAnalysesWithActivities.sql
+++ b/backend/prisma/sql/getSoftDeletedCurrentAnalysesWithActivities.sql
@@ -8,7 +8,13 @@ WITH allStudentSolutions AS (
       studentSolution."sessionId",
       studentSolution."taskId",
       studentSolution."solutionHash",
-      studentSolution."happenedAt" AS "createdAt",
+      studentSolution."happenedAt",
+      studentSolution."createdAt",
+      -- Keep this priority in sync with
+      -- SolutionsService.downloadLatestStudentSolutionOrThrow, which prefers a
+      -- StudentSolution when client and server timestamps are equal
+      1 AS "sourcePriority",
+      studentSolution."id" AS "sourceId",
       studentSolution."id" AS "studentSolutionId",
       studentSolution."isReference"
     FROM "StudentSolution" studentSolution
@@ -24,7 +30,11 @@ WITH allStudentSolutions AS (
       studentActivity."sessionId",
       studentActivity."taskId",
       studentActivity."solutionHash",
-      studentActivity."happenedAt" AS "createdAt",
+      studentActivity."happenedAt",
+      studentActivity."createdAt",
+      -- See the corresponding StudentSolution sourcePriority above.
+      0 AS "sourcePriority",
+      studentActivity."id" AS "sourceId",
       NULL::int AS "studentSolutionId",
       studentActivity."isReference"
     FROM "StudentActivity" studentActivity
@@ -42,7 +52,10 @@ WITH allStudentSolutions AS (
     AND analysis."deletedAt" IS NOT NULL
     ORDER BY
       allStudentSolutions."studentId",
-      allStudentSolutions."createdAt" DESC
+      allStudentSolutions."happenedAt" DESC,
+      allStudentSolutions."createdAt" DESC,
+      allStudentSolutions."sourcePriority" DESC,
+      allStudentSolutions."sourceId" DESC
     )
 SELECT
   analysis.*,

--- a/backend/prisma/sql/getSoftDeletedCurrentAnalysesWithActivities.sql
+++ b/backend/prisma/sql/getSoftDeletedCurrentAnalysesWithActivities.sql
@@ -8,7 +8,7 @@ WITH allStudentSolutions AS (
       studentSolution."sessionId",
       studentSolution."taskId",
       studentSolution."solutionHash",
-      studentSolution."createdAt",
+      studentSolution."happenedAt" AS "createdAt",
       studentSolution."id" AS "studentSolutionId",
       studentSolution."isReference"
     FROM "StudentSolution" studentSolution
@@ -24,7 +24,7 @@ WITH allStudentSolutions AS (
       studentActivity."sessionId",
       studentActivity."taskId",
       studentActivity."solutionHash",
-      studentActivity."createdAt",
+      studentActivity."happenedAt" AS "createdAt",
       NULL::int AS "studentSolutionId",
       studentActivity."isReference"
     FROM "StudentActivity" studentActivity

--- a/backend/prisma/sql/getSoftDeletedCurrentStudentSolutions.sql
+++ b/backend/prisma/sql/getSoftDeletedCurrentStudentSolutions.sql
@@ -17,4 +17,4 @@ LEFT JOIN "SolutionTest" test
   AND test."deletedAt" IS NOT NULL
 WHERE sessionTask."sessionId" = $1
 GROUP BY studentSolution."taskId", studentSolution."id"
-ORDER BY studentSolution."taskId", studentSolution."createdAt" DESC;
+ORDER BY studentSolution."taskId", studentSolution."happenedAt" DESC;

--- a/backend/prisma/sql/getSoftDeletedCurrentStudentSolutions.sql
+++ b/backend/prisma/sql/getSoftDeletedCurrentStudentSolutions.sql
@@ -17,4 +17,9 @@ LEFT JOIN "SolutionTest" test
   AND test."deletedAt" IS NOT NULL
 WHERE sessionTask."sessionId" = $1
 GROUP BY studentSolution."taskId", studentSolution."id"
-ORDER BY studentSolution."taskId", studentSolution."happenedAt" DESC;
+ORDER BY
+  studentSolution."taskId",
+  studentSolution."happenedAt" DESC,
+  -- The id is unique, so it is enough to break ties when two client
+  -- timestamps are exactly the same.
+  studentSolution."id" DESC;

--- a/backend/src/api/solutions/dto/create-solution.dto.ts
+++ b/backend/src/api/solutions/dto/create-solution.dto.ts
@@ -1,6 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
-import { IsArray } from "class-validator";
+import { IsArray, IsDate } from "class-validator";
 import { CreateSolutionTestDto } from "./create-solution-test.dto";
 
 export class CreateSolutionDto {
@@ -19,4 +19,13 @@ export class CreateSolutionDto {
     type: "string",
   })
   readonly file!: Express.Multer.File;
+
+  @Type(() => Date)
+  @IsDate()
+  @ApiProperty({
+    example: "2025-01-01T12:00:00Z",
+    description:
+      "Client timestamp of the solution submission. May differ from the server-side createdAt.",
+  })
+  readonly happenedAt!: Date;
 }

--- a/backend/src/api/solutions/dto/create-solution.dto.ts
+++ b/backend/src/api/solutions/dto/create-solution.dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import { IsArray, IsDate } from "class-validator";
-import { IsClientTimestamp } from "src/utilities/validation/client-timestamp";
+import { EnsureLimitedClientClockSkew } from "src/utilities/validation/client-timestamp";
 import { CreateSolutionTestDto } from "./create-solution-test.dto";
 
 export class CreateSolutionDto {
@@ -23,7 +23,7 @@ export class CreateSolutionDto {
 
   @Type(() => Date)
   @IsDate()
-  @IsClientTimestamp()
+  @EnsureLimitedClientClockSkew()
   @ApiProperty({
     example: "2025-01-01T12:00:00Z",
     description:

--- a/backend/src/api/solutions/dto/create-solution.dto.ts
+++ b/backend/src/api/solutions/dto/create-solution.dto.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import { IsArray, IsDate } from "class-validator";
+import { IsClientTimestamp } from "src/utilities/validation/client-timestamp";
 import { CreateSolutionTestDto } from "./create-solution-test.dto";
 
 export class CreateSolutionDto {
@@ -22,6 +23,7 @@ export class CreateSolutionDto {
 
   @Type(() => Date)
   @IsDate()
+  @IsClientTimestamp()
   @ApiProperty({
     example: "2025-01-01T12:00:00Z",
     description:

--- a/backend/src/api/solutions/dto/existing-student-solution.dto.ts
+++ b/backend/src/api/solutions/dto/existing-student-solution.dto.ts
@@ -33,6 +33,14 @@ export class ExistingStudentSolutionDto
   readonly createdAt!: Date;
 
   @ApiProperty({
+    description:
+      "Client timestamp of the solution submission. May differ from createdAt.",
+  })
+  @Expose()
+  @Type(() => Date)
+  readonly happenedAt!: Date;
+
+  @ApiProperty({
     example: "true",
     description: "Whether this solution is marked as a reference solution.",
     type: "boolean",

--- a/backend/src/api/solutions/solutions.controller.ts
+++ b/backend/src/api/solutions/solutions.controller.ts
@@ -98,10 +98,10 @@ export class SolutionsController {
 
     const studentSolution = await this.solutionsService.createStudentSolution(
       {
-        ...createSolutionDto,
         sessionId,
         taskId,
         studentId: student.id,
+        happenedAt: createSolutionDto.happenedAt,
         tests: {
           create: createSolutionDto.tests,
         },

--- a/backend/src/api/solutions/solutions.queries.spec.ts
+++ b/backend/src/api/solutions/solutions.queries.spec.ts
@@ -93,6 +93,7 @@ describe("getCurrentAnalyses and getCurrentAnalysesWithActivities", () => {
         solutionHash,
         studentId,
         sessionId,
+        happenedAt: createdAt ?? new Date(),
         ...(createdAt && { createdAt }),
       },
     });

--- a/backend/src/api/solutions/solutions.service.ts
+++ b/backend/src/api/solutions/solutions.service.ts
@@ -455,48 +455,63 @@ export class SolutionsService {
     studentId: number,
     includeSoftDelete = false,
   ): Promise<SolutionDataOnly> {
-    const latestSubmittedSolution = await this.prisma.studentSolution.findFirst(
-      {
-        select: {
-          solution: { select: { data: true, mimeType: true } },
-          happenedAt: true,
-        },
-        where: includeSoftDelete
-          ? { studentId, taskId, sessionId }
-          : { studentId, taskId, sessionId, deletedAt: null },
-        orderBy: {
-          happenedAt: "desc",
-        },
+    const latestStudentSolution = await this.prisma.studentSolution.findFirst({
+      select: {
+        solution: { select: { data: true, mimeType: true } },
+        id: true,
+        createdAt: true,
+        happenedAt: true,
       },
-    );
+      where: includeSoftDelete
+        ? { studentId, taskId, sessionId }
+        : { studentId, taskId, sessionId, deletedAt: null },
+      orderBy: [
+        { happenedAt: "desc" },
+        // The id is unique, so it is enough to break ties when two client
+        // timestamps are exactly the same.
+        { id: "desc" },
+      ],
+    });
 
-    const solutionFromLatestActivity =
-      await this.prisma.studentActivity.findFirst({
-        select: {
-          solution: { select: { data: true, mimeType: true } },
-          happenedAt: true,
-        },
-        where: includeSoftDelete
-          ? { studentId, taskId, sessionId }
-          : { studentId, taskId, sessionId, deletedAt: null },
-        orderBy: {
-          happenedAt: "desc",
-        },
-      });
+    const latestStudentActivity = await this.prisma.studentActivity.findFirst({
+      select: {
+        solution: { select: { data: true, mimeType: true } },
+        id: true,
+        createdAt: true,
+        happenedAt: true,
+        happenedAtCounter: true,
+      },
+      where: includeSoftDelete
+        ? { studentId, taskId, sessionId }
+        : { studentId, taskId, sessionId, deletedAt: null },
+      orderBy: [
+        { happenedAt: "desc" },
+        { happenedAtCounter: "desc" },
+        { createdAt: "desc" },
+        { id: "desc" },
+      ],
+    });
 
-    if (!latestSubmittedSolution && !solutionFromLatestActivity) {
+    if (!latestStudentSolution && !latestStudentActivity) {
       throw new NotFoundException();
     }
 
-    if (latestSubmittedSolution && solutionFromLatestActivity) {
+    if (latestStudentSolution && latestStudentActivity) {
       // prefer the most recent solution by client timestamp
-      return latestSubmittedSolution.happenedAt >
-        solutionFromLatestActivity.happenedAt
-        ? latestSubmittedSolution.solution
-        : solutionFromLatestActivity.solution;
+      const isStudentSolutionNewerThanActivity =
+        latestStudentSolution.happenedAt.getTime() >
+          latestStudentActivity.happenedAt.getTime() ||
+        (latestStudentSolution.happenedAt.getTime() ===
+          latestStudentActivity.happenedAt.getTime() &&
+          latestStudentSolution.createdAt.getTime() >=
+            latestStudentActivity.createdAt.getTime());
+
+      return isStudentSolutionNewerThanActivity
+        ? latestStudentSolution.solution
+        : latestStudentActivity.solution;
     }
 
-    return (latestSubmittedSolution || solutionFromLatestActivity)!.solution;
+    return (latestStudentSolution || latestStudentActivity)!.solution;
   }
 
   findManyStudentSolutions(

--- a/backend/src/api/solutions/solutions.service.ts
+++ b/backend/src/api/solutions/solutions.service.ts
@@ -459,13 +459,13 @@ export class SolutionsService {
       {
         select: {
           solution: { select: { data: true, mimeType: true } },
-          createdAt: true,
+          happenedAt: true,
         },
         where: includeSoftDelete
           ? { studentId, taskId, sessionId }
           : { studentId, taskId, sessionId, deletedAt: null },
         orderBy: {
-          createdAt: "desc",
+          happenedAt: "desc",
         },
       },
     );
@@ -474,13 +474,13 @@ export class SolutionsService {
       await this.prisma.studentActivity.findFirst({
         select: {
           solution: { select: { data: true, mimeType: true } },
-          createdAt: true,
+          happenedAt: true,
         },
         where: includeSoftDelete
           ? { studentId, taskId, sessionId }
           : { studentId, taskId, sessionId, deletedAt: null },
         orderBy: {
-          createdAt: "desc",
+          happenedAt: "desc",
         },
       });
 
@@ -489,9 +489,9 @@ export class SolutionsService {
     }
 
     if (latestSubmittedSolution && solutionFromLatestActivity) {
-      // prefer the most recent solution
-      return latestSubmittedSolution.createdAt >
-        solutionFromLatestActivity.createdAt
+      // prefer the most recent solution by client timestamp
+      return latestSubmittedSolution.happenedAt >
+        solutionFromLatestActivity.happenedAt
         ? latestSubmittedSolution.solution
         : solutionFromLatestActivity.solution;
     }

--- a/backend/src/api/student-activity/dto/track-activity.dto.ts
+++ b/backend/src/api/student-activity/dto/track-activity.dto.ts
@@ -1,7 +1,15 @@
 import { ApiProperty } from "@nestjs/swagger";
-import { IsNotEmpty, IsString, IsInt, IsEnum, IsDate } from "class-validator";
+import {
+  IsNotEmpty,
+  IsString,
+  IsInt,
+  IsEnum,
+  IsDate,
+  Min,
+} from "class-validator";
 import { Type } from "class-transformer";
 import { StudentActivityType } from "@prisma/client";
+import { IsClientTimestamp } from "src/utilities/validation/client-timestamp";
 import { TrackAppStudentActivityDto } from "./track-app-activity.dto";
 
 export class TrackStudentActivityDto {
@@ -41,6 +49,7 @@ export class TrackStudentActivityDto {
 
   @Type(() => Date)
   @IsDate()
+  @IsClientTimestamp()
   @ApiProperty({
     example: "2025-01-01T12:00:00Z",
     description: "The time the activity happened at.",
@@ -49,6 +58,7 @@ export class TrackStudentActivityDto {
 
   @Type(() => Number)
   @IsInt()
+  @Min(0)
   @ApiProperty({
     example: 0,
     description: "The counter for activities that happened at the same time.",

--- a/backend/src/api/student-activity/dto/track-activity.dto.ts
+++ b/backend/src/api/student-activity/dto/track-activity.dto.ts
@@ -9,7 +9,7 @@ import {
 } from "class-validator";
 import { Type } from "class-transformer";
 import { StudentActivityType } from "@prisma/client";
-import { IsClientTimestamp } from "src/utilities/validation/client-timestamp";
+import { EnsureLimitedClientClockSkew } from "src/utilities/validation/client-timestamp";
 import { TrackAppStudentActivityDto } from "./track-app-activity.dto";
 
 export class TrackStudentActivityDto {
@@ -49,7 +49,7 @@ export class TrackStudentActivityDto {
 
   @Type(() => Date)
   @IsDate()
-  @IsClientTimestamp()
+  @EnsureLimitedClientClockSkew()
   @ApiProperty({
     example: "2025-01-01T12:00:00Z",
     description: "The time the activity happened at.",

--- a/backend/src/utilities/validation/client-timestamp.ts
+++ b/backend/src/utilities/validation/client-timestamp.ts
@@ -1,0 +1,24 @@
+import { ValidateBy, ValidationOptions, buildMessage } from "class-validator";
+
+export const maxClientClockSkewMilliseconds = 5 * 60 * 1000;
+
+export const IsClientTimestamp = (
+  validationOptions?: ValidationOptions,
+): PropertyDecorator =>
+  ValidateBy(
+    {
+      name: "isClientTimestamp",
+      validator: {
+        validate: (value: unknown): boolean =>
+          value instanceof Date &&
+          !Number.isNaN(value.getTime()) &&
+          value.getTime() <= Date.now() + maxClientClockSkewMilliseconds,
+        defaultMessage: buildMessage(
+          (eachPrefix) =>
+            `${eachPrefix}$property must not be more than five minutes ahead of the server clock`,
+          validationOptions,
+        ),
+      },
+    },
+    validationOptions,
+  );

--- a/backend/src/utilities/validation/client-timestamp.ts
+++ b/backend/src/utilities/validation/client-timestamp.ts
@@ -2,12 +2,12 @@ import { ValidateBy, ValidationOptions, buildMessage } from "class-validator";
 
 export const maxClientClockSkewMilliseconds = 5 * 60 * 1000;
 
-export const IsClientTimestamp = (
+export const EnsureLimitedClientClockSkew = (
   validationOptions?: ValidationOptions,
 ): PropertyDecorator =>
   ValidateBy(
     {
-      name: "isClientTimestamp",
+      name: "EnsureLimitedClientClockSkew",
       validator: {
         validate: (value: unknown): boolean =>
           value instanceof Date &&

--- a/backend/test/helpers/task/index.ts
+++ b/backend/test/helpers/task/index.ts
@@ -109,6 +109,7 @@ export const createStudentSolution = async (
     solutionHash: Buffer;
     studentId: number;
     sessionId: number;
+    happenedAt?: Date;
   },
 ): Promise<StudentSolution> => {
   const prisma = app.get(PrismaService);
@@ -132,6 +133,7 @@ export const createStudentSolution = async (
       solutionHash: options.solutionHash,
       studentId: options.studentId,
       sessionId: options.sessionId,
+      happenedAt: options.happenedAt ?? new Date(),
       deletedAt: null,
     },
   });

--- a/frontend/src/api/collimator/generated/endpoints/solutions/solutions.msw.ts
+++ b/frontend/src/api/collimator/generated/endpoints/solutions/solutions.msw.ts
@@ -19,6 +19,7 @@ export const getSolutionsControllerCreateStudentSolutionV0ResponseMock = (
 ): ExistingStudentSolutionDto => ({
   id: faker.number.float({ min: undefined, max: undefined, fractionDigits: 2 }),
   createdAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
+  happenedAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
   isReference: faker.datatype.boolean(),
   studentId: faker.number.float({
     min: undefined,
@@ -104,6 +105,7 @@ export const getSolutionsControllerFindAllStudentSolutionsV0ResponseMock =
         fractionDigits: 2,
       }),
       createdAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
+      happenedAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
       isReference: faker.datatype.boolean(),
       studentId: faker.number.float({
         min: undefined,
@@ -327,6 +329,7 @@ export const getSolutionsControllerDownloadLatestStudentSolutionV0ResponseMock =
       fractionDigits: 2,
     }),
     createdAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
+    happenedAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
     isReference: faker.datatype.boolean(),
     studentId: faker.number.float({
       min: undefined,
@@ -405,6 +408,7 @@ export const getSolutionsControllerFindOneStudentSolutionV0ResponseMock = (
 ): ExistingStudentSolutionDto => ({
   id: faker.number.float({ min: undefined, max: undefined, fractionDigits: 2 }),
   createdAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
+  happenedAt: `${faker.date.past().toISOString().split(".")[0]}Z`,
   isReference: faker.datatype.boolean(),
   studentId: faker.number.float({
     min: undefined,

--- a/frontend/src/api/collimator/generated/endpoints/solutions/solutions.ts
+++ b/frontend/src/api/collimator/generated/endpoints/solutions/solutions.ts
@@ -40,6 +40,7 @@ export const solutionsControllerCreateStudentSolutionV0 = async (
     formData.append(`tests`, JSON.stringify(value)),
   );
   formData.append(`file`, createSolutionDto.file);
+  formData.append(`happenedAt`, createSolutionDto.happenedAt);
 
   return fetchApi<ExistingStudentSolutionDto>(
     getSolutionsControllerCreateStudentSolutionV0Url(

--- a/frontend/src/api/collimator/generated/models/createSolutionDto.ts
+++ b/frontend/src/api/collimator/generated/models/createSolutionDto.ts
@@ -12,4 +12,6 @@ export interface CreateSolutionDto {
   tests: CreateSolutionTestDto[];
   /** Solution file */
   file: Blob;
+  /** Client timestamp of the solution submission. May differ from the server-side createdAt. */
+  happenedAt: string;
 }

--- a/frontend/src/api/collimator/generated/models/existingStudentSolutionDto.ts
+++ b/frontend/src/api/collimator/generated/models/existingStudentSolutionDto.ts
@@ -12,6 +12,8 @@ export interface ExistingStudentSolutionDto {
   /** The solution's unique identifier, a positive integer. */
   id: number;
   createdAt: string;
+  /** Client timestamp of the solution submission. May differ from createdAt. */
+  happenedAt: string;
   /** Whether this solution is marked as a reference solution. */
   isReference: boolean;
   studentId: number;

--- a/frontend/src/api/collimator/hooks/solutions/useCreateSolution.ts
+++ b/frontend/src/api/collimator/hooks/solutions/useCreateSolution.ts
@@ -30,6 +30,7 @@ const solutionsControllerCreate = async (
   const formData = new FormData();
   formData.append("tests", JSON.stringify(createSolutionDto.tests));
   formData.append("file", createSolutionDto.file);
+  formData.append("happenedAt", createSolutionDto.happenedAt);
 
   return fetchApi<Promise<CreateStudentSolutionResponse>>(
     getSolutionsControllerCreateStudentSolutionV0Url(

--- a/frontend/src/api/collimator/hooks/student-activity/useTrackStudentActivity.ts
+++ b/frontend/src/api/collimator/hooks/student-activity/useTrackStudentActivity.ts
@@ -135,13 +135,7 @@ export const useTrackStudentActivity = (): [
         } catch (error) {
           // on error, ensure the activities are tracked again the next time
           // we send a request by appending them
-          activitiesToTrack = [
-            ...activitiesToTrack,
-            ...activities.map((activity) => ({
-              ...activity,
-              ...getActivityTimestamp(),
-            })),
-          ];
+          activitiesToTrack = [...activitiesToTrack, ...activities];
 
           throw error;
         }

--- a/frontend/src/api/collimator/models/solutions/existing-student-solutions.ts
+++ b/frontend/src/api/collimator/models/solutions/existing-student-solutions.ts
@@ -9,6 +9,7 @@ export class ExistingStudentSolution {
   readonly studentId: number;
   readonly taskId: number;
   readonly createdAt: Date;
+  readonly happenedAt: Date;
   readonly solution: ExistingSolution;
   readonly isReference: boolean;
   readonly tests: ExistingSolutionTest[] = [];
@@ -19,6 +20,7 @@ export class ExistingStudentSolution {
     studentId,
     taskId,
     createdAt,
+    happenedAt,
     solution,
     isReference,
     tests,
@@ -28,6 +30,7 @@ export class ExistingStudentSolution {
     this.studentId = studentId;
     this.taskId = taskId;
     this.createdAt = createdAt;
+    this.happenedAt = happenedAt;
     this.solution = solution;
     this.isReference = isReference;
     this.tests = tests;
@@ -37,6 +40,7 @@ export class ExistingStudentSolution {
     return new ExistingStudentSolution({
       ...dto,
       createdAt: new Date(dto.createdAt),
+      happenedAt: new Date(dto.happenedAt),
       solution: ExistingSolution.fromDto(dto.solution),
       tests: dto.tests.map(ExistingSolutionTest.fromDto),
     });
@@ -51,7 +55,8 @@ export class ExistingStudentSolution {
 
     return solutions.reduce(
       (mostRecentSolution, solution) =>
-        mostRecentSolution.createdAt.getTime() >= solution.createdAt.getTime()
+        mostRecentSolution.happenedAt.getTime() >=
+        solution.happenedAt.getTime()
           ? mostRecentSolution
           : solution,
       solutions[0],

--- a/frontend/src/api/collimator/models/solutions/existing-student-solutions.ts
+++ b/frontend/src/api/collimator/models/solutions/existing-student-solutions.ts
@@ -55,8 +55,7 @@ export class ExistingStudentSolution {
 
     return solutions.reduce(
       (mostRecentSolution, solution) =>
-        mostRecentSolution.happenedAt.getTime() >=
-        solution.happenedAt.getTime()
+        mostRecentSolution.happenedAt.getTime() >= solution.happenedAt.getTime()
           ? mostRecentSolution
           : solution,
       solutions[0],

--- a/frontend/src/api/collimator/models/solutions/existing-student-solutions.ts
+++ b/frontend/src/api/collimator/models/solutions/existing-student-solutions.ts
@@ -53,12 +53,19 @@ export class ExistingStudentSolution {
       return null;
     }
 
-    return solutions.reduce(
-      (mostRecentSolution, solution) =>
-        mostRecentSolution.happenedAt.getTime() >= solution.happenedAt.getTime()
-          ? mostRecentSolution
-          : solution,
-      solutions[0],
-    );
+    return solutions.reduce((mostRecentSolution, solution) => {
+      const happenedAtDifference =
+        mostRecentSolution.happenedAt.getTime() - solution.happenedAt.getTime();
+
+      if (happenedAtDifference !== 0) {
+        return happenedAtDifference > 0 ? mostRecentSolution : solution;
+      }
+
+      // The id is unique, so it is enough to tie break when two client
+      // timestamps are exactly the same
+      return mostRecentSolution.id >= solution.id
+        ? mostRecentSolution
+        : solution;
+    }, solutions[0]);
   }
 }

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/solve.tsx
@@ -143,6 +143,7 @@ const SolveTaskPage = () => {
           ...submission.failedTests.map(mapTest(false)),
           ...submission.passedTests.map(mapTest(true)),
         ],
+        happenedAt: new Date().toISOString(),
       });
 
       if (
@@ -292,6 +293,7 @@ const SolveTaskPage = () => {
         await createSolution(session.klass.id, session.id, task.id, {
           file: solutionBlob,
           tests: [],
+          happenedAt: new Date().toISOString(),
         });
         setSaveError(false);
       } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add client happenedAt to student solutions, validate it, and use it to consistently pick the latest submission across solutions and activities. Aligns ordering with Student Activities for CRT-455.

- **New Features**
  - Create-solution accepts/returns happenedAt; frontend sends it; DTOs/models/mocks updated.
  - Validate client timestamps (reject >5 min ahead) and require non‑negative happenedAtCounter; preserve activity timestamps on retry.
  - Deterministic “latest”: order by happenedAt with tie‑breakers (createdAt/happenedAtCounter/id); when mixing activities prefer StudentSolution on ties; applied to current/soft‑deleted queries and download‑latest.

- **Migration**
  - Add happenedAt TIMESTAMP(3) to StudentSolution.
  - Backfill existing rows with createdAt.
  - Set happenedAt to NOT NULL.

<sup>Written for commit 077e10adfc95977c205c9cb07f0338ccbd90e66d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

