### PR TITLE
Fix four Python-converter defects on valid student code

### DIFF
--- a/backend/src/ast/converters/python/__tests__/converter-regressions.spec.ts
+++ b/backend/src/ast/converters/python/__tests__/converter-regressions.spec.ts
@@ -1,0 +1,41 @@
+import { convertPythonToGeneralAst } from "../";
+
+const version = "3.10.4";
+
+const astJson = (source: string): string =>
+  JSON.stringify(convertPythonToGeneralAst(source, version));
+
+describe("Python AST converter", () => {
+  describe("regressions", () => {
+    it("converts a bare yield to a yield operator without operands", () => {
+      const asJson = astJson("def f():\n    yield\n");
+
+      expect(asJson).toContain('"operator":"yield","operands":[]');
+    });
+
+    it("converts a star-unpacking that follows a keyword argument", () => {
+      // `*args` after a keyword argument is parsed via the grammar's kwargs
+      // branch; it must still come out as the same unpack operator as a plain
+      // `f(*args)` call.
+      const asJson = astJson("f(x=2, *args)\n");
+
+      expect(asJson).toContain('"operator":"*"');
+      expect(asJson).toContain('"name":"args"');
+      expect(asJson).toContain('"operator":"named-parameter"');
+      expect(asJson).toContain('"value":"x"');
+    });
+
+    it("distinguishes def from async def", () => {
+      expect(
+        convertPythonToGeneralAst("def f():\n    pass\n", version),
+      ).not.toEqual(
+        convertPythonToGeneralAst("async def f():\n    pass\n", version),
+      );
+    });
+
+    it("marks only async functions as async", () => {
+      expect(astJson("async def f():\n    pass\n")).toContain('"isAsync":true');
+      expect(astJson("def f():\n    pass\n")).not.toContain('"isAsync"');
+    });
+  });
+});

--- a/backend/src/ast/converters/python/__tests__/crash-corpus.spec.ts
+++ b/backend/src/ast/converters/python/__tests__/crash-corpus.spec.ts
@@ -1,0 +1,157 @@
+import { convertPythonToGeneralAst } from "../";
+
+const version = "3.10.4";
+
+// Every snippet is valid Python. The converter must produce an AST for all of
+// them; a throw is a finding.
+const corpus: [string, string][] = [
+  // conditionals (regression for the CRT-457 fix)
+  ["bare if", "if x > 3:\n    y = 1\n"],
+  ["if/elif no else", "if x > 3:\n    y = 1\nelif x > 2:\n    y = 2\n"],
+  // try variants
+  ["try/bare except", "try:\n    x = 1\nexcept:\n    pass\n"],
+  ["try/except type", "try:\n    x = 1\nexcept ValueError:\n    pass\n"],
+  ["try/except as", "try:\n    x = 1\nexcept ValueError as e:\n    pass\n"],
+  ["try/finally only", "try:\n    x = 1\nfinally:\n    pass\n"],
+  [
+    "try/except/else",
+    "try:\n    x = 1\nexcept ValueError:\n    pass\nelse:\n    y = 2\n",
+  ],
+  [
+    "try/except/else/finally",
+    "try:\n    x = 1\nexcept ValueError:\n    pass\nelse:\n    y = 2\nfinally:\n    z = 3\n",
+  ],
+  // loops
+  ["for without else", "for i in range(3):\n    x = i\n"],
+  ["for with else", "for i in range(3):\n    x = i\nelse:\n    y = 1\n"],
+  ["while without else", "while False:\n    x = 1\n"],
+  ["for with break", "for i in range(3):\n    break\n"],
+  ["for with continue", "for i in range(3):\n    continue\n"],
+  // with
+  ["with as", 'with open("f") as f:\n    x = 1\n'],
+  ["with without as", "with lock:\n    x = 1\n"],
+  ["with two items", "with a as x, b as y:\n    pass\n"],
+  ["with item no as mixed", "with a, b as y:\n    pass\n"],
+  // return / raise / yield
+  ["bare return", "def f():\n    return\n"],
+  ["return value", "def f():\n    return 1\n"],
+  ["return tuple", "def f():\n    return 1, 2\n"],
+  ["bare raise", "def f():\n    raise\n"],
+  ["raise exc", "def f():\n    raise ValueError()\n"],
+  ["raise from", "def f():\n    raise ValueError() from None\n"],
+  ["bare yield", "def f():\n    yield\n"],
+  ["yield value", "def f():\n    yield 1\n"],
+  ["yield from", "def f():\n    yield from range(3)\n"],
+  // functions
+  ["lambda no params", "f = lambda: 1\n"],
+  ["lambda default", "f = lambda x=1: x\n"],
+  ["def star args", "def f(*args, **kwargs):\n    pass\n"],
+  ["def pos-only slash", "def f(x, /, y):\n    pass\n"],
+  ["def kw-only star", "def f(x, *, y):\n    pass\n"],
+  [
+    "def annotations",
+    'def f(x: int, y: str = "a") -> bool:\n    return True\n',
+  ],
+  ["def default value", "def f(x=1):\n    pass\n"],
+  ["decorator bare", "@staticmethod\ndef f():\n    pass\n"],
+  ["decorator call", "@decorator(1)\ndef f():\n    pass\n"],
+  ["nested def", "def f():\n    def g():\n        pass\n    return g\n"],
+  // classes
+  ["class no bases", "class C:\n    pass\n"],
+  ["class empty parens", "class C():\n    pass\n"],
+  ["class base", "class C(B):\n    pass\n"],
+  ["class metaclass kwarg", "class C(B, metaclass=M):\n    pass\n"],
+  // slices and subscripts
+  ["slice full open", "y = a[:]\n"],
+  ["slice full open with step colon", "y = a[::]\n"],
+  ["slice start", "y = a[1:]\n"],
+  ["slice stop", "y = a[:2]\n"],
+  ["slice step only", "y = a[::2]\n"],
+  ["slice negative step", "y = a[::-1]\n"],
+  ["slice all three", "y = a[1:2:3]\n"],
+  ["subscript tuple", "y = a[1, 2]\n"],
+  // simple statements
+  ["assert bare", "assert x\n"],
+  ["assert message", 'assert x, "boom"\n'],
+  ["del single", "del x\n"],
+  ["del multiple", "del x, y\n"],
+  ["global", "def f():\n    global x\n    x = 1\n"],
+  [
+    "nonlocal",
+    "def f():\n    x = 1\n    def g():\n        nonlocal x\n        x = 2\n    return g\n",
+  ],
+  ["pass", "pass\n"],
+  ["ellipsis", "x = ...\n"],
+  // imports
+  ["import", "import os\n"],
+  ["import as", "import os as o\n"],
+  ["from import", "from os import path\n"],
+  ["from import as", "from os import path as p\n"],
+  ["from import star", "from os import *\n"],
+  ["relative import", "from . import sibling\n"],
+  // assignments
+  ["chained assign", "a = b = 1\n"],
+  ["augmented", "x += 1\n"],
+  ["star unpack", "a, *b = [1, 2, 3]\n"],
+  ["annotated with value", "x: int = 1\n"],
+  ["annotated no value", "x: int\n"],
+  ["walrus", "if (n := 10) > 5:\n    y = n\n"],
+  ["tuple no parens", "x = 1, 2\n"],
+  // expressions
+  ["ternary", "y = a if c else b\n"],
+  ["chained comparison", "y = 1 < x < 10\n"],
+  ["unary ops", "y = -x + +x - ~x\n"],
+  ["not/and/or", "y = not a and b or c\n"],
+  ["is/in", "y = a is not None and b not in c\n"],
+  ["arith ops", "y = a ** 2 // 3 % 4 * 5 / 6\n"],
+  ["bitwise ops", "y = a & b | c ^ d << 2 >> 1\n"],
+  ["matmul", "y = a @ b\n"],
+  ["call kwargs", "f(1, x=2, *args, **kw)\n"],
+  ["call kwarg only", "f(x=2)\n"],
+  ["call star only", "f(*args)\n"],
+  ["call doublestar only", "f(**kw)\n"],
+  ["call kwarg then star", "f(x=2, *args)\n"],
+  ["call kwarg then doublestar", "f(x=2, **kw)\n"],
+  ["call star then kwarg", "f(*args, x=2)\n"],
+  ["call star then doublestar", "f(*args, **kw)\n"],
+  ["call pos then kwarg", "f(1, x=2)\n"],
+  ["attribute chain", "y = a.b.c.d\n"],
+  ["fstring simple", 'y = f"{x}"\n'],
+  ["fstring format spec", 'y = f"{x!r:>10}"\n'],
+  ["implicit concat", 'y = "a" "b"\n'],
+  ["bytes", 'y = b"abc"\n'],
+  ["numbers", "y = 1_000 + 0x1F + 1e-3 + 1j\n"],
+  ["empty collections", "a = []\nb = {}\nc = ()\nd = set()\n"],
+  ["list comp", "y = [i for i in range(3)]\n"],
+  ["list comp if", "y = [i for i in range(3) if i > 1]\n"],
+  ["dict comp", "y = {k: v for k, v in items}\n"],
+  ["set comp", "y = {i for i in range(3)}\n"],
+  ["genexp in call", "y = sum(i for i in range(3))\n"],
+  ["nested comp", "y = [[j for j in range(i)] for i in range(3)]\n"],
+  // async
+  ["async def", "async def f():\n    pass\n"],
+  ["await", "async def f():\n    await g()\n"],
+  ["async for", "async def f():\n    async for i in gen():\n        pass\n"],
+  ["async with", "async def f():\n    async with lock:\n        pass\n"],
+  // match (3.10+)
+  ["match wildcard", "match x:\n    case _:\n        pass\n"],
+  ["match literal", "match x:\n    case 1:\n        pass\n"],
+  ["match capture", "match x:\n    case y:\n        pass\n"],
+  ["match guard", "match x:\n    case y if y > 1:\n        pass\n"],
+  ["match or-pattern", "match x:\n    case 1 | 2:\n        pass\n"],
+  [
+    "match class pattern",
+    "match x:\n    case Point(x=0, y=0):\n        pass\n",
+  ],
+  ["match sequence", "match x:\n    case [a, b]:\n        pass\n"],
+  ["match star pattern", "match x:\n    case [a, *rest]:\n        pass\n"],
+  ["match mapping", 'match x:\n    case {"k": v}:\n        pass\n'],
+  ["match as-pattern", "match x:\n    case [1, 2] as pair:\n        pass\n"],
+  ["match value pattern", "match x:\n    case Color.RED:\n        pass\n"],
+];
+
+describe("Python AST converter crash corpus", () => {
+  it.each(corpus)("%s", (_label, source) => {
+    expect(() => convertPythonToGeneralAst(source, version)).not.toThrow();
+  });
+});

--- a/backend/src/ast/converters/python/__tests__/slices.spec.ts
+++ b/backend/src/ast/converters/python/__tests__/slices.spec.ts
@@ -1,0 +1,65 @@
+import { convertPythonToGeneralAst } from "../";
+
+const version = "3.10.4";
+
+// The create-slice operator name encodes which of start/stop/step are present
+// (e.g. "create-slice-stop"). These tests pin down that each expression is
+// bucketed by its position relative to the colons, not by count: `a[:2]` is a
+// stop, `a[::2]` is a step, and they must not collapse into the same AST.
+const sliceOperatorOf = (source: string): string => {
+  const asJson = JSON.stringify(convertPythonToGeneralAst(source, version));
+  const match = /"operator":"(create-slice[a-z-]*)"/.exec(asJson);
+  return match ? match[1] : `<no create-slice operator in ${asJson}>`;
+};
+
+describe("Python AST converter", () => {
+  describe("slices", () => {
+    it("converts a full-open slice a[:]", () => {
+      expect(sliceOperatorOf("y = a[:]\n")).toBe("create-slice");
+    });
+
+    it("converts a full-open slice a[::]", () => {
+      expect(sliceOperatorOf("y = a[::]\n")).toBe("create-slice");
+    });
+
+    it("converts a stop-only slice a[:2]", () => {
+      expect(sliceOperatorOf("y = a[:2]\n")).toBe("create-slice-stop");
+    });
+
+    it("converts a step-only slice a[::2]", () => {
+      expect(sliceOperatorOf("y = a[::2]\n")).toBe("create-slice-step");
+    });
+
+    it("converts a stop slice with a trailing colon a[:2:]", () => {
+      expect(sliceOperatorOf("y = a[:2:]\n")).toBe("create-slice-stop");
+    });
+
+    it("converts a start-only slice a[1:]", () => {
+      expect(sliceOperatorOf("y = a[1:]\n")).toBe("create-slice-start");
+    });
+
+    it("converts a start and step slice a[1::3]", () => {
+      expect(sliceOperatorOf("y = a[1::3]\n")).toBe("create-slice-start-step");
+    });
+
+    it("converts a stop and step slice a[:2:3]", () => {
+      expect(sliceOperatorOf("y = a[:2:3]\n")).toBe("create-slice-stop-step");
+    });
+
+    it("converts a start and stop slice a[1:2]", () => {
+      expect(sliceOperatorOf("y = a[1:2]\n")).toBe("create-slice-start-stop");
+    });
+
+    it("converts a full slice a[1:2:3]", () => {
+      expect(sliceOperatorOf("y = a[1:2:3]\n")).toBe(
+        "create-slice-start-stop-step",
+      );
+    });
+
+    it("produces different ASTs for a[:2] and a[::2]", () => {
+      expect(convertPythonToGeneralAst("y = a[:2]\n", version)).not.toEqual(
+        convertPythonToGeneralAst("y = a[::2]\n", version),
+      );
+    });
+  });
+});

--- a/backend/src/ast/converters/python/nodes/expressions/kwarg-or-starred.ts
+++ b/backend/src/ast/converters/python/nodes/expressions/kwarg-or-starred.ts
@@ -1,14 +1,8 @@
-import { AstNodeType } from "src/ast/types/general-ast";
-import {
-  ExpressionNodeType,
-  OperatorNode,
-} from "src/ast/types/general-ast/ast-nodes/expression-node";
 import { IPythonAstVisitor } from "../../python-ast-visitor-interface";
 import {
   Kwarg_or_starredContext,
   NameContext,
 } from "../../generated/PythonParser";
-import { starArgsOperator } from "../../operators";
 import { PythonFunctionArgument } from "./args";
 
 export const convertKwargOrStarred = (
@@ -16,22 +10,20 @@ export const convertKwargOrStarred = (
   ctx: Kwarg_or_starredContext,
 ): PythonFunctionArgument => {
   const name = ctx.name() as NameContext | undefined;
-  const expression = visitor.getExpression(ctx.expression());
 
   if (name) {
     return {
       name: name.getText(),
-      expression: expression.node,
+      expression: visitor.getExpression(ctx.expression()).node,
     };
   }
 
+  // The grammar's other alternative: a starred_expression (`*args` appearing
+  // after a keyword argument has started the kwargs list). expression() is
+  // null here; visiting the starred expression produces the same unpack
+  // operator as a plain `f(*args)` call.
   return {
     name: null,
-    expression: {
-      nodeType: AstNodeType.expression,
-      expressionType: ExpressionNodeType.operator,
-      operator: starArgsOperator,
-      operands: [expression.node],
-    } satisfies OperatorNode,
+    expression: visitor.getExpression(ctx.starred_expression()).node,
   };
 };

--- a/backend/src/ast/converters/python/nodes/expressions/slice.ts
+++ b/backend/src/ast/converters/python/nodes/expressions/slice.ts
@@ -13,48 +13,45 @@ export const convertSlice = (
   visitor: IPythonAstVisitor,
   ctx: SliceContext,
 ): PythonVisitorReturnValue => {
-  const { nodes: expressions, functionDeclarations } = visitor.getExpressions(
-    ctx.expression_list(),
-  );
+  const colons = ctx.COLON_list();
 
-  if (expressions.length > 0) {
-    let startExpression: ExpressionNode | null = null;
-    let stopExpression: ExpressionNode | null = null;
-    let stepExpression: ExpressionNode | null = null;
-
-    const colonList = ctx.COLON_list();
-    if (ctx.start.text === ":") {
-      // we do not have a start expression
-      stopExpression = expressions[0];
-      stepExpression = expressions.length > 1 ? expressions[1] : null;
-    } else if (colonList.length === 1) {
-      // we do not have a step expression
-      startExpression = expressions[0];
-      stopExpression = expressions.length > 1 ? expressions[1] : null;
-    } else if (colonList.length === 2 && expressions.length === 2) {
-      // we have do not have a stop expression
-      startExpression = expressions[0];
-      stepExpression = expressions[1];
-    } else if (colonList.length === 2 && expressions.length === 3) {
-      // we have all three expressions
-      startExpression = expressions[0];
-      stopExpression = expressions[1];
-      stepExpression = expressions[2];
-    } else {
-      throw new Error(
-        `Unexpected slice format. Found ${colonList.length} colons, ${expressions.length} expressions and the '${ctx.start.text}' starting token.`,
-      );
-    }
-
-    return createSliceExpression(
-      startExpression,
-      stopExpression,
-      stepExpression,
-      functionDeclarations,
-    );
+  if (colons.length === 0) {
+    // the grammar's named_expression alternative: a plain subscript like a[1]
+    return visitor.visit(ctx.named_expression());
   }
 
-  return visitor.visit(ctx.named_expression());
+  // The colon form: which of start/stop/step an expression is follows from
+  // its position relative to the colons, not from how many expressions there
+  // are (a[:2] is a stop, a[::2] is a step). A fully open slice like a[:] has
+  // no expressions at all.
+  let startExpression: ExpressionNode | null = null;
+  let stopExpression: ExpressionNode | null = null;
+  let stepExpression: ExpressionNode | null = null;
+  const functionDeclarations: FunctionDeclarationNode[] = [];
+
+  for (const expressionCtx of ctx.expression_list()) {
+    const colonsBefore = colons.filter(
+      (colon) => colon.symbol.tokenIndex < expressionCtx.start.tokenIndex,
+    ).length;
+
+    const expression = visitor.getExpression(expressionCtx);
+    functionDeclarations.push(...expression.functionDeclarations);
+
+    if (colonsBefore === 0) {
+      startExpression = expression.node;
+    } else if (colonsBefore === 1) {
+      stopExpression = expression.node;
+    } else {
+      stepExpression = expression.node;
+    }
+  }
+
+  return createSliceExpression(
+    startExpression,
+    stopExpression,
+    stepExpression,
+    functionDeclarations,
+  );
 };
 
 const createSliceExpression = (

--- a/backend/src/ast/converters/python/nodes/expressions/yield-expr.ts
+++ b/backend/src/ast/converters/python/nodes/expressions/yield-expr.ts
@@ -12,11 +12,11 @@ export const convertYieldExpr = (
   visitor: IPythonAstVisitor,
   ctx: Yield_exprContext,
 ): PythonVisitorReturnValue => {
-  const expression = visitor.getExpression(
-    ctx.expression() ?? ctx.star_expressions(),
-  );
+  // a bare `yield` has no value at all; the null check must happen before
+  // getExpression, which cannot handle a null context
+  const valueContext = ctx.expression() ?? ctx.star_expressions();
 
-  if (expression == null) {
+  if (valueContext == null) {
     return {
       node: {
         nodeType: AstNodeType.expression,
@@ -27,6 +27,8 @@ export const convertYieldExpr = (
       functionDeclarations: [],
     };
   }
+
+  const expression = visitor.getExpression(valueContext);
 
   return {
     node: {

--- a/backend/src/ast/converters/python/nodes/statements/function-def-raw.ts
+++ b/backend/src/ast/converters/python/nodes/statements/function-def-raw.ts
@@ -26,7 +26,8 @@ export const convertFunctionDefRaw = (
   returnType: ExpressionNode | null;
   body: StatementSequenceNode;
 } => {
-  const isAsync = ctx.ASYNC() !== undefined;
+  // ANTLR's accessor returns null - not undefined - when `async` is absent
+  const isAsync = ctx.ASYNC() ? true : false;
   const name = ctx.name().getText();
 
   const typeParams = ctx.type_params() as Type_paramsContext | undefined;

--- a/backend/src/ast/converters/python/nodes/statements/function-def.ts
+++ b/backend/src/ast/converters/python/nodes/statements/function-def.ts
@@ -37,6 +37,7 @@ export const convertFunctionDef = (
         parameterNames: functionDeclaration.parameters.map((p) => p.name),
         body: functionDeclaration.body,
         decorators: node.expressions,
+        ...(functionDeclaration.isAsync ? { isAsync: true } : {}),
       } satisfies FunctionDeclarationNode,
       // python function declarations are not hoisted
       functionDeclarations: [],
@@ -50,6 +51,7 @@ export const convertFunctionDef = (
       name: functionDeclaration.name,
       parameterNames: functionDeclaration.parameters.map((p) => p.name),
       body: functionDeclaration.body,
+      ...(functionDeclaration.isAsync ? { isAsync: true } : {}),
     } satisfies FunctionDeclarationNode,
     // python function declarations are not hoisted
     functionDeclarations: [],

--- a/backend/src/ast/types/general-ast/ast-nodes/statement-node/function-declaration-node.ts
+++ b/backend/src/ast/types/general-ast/ast-nodes/statement-node/function-declaration-node.ts
@@ -13,5 +13,8 @@ export interface FunctionDeclarationNode extends StatementNodeBase {
 
   parameterNames: string[];
   decorators?: ExpressionNode[];
+  // set (to true) only for declarations the language marks asynchronous,
+  // e.g. python's `async def`
+  isAsync?: boolean;
   body: StatementSequenceNode;
 }


### PR DESCRIPTION
## Summary

Follow-up to #639: an adversarial review of the whole Python AST conversion (grammar-vs-code analysis of every ctx accessor by three independent reviewers, cross-checked by a 106-construct valid-Python corpus run through the converter) found four more defects, all demonstrated by failing tests before being fixed. No Jira ticket yet — happy to rename branch/commits once one exists.

### Crashes on valid Python (`TypeError: Cannot read properties of null (reading 'accept')`)

1. **Bare `yield`** — the guard added in `521a772a` runs *after* `getExpression(null)` has already thrown, so it was unreachable and a bare `yield` still crashed. The null-check now happens before.
2. **`a[:]` / `a[::]`** — a zero-expression slice fell through to the `named_expression` branch, which is null for the colon form.
3. **`f(x=2, *args)`** — star-unpacking after a keyword argument takes the `kwarg_or_starred: starred_expression` alternative, whose `expression()` accessor is null yet was read unconditionally (its hand-built `star-args` branch was unreachable dead code).

### Silent wrong ASTs (no crash — the similarity analysis was just wrong)

4. **`a[::2]` (step) ≡ `a[:2]` (stop)** — slice expressions were bucketed by count, not by which colon they follow. Now bucketed by colon position.
5. **`def` ≡ `async def`** — `isAsync` was computed with `ctx.ASYNC() !== undefined` (always true; ANTLR returns null) and then never surfaced into the AST at all, while `async for`/`async with` *are* distinguished. Fixed the detection and added an optional `isAsync` marker to `FunctionDeclarationNode`, set only for async declarations (existing sync ASTs unchanged).

## Commits

- `test:` failing tests for all five behaviours + a permanent **crash corpus**: 106 valid Python constructs that must all convert without throwing.
- Four `fix(python-ast):` commits, one per defect area (slice, kwarg-or-starred, yield, async).

## Verification

- All new tests fail before their fix and pass after.
- `src/ast`: 15 suites, 280 tests, green. Full backend jest: only pre-existing DB-dependent suites fail locally (`PrismaClientInitializationError`, no test DB in this environment) — unrelated to this `src/ast`-only diff.
- eslint + prettier clean.

### Out of scope (identified, not fixed here)

Uncontrolled behaviour on **invalid** Python: syntax errors either crash with the same raw `TypeError` (`def f(:`, malformed `case` patterns, `del (:`) or silently convert to a garbage AST (stray indent, unterminated string) because no ANTLR `ErrorListener` is registered. Hardening branch to follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes four defects in the Python AST converter that caused crashes or wrong ASTs on valid code. Removes crashes on bare yield, zero‑expr slices, and `f(x=2, *args)`, correctly distinguishes `a[:2]` vs `a[::2]`, adds `isAsync` for `async def`, and adds a 106‑snippet crash corpus to prevent regressions.

- **Bug Fixes**
  - Yield: guard null before visiting; bare `yield` now emits a no‑operand yield operator.
  - Slices: classify by colon position (start/stop/step) and handle `a[:]`/`a[::]`; `a[:2]` and `a[::2]` now produce different ASTs.
  - Calls: support the `starred_expression` alternative in `kwarg_or_starred` so `f(x=2, *args)` unpacks like `f(*args)`.
  - Functions: correct `async` detection and surface it as optional `isAsync` on `FunctionDeclarationNode` (sync ASTs unchanged).

<sup>Written for commit 665397dc46609defc132ca882d23f0c15c0a513f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

