### PR TITLE
Invalidate cloudfront upon deploying

### DIFF
--- a/.github/workflows/deploy_collimator.yml
+++ b/.github/workflows/deploy_collimator.yml
@@ -68,6 +68,10 @@ on:
         required: true
         type: string
 
+      jupyter_app_sentry_dsn:
+        required: true
+        type: string
+
     secrets:
       SENTRY_AUTH_TOKEN:
         required: true
@@ -127,6 +131,7 @@ jobs:
       SENTRY_ENVIRONMENT: ${{ inputs.sentry_environment }}
       FRONTEND_SENTRY_DSN: ${{ inputs.frontend_sentry_dsn }}
       APP_SCRATCH_SENTRY_DSN: ${{ inputs.scratch_app_sentry_dsn }}
+      APP_JUPYTER_SENTRY_DSN: ${{ inputs.jupyter_app_sentry_dsn }}
 
     steps:
       - name: Check out repository code

--- a/.github/workflows/deploy_collimator.yml
+++ b/.github/workflows/deploy_collimator.yml
@@ -44,6 +44,10 @@ on:
         required: true
         type: string
 
+      cloudfront_distribution_id:
+        required: true
+        type: string
+
       backend_cluster_name:
         required: true
         type: string
@@ -113,6 +117,7 @@ jobs:
       FRONTEND_BUCKET_ID: ${{ inputs.frontend_bucket_id }}
       SCRATCH_APP_BUCKET_ID: ${{ inputs.scratch_app_bucket_id }}
       JUPYTER_APP_BUCKET_ID: ${{ inputs.jupyter_app_bucket_id }}
+      CLOUDFRONT_DISTRIBUTION_ID: ${{ inputs.cloudfront_distribution_id }}
 
       BACKEND_CLUSTER_NAME: ${{ inputs.backend_cluster_name }}
       BACKEND_SERVICE_NAME: ${{ inputs.backend_service_name }}
@@ -203,6 +208,9 @@ jobs:
           aws s3 sync ./frontend/dist/ "s3://${FRONTEND_BUCKET_ID}/" --delete
           aws s3 sync ./apps/scratch/build/ "s3://${SCRATCH_APP_BUCKET_ID}/" --delete
           aws s3 sync ./apps/jupyter/dist/app/ "s3://${JUPYTER_APP_BUCKET_ID}/" --delete
+
+      - name: Invalidate CloudFront cache
+        run: aws cloudfront create-invalidation --distribution-id "${CLOUDFRONT_DISTRIBUTION_ID}" --paths "/*"
 
       - name: Authenticate to ECR
         shell: bash

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -50,6 +50,7 @@ jobs:
       sentry_environment: development
       frontend_sentry_dsn: ${{ vars.DEV_FRONTEND_SENTRY_DSN }}
       scratch_app_sentry_dsn: ${{ vars.DEV_APP_SCRATCH_SENTRY_DSN }}
+      jupyter_app_sentry_dsn: ${{ vars.DEV_APP_JUPYTER_SENTRY_DSN }}
       
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.DEV_SENTRY_AUTH_TOKEN }}

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -42,6 +42,7 @@ jobs:
       frontend_bucket_id: ${{ vars.DEV_FRONTEND_BUCKET_ID }}
       scratch_app_bucket_id: ${{ vars.DEV_SCRATCH_APP_BUCKET_ID }}
       jupyter_app_bucket_id: ${{ vars.DEV_JUPYTER_APP_BUCKET_ID }}
+      cloudfront_distribution_id: ${{ vars.DEV_CLOUDFRONT_DISTRIBUTION_ID }}
 
       backend_cluster_name: ${{ vars.DEV_BACKEND_CLUSTER_NAME }}
       backend_service_name: ${{ vars.DEV_BACKEND_SERVICE_NAME }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -41,6 +41,7 @@ jobs:
       frontend_bucket_id: ${{ vars.PROD_FRONTEND_BUCKET_ID }}
       scratch_app_bucket_id: ${{ vars.PROD_SCRATCH_APP_BUCKET_ID }}
       jupyter_app_bucket_id: ${{ vars.PROD_JUPYTER_APP_BUCKET_ID }}
+      cloudfront_distribution_id: ${{ vars.PROD_CLOUDFRONT_DISTRIBUTION_ID }}
 
       backend_cluster_name: ${{ vars.PROD_BACKEND_CLUSTER_NAME }}
       backend_service_name: ${{ vars.PROD_BACKEND_SERVICE_NAME }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -49,6 +49,7 @@ jobs:
       sentry_environment: production
       frontend_sentry_dsn: ${{ vars.PROD_FRONTEND_SENTRY_DSN }}
       scratch_app_sentry_dsn: ${{ vars.PROD_APP_SCRATCH_SENTRY_DSN }}
+      jupyter_app_sentry_dsn: ${{ vars.PROD_APP_JUPYTER_SENTRY_DSN }}
       
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.PROD_SENTRY_AUTH_TOKEN }}

--- a/apps/jupyter/Taskfile.yml
+++ b/apps/jupyter/Taskfile.yml
@@ -127,6 +127,7 @@ tasks:
     cmds:
       - node scripts/create-symlink.js
       - node scripts/create-version.js
+      - node scripts/create-sentry-config.js
       - task: exts:nbrunner:pip
       - task: exts:nbrunner:link
 

--- a/apps/jupyter/extensions/notebook-runner/.gitignore
+++ b/apps/jupyter/extensions/notebook-runner/.gitignore
@@ -13,6 +13,9 @@ notebook_runner/labextension
 # Version file is handled by hatchling
 notebook_runner/_version.py
 
+# Generated from APP_JUPYTER_SENTRY_DSN during setup
+src/sentry-config.ts
+
 # Integration tests
 ui-tests/test-results/
 ui-tests/playwright-report/

--- a/apps/jupyter/extensions/notebook-runner/scripts/create-sentry-config.js
+++ b/apps/jupyter/extensions/notebook-runner/scripts/create-sentry-config.js
@@ -1,0 +1,7 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const dsn = process.env.APP_JUPYTER_SENTRY_DSN ?? "";
+const content = `export const SENTRY_DSN = ${JSON.stringify(dsn)};\n`;
+
+fs.writeFileSync(path.resolve(__dirname, "../src/sentry-config.ts"), content);

--- a/apps/jupyter/extensions/notebook-runner/src/sentry.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/sentry.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/browser";
+import { SENTRY_DSN } from "./sentry-config";
 import { VERSION } from "./version";
 
 export const enableSentry = (): void => {
@@ -8,7 +9,7 @@ export const enableSentry = (): void => {
     window.location.hostname !== "127.0.0.1";
 
   Sentry.init({
-    dsn: "https://2b691a9ac828880dda066b5be1ae9873@o4508199129382912.ingest.de.sentry.io/4510680604016720",
+    dsn: SENTRY_DSN,
 
     // Adds request headers and IP for users, for more info visit:
     // https://docs.sentry.io/platforms/javascript/configuration/options/#sendDefaultPii


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add CloudFront invalidation to the deploy workflow so users get fresh assets after each release. Generate the Jupyter extension Sentry DSN at build time and pass new inputs through the dev/prod workflows.

- **Migration**
  - Set `DEV_CLOUDFRONT_DISTRIBUTION_ID`, `PROD_CLOUDFRONT_DISTRIBUTION_ID`, `DEV_APP_JUPYTER_SENTRY_DSN`, and `PROD_APP_JUPYTER_SENTRY_DSN` GitHub variables.
  - If you reuse `deploy_collimator.yml`, pass `cloudfront_distribution_id` and `jupyter_app_sentry_dsn`.

<sup>Written for commit 4b0366678b3969a8f43f0369a1405b4eeed16781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

