### PR TITLE
[CRT-458] Reject invalid Python with a controlled syntax error

### DIFF
--- a/backend/src/ast/converters/python/__tests__/syntax-errors.spec.ts
+++ b/backend/src/ast/converters/python/__tests__/syntax-errors.spec.ts
@@ -1,0 +1,33 @@
+import { convertPythonToGeneralAst } from "../";
+import { PythonSyntaxError } from "../python-syntax-error";
+
+const version = "3.10.4";
+
+describe("Python AST converter", () => {
+  describe("syntax errors", () => {
+    // Invalid Python must be rejected with a controlled PythonSyntaxError -
+    // not an uncontrolled TypeError from a half-built parse tree, and not a
+    // silently converted garbage AST.
+    it.each([
+      ["unclosed def", "def f(:\n    pass\n"],
+      ["lone operator", "x = +\n"],
+      ["malformed case pattern", "match x:\n    case Foo(a=):\n        pass\n"],
+      ["malformed del target", "del (:\n"],
+      ["stray indent", "x = 1\n    y = 2\n"],
+      ["unterminated string", 'x = "abc\n'],
+    ])("rejects %s", (_label, source) => {
+      expect(() => convertPythonToGeneralAst(source, version)).toThrow(
+        PythonSyntaxError,
+      );
+    });
+
+    it.each([
+      ["simple assignment", "x = 1\n"],
+      ["function definition", "def f(x):\n    return x\n"],
+      ["comment only", "# just a comment\n"],
+      ["empty input", ""],
+    ])("still accepts valid python: %s", (_label, source) => {
+      expect(() => convertPythonToGeneralAst(source, version)).not.toThrow();
+    });
+  });
+});

--- a/backend/src/ast/converters/python/index.ts
+++ b/backend/src/ast/converters/python/index.ts
@@ -15,6 +15,11 @@ import { PythonVersion } from "./python-version";
 import PythonLexer from "./generated/PythonLexer";
 import PythonParser from "./generated/PythonParser";
 import { PythonAstVisitor } from "./python-ast-visitor";
+import { CollectingErrorListener } from "./python-error-listener";
+import {
+  PythonSyntaxError,
+  PythonSyntaxErrorDetail,
+} from "./python-syntax-error";
 
 const versionRegex = /^(\d+)(?:\.(\d+)(?:\.(\d+))?)?$/;
 
@@ -65,14 +70,29 @@ export const convertPythonV3ToStatement = (
     };
   }
 
+  // Collect syntax errors instead of ANTLR's default console logging: an
+  // error-recovered parse tree leaves grammar-mandatory children null (which
+  // crashes the visitor) or silently yields a garbage AST, so invalid Python
+  // must be rejected with a controlled error before visiting.
+  const syntaxErrors: PythonSyntaxErrorDetail[] = [];
+
   const chars = new CharStream(input);
   const lexer = new PythonLexer(chars);
+  lexer.removeErrorListeners();
+  lexer.addErrorListener(new CollectingErrorListener(syntaxErrors));
+
   const tokens = new CommonTokenStream(lexer);
   const parser = new PythonParser(tokens);
+  parser.removeErrorListeners();
+  parser.addErrorListener(new CollectingErrorListener(syntaxErrors));
   parser.buildParseTrees = true;
 
   // Use the file input entrypoint
   const tree = parser.file_input();
+
+  if (syntaxErrors.length > 0) {
+    throw new PythonSyntaxError(syntaxErrors);
+  }
 
   const { node, functionDeclarations } = new PythonAstVisitor().visit(tree);
 

--- a/backend/src/ast/converters/python/python-error-listener.ts
+++ b/backend/src/ast/converters/python/python-error-listener.ts
@@ -1,0 +1,25 @@
+import { ErrorListener, RecognitionException, Recognizer } from "antlr4";
+import { PythonSyntaxErrorDetail } from "./python-syntax-error";
+
+/**
+ * Collects lexer/parser syntax errors into a shared list instead of ANTLR's
+ * default console logging, so the converter can reject invalid Python with a
+ * controlled error rather than crashing on (or silently accepting) the
+ * error-recovered parse tree.
+ */
+export class CollectingErrorListener<TSymbol> extends ErrorListener<TSymbol> {
+  constructor(private readonly errors: PythonSyntaxErrorDetail[]) {
+    super();
+  }
+
+  override syntaxError(
+    _recognizer: Recognizer<TSymbol>,
+    _offendingSymbol: TSymbol,
+    line: number,
+    column: number,
+    message: string,
+    _e: RecognitionException | undefined,
+  ): void {
+    this.errors.push({ line, column, message });
+  }
+}

--- a/backend/src/ast/converters/python/python-syntax-error.ts
+++ b/backend/src/ast/converters/python/python-syntax-error.ts
@@ -1,0 +1,22 @@
+export interface PythonSyntaxErrorDetail {
+  line: number;
+  column: number;
+  message: string;
+}
+
+/**
+ * Thrown when the input is not valid Python. Without this, a syntax error
+ * either crashed the conversion with an uncontrolled TypeError (a parse-error
+ * recovery tree leaves mandatory children null) or - worse - silently
+ * converted into a garbage AST that polluted the similarity analysis.
+ */
+export class PythonSyntaxError extends Error {
+  constructor(readonly errors: PythonSyntaxErrorDetail[]) {
+    super(
+      `Input is not valid Python: ${errors
+        .map((e) => `line ${e.line}:${e.column} ${e.message}`)
+        .join("; ")}`,
+    );
+    this.name = "PythonSyntaxError";
+  }
+}


### PR DESCRIPTION
## Summary

Final piece of the Python-converter adversarial review (after #639 and #641): the converter registered **no ANTLR error listener**, so a cell containing a syntax error was never rejected cleanly. Depending on the input it either:

- **crashed** with an uncontrolled `TypeError: Cannot read properties of null (reading 'accept')` — the error-recovery parse tree leaves grammar-mandatory children null (`def f(:`, `x = +`, malformed `case` patterns, `del (:`), or
- **silently converted to a garbage AST** that polluted the similarity analysis (stray indent, unterminated string — ANTLR printed to the console and recovery "succeeded").

Callers couldn't distinguish a student's syntax error from a converter bug.

## Change

- `PythonSyntaxError` (new): controlled error carrying line/column/message per collected syntax error.
- `CollectingErrorListener` (new): registered on **both lexer and parser**, replacing the default console listener.
- `convertPythonV3ToStatement`: throws `PythonSyntaxError` before visiting whenever the parse reported errors.

`performAnalysis` already try/catches conversion, so invalid student code now lands in the ordinary failed-analysis path (bounded by `failedAnalyses`) with a descriptive, distinguishable error.

**Behavior change to be aware of**: inputs that previously converted *silently despite being invalid* (stray indent, unterminated string) are now rejected. That's intended — their "successful" ASTs were error-recovery artifacts.

## Commits

1. `test:` `PythonSyntaxError` contract + failing tests (6 invalid inputs must be rejected; 4 valid ones must keep converting).
2. `fix(python-ast):` the listener + throw.

## Verification

- The 6 rejection tests fail before the fix (TypeError or silent success) and pass after; valid-input tests green throughout.
- `src/ast`: 13 suites, 161 tests, all green — no existing source shape (template-literal indentation etc.) is newly rejected.
- Full backend jest: only the pre-existing DB-dependent suites fail locally (`PrismaClientInitializationError`, no test DB here).
- eslint + prettier clean.

No Jira ticket yet — happy to rename branch/commits once one exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid Python with a controlled `PythonSyntaxError` instead of crashing or producing a bad AST. This makes failures clear and prevents bad data from entering similarity analysis.

- **Bug Fixes**
  - Added `CollectingErrorListener` to the lexer and parser to collect syntax errors.
  - Throw `PythonSyntaxError` (with line/column/message) before visiting when any errors are reported.
  - Replaced ANTLR console logging; previously invalid inputs could crash or silently pass.
  - Tests cover 6 invalid inputs (now rejected) and 4 valid inputs (still accepted).

<sup>Written for commit ad183ba4e3d669dba56c40de6441cdcbf70a2c60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

