### PR TITLE
[CRT-460] Authorize reads of a task by id

### DIFF
--- a/backend/src/api/authorization/authorization.service.ts
+++ b/backend/src/api/authorization/authorization.service.ts
@@ -84,6 +84,57 @@ export class AuthorizationService {
     return task !== null;
   }
 
+  /**
+   * A task may be read by an admin, by its creator, by any user while it is
+   * public, and by a student taking part in a session that uses it. This
+   * mirrors what the task list already returns, so nothing a user cannot
+   * discover through the list becomes reachable by guessing an id.
+   */
+  async canViewTask(
+    authenticatedUser: User | null,
+    authenticatedStudent: Student | null,
+    taskId: number,
+  ): Promise<boolean> {
+    if (authenticatedUser !== null) {
+      if (authenticatedUser.type === UserType.ADMIN) {
+        return true;
+      }
+
+      const task = await this.prisma.task.findFirst({
+        where: {
+          id: taskId,
+          deletedAt: null,
+          OR: [{ isPublic: true }, { creatorId: authenticatedUser.id }],
+        },
+        select: { id: true },
+      });
+
+      return task !== null;
+    }
+
+    if (authenticatedStudent !== null) {
+      // the student flow reads a task by id alone, without naming a session,
+      // so any session they take part in that uses the task authorizes it
+      const sessionTask = await this.prisma.sessionTask.findFirst({
+        where: {
+          taskId,
+          deletedAt: null,
+          task: { deletedAt: null },
+          session: {
+            deletedAt: null,
+            class: { deletedAt: null },
+            ...this.participatesInSession(authenticatedStudent.id),
+          },
+        },
+        select: { taskId: true },
+      });
+
+      return sessionTask !== null;
+    }
+
+    return false;
+  }
+
   async canUpdateTask(
     authenticatedUser: User,
     taskId: number,

--- a/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
@@ -116,6 +116,32 @@ describe("Task visibility authorization", () => {
       );
     });
 
+    it("allows a student who joined the lesson anonymously", async () => {
+      // An anonymous participant is not on any class roster, so only the
+      // anonymous branch of the participation check can authorize them.
+      // @AuthenticatedStudent resolves them like any other student: it carries
+      // the Student row of whoever holds the token, authenticated or anonymous.
+      prismaMock.sessionTask.findFirst.mockImplementation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (args: any) => {
+          const alternatives = args?.where?.session?.OR ?? [];
+
+          const matchesAnonymously = alternatives.some(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (alternative: any) =>
+              alternative.anonymousStudents?.some?.studentId === student.id,
+          );
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return (matchesAnonymously ? { taskId } : null) as any;
+        },
+      );
+
+      await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+        true,
+      );
+    });
+
     it("denies a student a task from a session they do not take part in", async () => {
       prismaMock.sessionTask.findFirst.mockResolvedValue(null);
 

--- a/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
@@ -1,0 +1,217 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { PrismaClient, Student, User, UserType } from "@prisma/client";
+import { ForbiddenException } from "@nestjs/common";
+import { PrismaService } from "src/prisma/prisma.service";
+import { AuthorizationService } from "../../authorization/authorization.service";
+import { TasksController } from "../tasks.controller";
+import { TasksService } from "../tasks.service";
+
+// A teacher could read any task by guessing its id: the task detail, download
+// and with-reference-solutions endpoints never checked who was asking, so
+// another teacher's private task - and its reference solutions, i.e. the
+// answers - came straight back (CRT-460). Visibility must match what the list
+// endpoint already grants: public tasks, plus your own, plus everything for an
+// admin; a student instead sees the tasks of the sessions they take part in.
+
+const taskId = 3;
+const owner = { id: 10, type: UserType.TEACHER } as User;
+const otherTeacher = { id: 11, type: UserType.TEACHER } as User;
+const admin = { id: 12, type: UserType.ADMIN } as User;
+const student: Student = { id: 8, deletedAt: null };
+
+describe("Task visibility authorization", () => {
+  describe("AuthorizationService.canViewTask", () => {
+    let service: AuthorizationService;
+    let prismaMock: DeepMockProxy<PrismaClient>;
+    let module: TestingModule;
+
+    beforeEach(async () => {
+      prismaMock = mockDeep<PrismaClient>();
+
+      module = await Test.createTestingModule({
+        providers: [
+          AuthorizationService,
+          { provide: PrismaService, useValue: prismaMock },
+        ],
+      }).compile();
+
+      service = module.get<AuthorizationService>(AuthorizationService);
+    });
+
+    afterEach(() => module.close());
+
+    /**
+     * Stands in for the task lookup: resolves a row only when the given
+     * where-clause actually admits this task, so a query that forgets to
+     * constrain visibility matches it - the behaviour under test.
+     */
+    const withTask = (task: {
+      isPublic: boolean;
+      creatorId: number | null;
+    }): void => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prismaMock.task.findFirst.mockImplementation((args: any) => {
+        const where = args?.where ?? {};
+        const alternatives = Array.isArray(where.OR) ? where.OR : [where];
+
+        const matches = alternatives.some(
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          (alternative: any) =>
+            (alternative.isPublic === undefined ||
+              alternative.isPublic === task.isPublic) &&
+            (alternative.creatorId === undefined ||
+              alternative.creatorId === task.creatorId),
+        );
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (matches ? { id: taskId } : null) as any;
+      });
+    };
+
+    it("denies a teacher another teacher's private task", async () => {
+      withTask({ isPublic: false, creatorId: owner.id });
+
+      await expect(
+        service.canViewTask(otherTeacher, null, taskId),
+      ).resolves.toBe(false);
+    });
+
+    it("allows the creator their own private task", async () => {
+      withTask({ isPublic: false, creatorId: owner.id });
+
+      await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(
+        true,
+      );
+    });
+
+    it("allows any teacher a public task", async () => {
+      withTask({ isPublic: true, creatorId: owner.id });
+
+      await expect(
+        service.canViewTask(otherTeacher, null, taskId),
+      ).resolves.toBe(true);
+    });
+
+    it("allows an admin another user's private task", async () => {
+      withTask({ isPublic: false, creatorId: owner.id });
+
+      await expect(service.canViewTask(admin, null, taskId)).resolves.toBe(
+        true,
+      );
+    });
+
+    it("denies unauthenticated requests", async () => {
+      await expect(service.canViewTask(null, null, taskId)).resolves.toBe(
+        false,
+      );
+    });
+
+    it("allows a student taking part in a session that uses the task", async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      prismaMock.sessionTask.findFirst.mockResolvedValue({ taskId } as any);
+
+      await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+        true,
+      );
+    });
+
+    it("denies a student a task from a session they do not take part in", async () => {
+      prismaMock.sessionTask.findFirst.mockResolvedValue(null);
+
+      await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+        false,
+      );
+    });
+  });
+
+  describe("TasksController enforces it", () => {
+    const buildController = (
+      canView: boolean,
+    ): { controller: TasksController; tasksService: MockTasksService } => {
+      const tasksService = {
+        findByIdOrThrow: jest.fn().mockResolvedValue({
+          id: taskId,
+          title: "t",
+          description: "d",
+          type: "SCRATCH",
+          creatorId: owner.id,
+          isPublic: false,
+        }),
+        findByIdOrThrowWithReferenceSolutions: jest.fn().mockResolvedValue({
+          id: taskId,
+          title: "t",
+          description: "d",
+          type: "SCRATCH",
+          creatorId: owner.id,
+          isPublic: false,
+          referenceSolutions: [],
+        }),
+        downloadByIdOrThrow: jest
+          .fn()
+          .mockResolvedValue({ data: Buffer.from(""), mimeType: "text/plain" }),
+        isTaskInUse: jest.fn().mockResolvedValue(false),
+      };
+
+      const authorizationService = {
+        canViewTask: jest.fn().mockResolvedValue(canView),
+      };
+
+      const controller = new TasksController(
+        tasksService as unknown as TasksService,
+        authorizationService as unknown as AuthorizationService,
+      );
+
+      return { controller, tasksService };
+    };
+
+    it("refuses the task detail when the task is not visible", async () => {
+      const { controller, tasksService } = buildController(false);
+
+      await expect(
+        controller.findOne(otherTeacher, null, taskId),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(tasksService.findByIdOrThrow).not.toHaveBeenCalled();
+    });
+
+    it("refuses the download when the task is not visible", async () => {
+      const { controller, tasksService } = buildController(false);
+
+      await expect(
+        controller.downloadOne(otherTeacher, null, taskId),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(tasksService.downloadByIdOrThrow).not.toHaveBeenCalled();
+    });
+
+    it("refuses the reference solutions when the task is not visible", async () => {
+      const { controller, tasksService } = buildController(false);
+
+      await expect(
+        controller.findOneWithReferenceSolutions(otherTeacher, taskId),
+      ).rejects.toThrow(ForbiddenException);
+
+      expect(
+        tasksService.findByIdOrThrowWithReferenceSolutions,
+      ).not.toHaveBeenCalled();
+    });
+
+    it("serves the task detail when the task is visible", async () => {
+      const { controller, tasksService } = buildController(true);
+
+      await expect(
+        controller.findOne(owner, null, taskId),
+      ).resolves.toBeDefined();
+
+      expect(tasksService.findByIdOrThrow).toHaveBeenCalled();
+    });
+  });
+});
+
+type MockTasksService = {
+  findByIdOrThrow: jest.Mock;
+  findByIdOrThrowWithReferenceSolutions: jest.Mock;
+  downloadByIdOrThrow: jest.Mock;
+  isTaskInUse: jest.Mock;
+};

--- a/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from "@nestjs/testing";
 import { DeepMockProxy, mockDeep } from "jest-mock-extended";
-import { PrismaClient, Student, User, UserType } from "@prisma/client";
+import { Prisma, PrismaClient, Student, User, UserType } from "@prisma/client";
 import { ForbiddenException } from "@nestjs/common";
 import { PrismaService } from "src/prisma/prisma.service";
 import { AuthorizationService } from "../../authorization/authorization.service";
@@ -50,23 +50,25 @@ describe("Task visibility authorization", () => {
       isPublic: boolean;
       creatorId: number | null;
     }): void => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prismaMock.task.findFirst.mockImplementation((args: any) => {
-        const where = args?.where ?? {};
-        const alternatives = Array.isArray(where.OR) ? where.OR : [where];
-
-        const matches = alternatives.some(
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          (alternative: any) =>
+      const findFirst = (
+        args: Prisma.TaskFindFirstArgs,
+      ): { id: number } | null => {
+        const where = args.where ?? {};
+        // an alternative that does not constrain a field admits any value
+        const matches = (where.OR ?? [where]).some(
+          (alternative) =>
             (alternative.isPublic === undefined ||
               alternative.isPublic === task.isPublic) &&
             (alternative.creatorId === undefined ||
               alternative.creatorId === task.creatorId),
         );
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return (matches ? { id: taskId } : null) as any;
-      });
+        return matches ? { id: taskId } : null;
+      };
+
+      // `as never` (the convention in authorization.service.spec.ts) lets a
+      // partial row stand in for the full model the delegate is typed to return
+      prismaMock.task.findFirst.mockImplementation(findFirst as never);
     };
 
     it("denies a teacher another teacher's private task", async () => {
@@ -108,8 +110,7 @@ describe("Task visibility authorization", () => {
     });
 
     it("allows a student taking part in a session that uses the task", async () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      prismaMock.sessionTask.findFirst.mockResolvedValue({ taskId } as any);
+      prismaMock.sessionTask.findFirst.mockResolvedValue({ taskId } as never);
 
       await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
         true,
@@ -121,21 +122,21 @@ describe("Task visibility authorization", () => {
       // anonymous branch of the participation check can authorize them.
       // @AuthenticatedStudent resolves them like any other student: it carries
       // the Student row of whoever holds the token, authenticated or anonymous.
-      prismaMock.sessionTask.findFirst.mockImplementation(
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (args: any) => {
-          const alternatives = args?.where?.session?.OR ?? [];
+      const findFirst = (
+        args: Prisma.SessionTaskFindFirstArgs,
+      ): { taskId: number } | null => {
+        // the session filter is an XOR of a relation filter and a where input
+        const session = (args.where?.session ?? {}) as Prisma.SessionWhereInput;
 
-          const matchesAnonymously = alternatives.some(
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (alternative: any) =>
-              alternative.anonymousStudents?.some?.studentId === student.id,
-          );
+        const joinedAnonymously = (session.OR ?? []).some(
+          (alternative) =>
+            alternative.anonymousStudents?.some?.studentId === student.id,
+        );
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          return (matchesAnonymously ? { taskId } : null) as any;
-        },
-      );
+        return joinedAnonymously ? { taskId } : null;
+      };
+
+      prismaMock.sessionTask.findFirst.mockImplementation(findFirst as never);
 
       await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
         true,

--- a/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
@@ -1,305 +1,96 @@
-import { Test, TestingModule } from "@nestjs/testing";
-import {
-  AuthenticationProvider,
-  Student,
-  User,
-  UserType,
-} from "@prisma/client";
 import { ForbiddenException } from "@nestjs/common";
-import { CoreModule } from "src/core/core.module";
-import { PrismaService } from "src/prisma/prisma.service";
-import { mockConfigModule } from "src/utilities/test/mock-config.service";
+import { User, UserType } from "@prisma/client";
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { TasksController } from "../tasks.controller";
 import { TasksService } from "../tasks.service";
 
-// A teacher could read any task by guessing its id: the task detail, download
-// and with-reference-solutions endpoints never checked who was asking, so
-// another teacher's private task - and its reference solutions, i.e. the
-// answers - came straight back (CRT-460). Visibility must match what the list
-// endpoint already grants: public tasks, plus your own, plus everything for an
-// admin; a student instead sees the tasks of the sessions they take part in.
+// The rule for which tasks are visible is exercised against the database in
+// test/task-visibility-authorization.e2e-spec.ts. Here we only check that the
+// three read endpoints refuse when the authorization check says no, which needs
+// no database - the AuthorizationService is mocked.
+describe("TasksController task-visibility enforcement", () => {
+  const taskId = 3;
+  const teacher = { id: 11, type: UserType.TEACHER } as User;
 
-describe("Task visibility authorization", () => {
-  describe("AuthorizationService.canViewTask", () => {
-    let service: AuthorizationService;
-    let prisma: PrismaService;
-    let module: TestingModule;
-
-    let owner: User;
-    let otherTeacher: User;
-    let admin: User;
-
-    const uniqueEmail = (prefix: string): string =>
-      `${prefix}-${Date.now()}-${Math.round(Math.random() * 1e9)}@example.com`;
-
-    const createUser = (prefix: string, type: UserType): Promise<User> =>
-      prisma.user.create({
-        data: {
-          email: uniqueEmail(prefix),
-          authenticationProvider: AuthenticationProvider.MICROSOFT,
-          type,
-        },
-      });
-
-    beforeEach(async () => {
-      module = await Test.createTestingModule({
-        imports: [CoreModule, mockConfigModule],
-        providers: [AuthorizationService],
-      }).compile();
-
-      service = module.get<AuthorizationService>(AuthorizationService);
-      prisma = module.get<PrismaService>(PrismaService);
-
-      owner = await createUser("owner", UserType.TEACHER);
-      otherTeacher = await createUser("other-teacher", UserType.TEACHER);
-      admin = await createUser("admin", UserType.ADMIN);
-    });
-
-    afterEach(() => module.close());
-
-    const createTask = async (isPublic: boolean): Promise<number> => {
-      const task = await prisma.task.create({
-        data: {
-          title: "A task",
-          description: "A task for testing",
-          type: "SCRATCH",
-          mimeType: "application/json",
-          data: Buffer.from("task-data"),
-          creatorId: owner.id,
-          isPublic,
-        },
-      });
-
-      return task.id;
+  const buildController = (
+    canView: boolean,
+  ): { controller: TasksController; tasksService: MockTasksService } => {
+    const tasksService = {
+      findByIdOrThrow: jest.fn().mockResolvedValue({
+        id: taskId,
+        title: "t",
+        description: "d",
+        type: "SCRATCH",
+        creatorId: 10,
+        isPublic: false,
+      }),
+      findByIdOrThrowWithReferenceSolutions: jest.fn().mockResolvedValue({
+        id: taskId,
+        title: "t",
+        description: "d",
+        type: "SCRATCH",
+        creatorId: 10,
+        isPublic: false,
+        referenceSolutions: [],
+      }),
+      downloadByIdOrThrow: jest
+        .fn()
+        .mockResolvedValue({ data: Buffer.from(""), mimeType: "text/plain" }),
+      isTaskInUse: jest.fn().mockResolvedValue(false),
     };
 
-    /**
-     * A lesson of the owner's class containing the task, joined by a student -
-     * either enrolled in the class or anonymously, as the sharing type decides.
-     */
-    const createStudentInLessonWith = async (
-      taskId: number,
-      joinAnonymously: boolean,
-    ): Promise<Student> => {
-      const klass = await prisma.class.create({
-        data: { name: "A class", teacherId: owner.id },
-      });
-
-      const session = await prisma.session.create({
-        data: {
-          title: "A lesson",
-          description: "A lesson for testing",
-          classId: klass.id,
-          isAnonymous: joinAnonymously,
-          tasks: { create: [{ taskId, index: 0 }] },
-        },
-      });
-
-      const student = await prisma.student.create({ data: {} });
-
-      if (joinAnonymously) {
-        await prisma.anonymousStudent.create({
-          data: { studentId: student.id, sessionId: session.id },
-        });
-      } else {
-        await prisma.authenticatedStudent.create({
-          data: {
-            studentId: student.id,
-            classId: klass.id,
-            pseudonym: Buffer.from(`pseudonym-${student.id}`),
-          },
-        });
-      }
-
-      return student;
+    const authorizationService = {
+      canViewTask: jest.fn().mockResolvedValue(canView),
     };
 
-    it("denies a teacher another teacher's private task", async () => {
-      const taskId = await createTask(false);
+    const controller = new TasksController(
+      tasksService as unknown as TasksService,
+      authorizationService as unknown as AuthorizationService,
+    );
 
-      await expect(
-        service.canViewTask(otherTeacher, null, taskId),
-      ).resolves.toBe(false);
-    });
+    return { controller, tasksService };
+  };
 
-    it("allows the creator their own private task", async () => {
-      const taskId = await createTask(false);
+  it("refuses the task detail when the task is not visible", async () => {
+    const { controller, tasksService } = buildController(false);
 
-      await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(
-        true,
-      );
-    });
+    await expect(controller.findOne(teacher, null, taskId)).rejects.toThrow(
+      ForbiddenException,
+    );
 
-    it("allows any teacher a public task", async () => {
-      const taskId = await createTask(true);
-
-      await expect(
-        service.canViewTask(otherTeacher, null, taskId),
-      ).resolves.toBe(true);
-    });
-
-    it("allows an admin another user's private task", async () => {
-      const taskId = await createTask(false);
-
-      await expect(service.canViewTask(admin, null, taskId)).resolves.toBe(
-        true,
-      );
-    });
-
-    it("denies unauthenticated requests", async () => {
-      const taskId = await createTask(true);
-
-      await expect(service.canViewTask(null, null, taskId)).resolves.toBe(
-        false,
-      );
-    });
-
-    it("denies a teacher a soft-deleted task they created", async () => {
-      const taskId = await createTask(false);
-      await prisma.task.update({
-        where: { id: taskId },
-        data: { deletedAt: new Date() },
-      });
-
-      await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(
-        false,
-      );
-    });
-
-    it("allows a student taking part in a lesson that uses the task", async () => {
-      const taskId = await createTask(false);
-      const student = await createStudentInLessonWith(taskId, false);
-
-      await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
-        true,
-      );
-    });
-
-    it("allows a student who joined the lesson anonymously", async () => {
-      // an anonymous participant is on no class roster, so only the anonymous
-      // branch of the participation check can authorize them
-      const taskId = await createTask(false);
-      const student = await createStudentInLessonWith(taskId, true);
-
-      await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
-        true,
-      );
-    });
-
-    it("denies a student a task from a lesson they do not take part in", async () => {
-      const taskId = await createTask(false);
-      await createStudentInLessonWith(taskId, false);
-
-      // a student of some other lesson entirely
-      const outsider = await prisma.student.create({ data: {} });
-
-      await expect(service.canViewTask(null, outsider, taskId)).resolves.toBe(
-        false,
-      );
-    });
-
-    it("denies a student once the task is removed from their lesson", async () => {
-      const taskId = await createTask(false);
-      const student = await createStudentInLessonWith(taskId, false);
-
-      await prisma.sessionTask.updateMany({
-        where: { taskId },
-        data: { deletedAt: new Date() },
-      });
-
-      await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
-        false,
-      );
-    });
+    expect(tasksService.findByIdOrThrow).not.toHaveBeenCalled();
   });
 
-  // The controller only has to refuse when the check says no; which tasks are
-  // visible is settled against the database above.
-  describe("TasksController enforces it", () => {
-    const taskId = 3;
-    const teacher = { id: 11, type: UserType.TEACHER } as User;
+  it("refuses the download when the task is not visible", async () => {
+    const { controller, tasksService } = buildController(false);
 
-    const buildController = (
-      canView: boolean,
-    ): { controller: TasksController; tasksService: MockTasksService } => {
-      const tasksService = {
-        findByIdOrThrow: jest.fn().mockResolvedValue({
-          id: taskId,
-          title: "t",
-          description: "d",
-          type: "SCRATCH",
-          creatorId: 10,
-          isPublic: false,
-        }),
-        findByIdOrThrowWithReferenceSolutions: jest.fn().mockResolvedValue({
-          id: taskId,
-          title: "t",
-          description: "d",
-          type: "SCRATCH",
-          creatorId: 10,
-          isPublic: false,
-          referenceSolutions: [],
-        }),
-        downloadByIdOrThrow: jest
-          .fn()
-          .mockResolvedValue({ data: Buffer.from(""), mimeType: "text/plain" }),
-        isTaskInUse: jest.fn().mockResolvedValue(false),
-      };
+    await expect(controller.downloadOne(teacher, null, taskId)).rejects.toThrow(
+      ForbiddenException,
+    );
 
-      const authorizationService = {
-        canViewTask: jest.fn().mockResolvedValue(canView),
-      };
+    expect(tasksService.downloadByIdOrThrow).not.toHaveBeenCalled();
+  });
 
-      const controller = new TasksController(
-        tasksService as unknown as TasksService,
-        authorizationService as unknown as AuthorizationService,
-      );
+  it("refuses the reference solutions when the task is not visible", async () => {
+    const { controller, tasksService } = buildController(false);
 
-      return { controller, tasksService };
-    };
+    await expect(
+      controller.findOneWithReferenceSolutions(teacher, taskId),
+    ).rejects.toThrow(ForbiddenException);
 
-    it("refuses the task detail when the task is not visible", async () => {
-      const { controller, tasksService } = buildController(false);
+    expect(
+      tasksService.findByIdOrThrowWithReferenceSolutions,
+    ).not.toHaveBeenCalled();
+  });
 
-      await expect(controller.findOne(teacher, null, taskId)).rejects.toThrow(
-        ForbiddenException,
-      );
+  it("serves the task detail when the task is visible", async () => {
+    const { controller, tasksService } = buildController(true);
 
-      expect(tasksService.findByIdOrThrow).not.toHaveBeenCalled();
-    });
+    await expect(
+      controller.findOne(teacher, null, taskId),
+    ).resolves.toBeDefined();
 
-    it("refuses the download when the task is not visible", async () => {
-      const { controller, tasksService } = buildController(false);
-
-      await expect(
-        controller.downloadOne(teacher, null, taskId),
-      ).rejects.toThrow(ForbiddenException);
-
-      expect(tasksService.downloadByIdOrThrow).not.toHaveBeenCalled();
-    });
-
-    it("refuses the reference solutions when the task is not visible", async () => {
-      const { controller, tasksService } = buildController(false);
-
-      await expect(
-        controller.findOneWithReferenceSolutions(teacher, taskId),
-      ).rejects.toThrow(ForbiddenException);
-
-      expect(
-        tasksService.findByIdOrThrowWithReferenceSolutions,
-      ).not.toHaveBeenCalled();
-    });
-
-    it("serves the task detail when the task is visible", async () => {
-      const { controller, tasksService } = buildController(true);
-
-      await expect(
-        controller.findOne(teacher, null, taskId),
-      ).resolves.toBeDefined();
-
-      expect(tasksService.findByIdOrThrow).toHaveBeenCalled();
-    });
+    expect(tasksService.findByIdOrThrow).toHaveBeenCalled();
   });
 });
 

--- a/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-visibility-authorization.spec.ts
@@ -1,8 +1,14 @@
 import { Test, TestingModule } from "@nestjs/testing";
-import { DeepMockProxy, mockDeep } from "jest-mock-extended";
-import { Prisma, PrismaClient, Student, User, UserType } from "@prisma/client";
+import {
+  AuthenticationProvider,
+  Student,
+  User,
+  UserType,
+} from "@prisma/client";
 import { ForbiddenException } from "@nestjs/common";
+import { CoreModule } from "src/core/core.module";
 import { PrismaService } from "src/prisma/prisma.service";
+import { mockConfigModule } from "src/utilities/test/mock-config.service";
 import { AuthorizationService } from "../../authorization/authorization.service";
 import { TasksController } from "../tasks.controller";
 import { TasksService } from "../tasks.service";
@@ -14,65 +20,103 @@ import { TasksService } from "../tasks.service";
 // endpoint already grants: public tasks, plus your own, plus everything for an
 // admin; a student instead sees the tasks of the sessions they take part in.
 
-const taskId = 3;
-const owner = { id: 10, type: UserType.TEACHER } as User;
-const otherTeacher = { id: 11, type: UserType.TEACHER } as User;
-const admin = { id: 12, type: UserType.ADMIN } as User;
-const student: Student = { id: 8, deletedAt: null };
-
 describe("Task visibility authorization", () => {
   describe("AuthorizationService.canViewTask", () => {
     let service: AuthorizationService;
-    let prismaMock: DeepMockProxy<PrismaClient>;
+    let prisma: PrismaService;
     let module: TestingModule;
 
-    beforeEach(async () => {
-      prismaMock = mockDeep<PrismaClient>();
+    let owner: User;
+    let otherTeacher: User;
+    let admin: User;
 
+    const uniqueEmail = (prefix: string): string =>
+      `${prefix}-${Date.now()}-${Math.round(Math.random() * 1e9)}@example.com`;
+
+    const createUser = (prefix: string, type: UserType): Promise<User> =>
+      prisma.user.create({
+        data: {
+          email: uniqueEmail(prefix),
+          authenticationProvider: AuthenticationProvider.MICROSOFT,
+          type,
+        },
+      });
+
+    beforeEach(async () => {
       module = await Test.createTestingModule({
-        providers: [
-          AuthorizationService,
-          { provide: PrismaService, useValue: prismaMock },
-        ],
+        imports: [CoreModule, mockConfigModule],
+        providers: [AuthorizationService],
       }).compile();
 
       service = module.get<AuthorizationService>(AuthorizationService);
+      prisma = module.get<PrismaService>(PrismaService);
+
+      owner = await createUser("owner", UserType.TEACHER);
+      otherTeacher = await createUser("other-teacher", UserType.TEACHER);
+      admin = await createUser("admin", UserType.ADMIN);
     });
 
     afterEach(() => module.close());
 
+    const createTask = async (isPublic: boolean): Promise<number> => {
+      const task = await prisma.task.create({
+        data: {
+          title: "A task",
+          description: "A task for testing",
+          type: "SCRATCH",
+          mimeType: "application/json",
+          data: Buffer.from("task-data"),
+          creatorId: owner.id,
+          isPublic,
+        },
+      });
+
+      return task.id;
+    };
+
     /**
-     * Stands in for the task lookup: resolves a row only when the given
-     * where-clause actually admits this task, so a query that forgets to
-     * constrain visibility matches it - the behaviour under test.
+     * A lesson of the owner's class containing the task, joined by a student -
+     * either enrolled in the class or anonymously, as the sharing type decides.
      */
-    const withTask = (task: {
-      isPublic: boolean;
-      creatorId: number | null;
-    }): void => {
-      const findFirst = (
-        args: Prisma.TaskFindFirstArgs,
-      ): { id: number } | null => {
-        const where = args.where ?? {};
-        // an alternative that does not constrain a field admits any value
-        const matches = (where.OR ?? [where]).some(
-          (alternative) =>
-            (alternative.isPublic === undefined ||
-              alternative.isPublic === task.isPublic) &&
-            (alternative.creatorId === undefined ||
-              alternative.creatorId === task.creatorId),
-        );
+    const createStudentInLessonWith = async (
+      taskId: number,
+      joinAnonymously: boolean,
+    ): Promise<Student> => {
+      const klass = await prisma.class.create({
+        data: { name: "A class", teacherId: owner.id },
+      });
 
-        return matches ? { id: taskId } : null;
-      };
+      const session = await prisma.session.create({
+        data: {
+          title: "A lesson",
+          description: "A lesson for testing",
+          classId: klass.id,
+          isAnonymous: joinAnonymously,
+          tasks: { create: [{ taskId, index: 0 }] },
+        },
+      });
 
-      // `as never` (the convention in authorization.service.spec.ts) lets a
-      // partial row stand in for the full model the delegate is typed to return
-      prismaMock.task.findFirst.mockImplementation(findFirst as never);
+      const student = await prisma.student.create({ data: {} });
+
+      if (joinAnonymously) {
+        await prisma.anonymousStudent.create({
+          data: { studentId: student.id, sessionId: session.id },
+        });
+      } else {
+        await prisma.authenticatedStudent.create({
+          data: {
+            studentId: student.id,
+            classId: klass.id,
+            pseudonym: Buffer.from(`pseudonym-${student.id}`),
+          },
+        });
+      }
+
+      return student;
     };
 
     it("denies a teacher another teacher's private task", async () => {
-      withTask({ isPublic: false, creatorId: owner.id });
+      const taskId = await createTask(false);
 
       await expect(
         service.canViewTask(otherTeacher, null, taskId),
@@ -80,7 +124,7 @@ describe("Task visibility authorization", () => {
     });
 
     it("allows the creator their own private task", async () => {
-      withTask({ isPublic: false, creatorId: owner.id });
+      const taskId = await createTask(false);
 
       await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(
         true,
@@ -88,7 +132,7 @@ describe("Task visibility authorization", () => {
     });
 
     it("allows any teacher a public task", async () => {
-      withTask({ isPublic: true, creatorId: owner.id });
+      const taskId = await createTask(true);
 
       await expect(
         service.canViewTask(otherTeacher, null, taskId),
@@ -96,7 +140,7 @@ describe("Task visibility authorization", () => {
     });
 
     it("allows an admin another user's private task", async () => {
-      withTask({ isPublic: false, creatorId: owner.id });
+      const taskId = await createTask(false);
 
       await expect(service.canViewTask(admin, null, taskId)).resolves.toBe(
         true,
@@ -104,13 +148,28 @@ describe("Task visibility authorization", () => {
     });
 
     it("denies unauthenticated requests", async () => {
+      const taskId = await createTask(true);
+
       await expect(service.canViewTask(null, null, taskId)).resolves.toBe(
         false,
       );
     });
 
-    it("allows a student taking part in a session that uses the task", async () => {
-      prismaMock.sessionTask.findFirst.mockResolvedValue({ taskId } as never);
+    it("denies a teacher a soft-deleted task they created", async () => {
+      const taskId = await createTask(false);
+      await prisma.task.update({
+        where: { id: taskId },
+        data: { deletedAt: new Date() },
+      });
+
+      await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(
+        false,
+      );
+    });
+
+    it("allows a student taking part in a lesson that uses the task", async () => {
+      const taskId = await createTask(false);
+      const student = await createStudentInLessonWith(taskId, false);
 
       await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
         true,
@@ -118,33 +177,36 @@ describe("Task visibility authorization", () => {
     });
 
     it("allows a student who joined the lesson anonymously", async () => {
-      // An anonymous participant is not on any class roster, so only the
-      // anonymous branch of the participation check can authorize them.
-      // @AuthenticatedStudent resolves them like any other student: it carries
-      // the Student row of whoever holds the token, authenticated or anonymous.
-      const findFirst = (
-        args: Prisma.SessionTaskFindFirstArgs,
-      ): { taskId: number } | null => {
-        // the session filter is an XOR of a relation filter and a where input
-        const session = (args.where?.session ?? {}) as Prisma.SessionWhereInput;
-
-        const joinedAnonymously = (session.OR ?? []).some(
-          (alternative) =>
-            alternative.anonymousStudents?.some?.studentId === student.id,
-        );
-
-        return joinedAnonymously ? { taskId } : null;
-      };
-
-      prismaMock.sessionTask.findFirst.mockImplementation(findFirst as never);
+      // an anonymous participant is on no class roster, so only the anonymous
+      // branch of the participation check can authorize them
+      const taskId = await createTask(false);
+      const student = await createStudentInLessonWith(taskId, true);
 
       await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
         true,
       );
     });
 
-    it("denies a student a task from a session they do not take part in", async () => {
-      prismaMock.sessionTask.findFirst.mockResolvedValue(null);
+    it("denies a student a task from a lesson they do not take part in", async () => {
+      const taskId = await createTask(false);
+      await createStudentInLessonWith(taskId, false);
+
+      // a student of some other lesson entirely
+      const outsider = await prisma.student.create({ data: {} });
+
+      await expect(service.canViewTask(null, outsider, taskId)).resolves.toBe(
+        false,
+      );
+    });
+
+    it("denies a student once the task is removed from their lesson", async () => {
+      const taskId = await createTask(false);
+      const student = await createStudentInLessonWith(taskId, false);
+
+      await prisma.sessionTask.updateMany({
+        where: { taskId },
+        data: { deletedAt: new Date() },
+      });
 
       await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
         false,
@@ -152,7 +214,12 @@ describe("Task visibility authorization", () => {
     });
   });
 
+  // The controller only has to refuse when the check says no; which tasks are
+  // visible is settled against the database above.
   describe("TasksController enforces it", () => {
+    const taskId = 3;
+    const teacher = { id: 11, type: UserType.TEACHER } as User;
+
     const buildController = (
       canView: boolean,
     ): { controller: TasksController; tasksService: MockTasksService } => {
@@ -162,7 +229,7 @@ describe("Task visibility authorization", () => {
           title: "t",
           description: "d",
           type: "SCRATCH",
-          creatorId: owner.id,
+          creatorId: 10,
           isPublic: false,
         }),
         findByIdOrThrowWithReferenceSolutions: jest.fn().mockResolvedValue({
@@ -170,7 +237,7 @@ describe("Task visibility authorization", () => {
           title: "t",
           description: "d",
           type: "SCRATCH",
-          creatorId: owner.id,
+          creatorId: 10,
           isPublic: false,
           referenceSolutions: [],
         }),
@@ -195,9 +262,9 @@ describe("Task visibility authorization", () => {
     it("refuses the task detail when the task is not visible", async () => {
       const { controller, tasksService } = buildController(false);
 
-      await expect(
-        controller.findOne(otherTeacher, null, taskId),
-      ).rejects.toThrow(ForbiddenException);
+      await expect(controller.findOne(teacher, null, taskId)).rejects.toThrow(
+        ForbiddenException,
+      );
 
       expect(tasksService.findByIdOrThrow).not.toHaveBeenCalled();
     });
@@ -206,7 +273,7 @@ describe("Task visibility authorization", () => {
       const { controller, tasksService } = buildController(false);
 
       await expect(
-        controller.downloadOne(otherTeacher, null, taskId),
+        controller.downloadOne(teacher, null, taskId),
       ).rejects.toThrow(ForbiddenException);
 
       expect(tasksService.downloadByIdOrThrow).not.toHaveBeenCalled();
@@ -216,7 +283,7 @@ describe("Task visibility authorization", () => {
       const { controller, tasksService } = buildController(false);
 
       await expect(
-        controller.findOneWithReferenceSolutions(otherTeacher, taskId),
+        controller.findOneWithReferenceSolutions(teacher, taskId),
       ).rejects.toThrow(ForbiddenException);
 
       expect(
@@ -228,7 +295,7 @@ describe("Task visibility authorization", () => {
       const { controller, tasksService } = buildController(true);
 
       await expect(
-        controller.findOne(owner, null, taskId),
+        controller.findOne(teacher, null, taskId),
       ).resolves.toBeDefined();
 
       expect(tasksService.findByIdOrThrow).toHaveBeenCalled();

--- a/backend/src/api/tasks/tasks.controller.ts
+++ b/backend/src/api/tasks/tasks.controller.ts
@@ -31,9 +31,10 @@ import {
 } from "@nestjs/swagger";
 import { FileFieldsInterceptor } from "@nestjs/platform-express";
 import "multer";
-import { User, UserType } from "@prisma/client";
+import { Student, User, UserType } from "@prisma/client";
 import { JsonToObjectsInterceptor } from "src/utilities/json-to-object-interceptor";
 import { AuthenticatedUser } from "../authentication/authenticated-user.decorator";
+import { AuthenticatedStudent } from "../authentication/authenticated-student.decorator";
 import { NonUserRoles, Roles } from "../authentication/role.decorator";
 import { AuthorizationService } from "../authorization/authorization.service";
 import { ErrorCode, ErrorCodeDto } from "../exceptions/error-codes";
@@ -171,10 +172,22 @@ export class TasksController {
   @ApiForbiddenResponse()
   @ApiNotFoundResponse()
   async findOne(
+    @AuthenticatedUser() user: User | null,
+    @AuthenticatedStudent() student: Student | null,
     @Param("id", ParseIntPipe) id: TaskId,
     @Query("includeSoftDelete", new ParseBoolPipe({ optional: true }))
     includeSoftDelete?: boolean,
   ): Promise<ExistingTaskDto> {
+    const isAuthorized = await this.authorizationService.canViewTask(
+      user,
+      student,
+      id,
+    );
+
+    if (!isAuthorized) {
+      throw new ForbiddenException();
+    }
+
     const [task, isInUse] = await Promise.all([
       this.tasksService.findByIdOrThrow(id, includeSoftDelete),
       // todo: probably needs to include soft delete too
@@ -199,10 +212,22 @@ export class TasksController {
   @ApiForbiddenResponse()
   @ApiNotFoundResponse()
   async findOneWithReferenceSolutions(
+    @AuthenticatedUser() user: User | null,
     @Param("id", ParseIntPipe) id: TaskId,
     @Query("includeSoftDelete", new ParseBoolPipe({ optional: true }))
     includeSoftDelete?: boolean,
   ): Promise<ExistingTaskWithReferenceSolutionsDto> {
+    // students are already excluded by the role guard above
+    const isAuthorized = await this.authorizationService.canViewTask(
+      user,
+      null,
+      id,
+    );
+
+    if (!isAuthorized) {
+      throw new ForbiddenException();
+    }
+
     const [task, isInUse] = await Promise.all([
       this.tasksService.findByIdOrThrowWithReferenceSolutions(
         id,
@@ -236,10 +261,22 @@ export class TasksController {
   @ApiForbiddenResponse()
   @ApiNotFoundResponse()
   async downloadOne(
+    @AuthenticatedUser() user: User | null,
+    @AuthenticatedStudent() student: Student | null,
     @Param("id", ParseIntPipe) id: TaskId,
     @Query("includeSoftDelete", new ParseBoolPipe({ optional: true }))
     includeSoftDelete?: boolean,
   ): Promise<StreamableFile> {
+    const isAuthorized = await this.authorizationService.canViewTask(
+      user,
+      student,
+      id,
+    );
+
+    if (!isAuthorized) {
+      throw new ForbiddenException();
+    }
+
     const task = await this.tasksService.downloadByIdOrThrow(
       id,
       includeSoftDelete,

--- a/backend/test/task-visibility-authorization.e2e-spec.ts
+++ b/backend/test/task-visibility-authorization.e2e-spec.ts
@@ -141,6 +141,26 @@ describe("AuthorizationService.canViewTask (e2e)", () => {
     );
   });
 
+  it("denies a student the task once it is soft-deleted, even in an active lesson", async () => {
+    // isStudentOfSessionTasks keeps a student *working* on a soft-deleted task
+    // (submit/activity go through the SessionTask row), but the task detail and
+    // download never exposed it: a student's fetch defaults to deletedAt: null
+    // and 404s. canViewTask stays strict here so the outcome is a denial either
+    // way - the student sees a 403 instead of that pre-existing 404, not new
+    // access.
+    await createOwnedTask(false);
+    const student = await createStudentInLessonWith(false);
+
+    await prisma.task.update({
+      where: { id: taskId },
+      data: { deletedAt: new Date() },
+    });
+
+    await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+      false,
+    );
+  });
+
   it("denies a student a task from a lesson they do not take part in", async () => {
     await createOwnedTask(false);
     await createStudentInLessonWith(false);

--- a/backend/test/task-visibility-authorization.e2e-spec.ts
+++ b/backend/test/task-visibility-authorization.e2e-spec.ts
@@ -1,0 +1,169 @@
+import { INestApplication } from "@nestjs/common";
+import { Student, User, UserType } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { AuthorizationService } from "src/api/authorization/authorization.service";
+import { defaultAdmin, defaultTeacher } from "test/seed";
+import { getApp } from "./helpers/index";
+import { createUser } from "./helpers/user";
+import { createClassWithId } from "./helpers/class";
+import { createSessionWithId } from "./helpers/session";
+import { createTask } from "./helpers/task";
+import {
+  createStudent,
+  createAuthenticatedStudent,
+  createAnonymousStudent,
+} from "./helpers/student";
+
+// A teacher could read any task by guessing its id: the task detail, download
+// and with-reference-solutions endpoints never checked who was asking, so
+// another teacher's private task - and its reference solutions, i.e. the
+// answers - came straight back (CRT-460). Visibility must match what the list
+// endpoint already grants: public tasks, plus your own, plus everything for an
+// admin; a student instead sees the tasks of the sessions they take part in.
+// These run under jest-prisma, so the rule is decided by Postgres and every
+// test rolls back.
+describe("AuthorizationService.canViewTask (e2e)", () => {
+  let app: INestApplication;
+  let service: AuthorizationService;
+  let prisma: PrismaService;
+
+  const owner = { id: defaultTeacher.id, type: UserType.TEACHER } as User;
+  const admin = { id: defaultAdmin.id, type: UserType.ADMIN } as User;
+  let otherTeacher: User;
+
+  const taskId = 1301;
+  const classId = 1201;
+  const sessionId = 1401;
+
+  beforeEach(async () => {
+    app = await getApp();
+    service = app.get(AuthorizationService, { strict: false });
+    prisma = app.get(PrismaService);
+
+    otherTeacher = await createUser(app, {
+      id: 1103,
+      type: UserType.TEACHER,
+    });
+  });
+
+  afterEach(() => app.close());
+
+  const createOwnedTask = (isPublic: boolean): Promise<unknown> =>
+    createTask(app, { id: taskId, creatorId: owner.id, isPublic });
+
+  /**
+   * A lesson of a class containing the task, joined by a student - either
+   * enrolled in the class or anonymously, as the sharing type decides.
+   */
+  const createStudentInLessonWith = async (
+    joinAnonymously: boolean,
+  ): Promise<Student> => {
+    await createClassWithId(app, { id: classId, teacherId: owner.id });
+    await createSessionWithId(app, {
+      id: sessionId,
+      classId,
+      isAnonymous: joinAnonymously,
+    });
+    await prisma.sessionTask.create({ data: { sessionId, taskId, index: 0 } });
+
+    const student = await createStudent(app, { id: 1501 });
+
+    if (joinAnonymously) {
+      await createAnonymousStudent(app, { studentId: student.id, sessionId });
+    } else {
+      await createAuthenticatedStudent(app, { studentId: student.id, classId });
+    }
+
+    return student;
+  };
+
+  it("denies a teacher another teacher's private task", async () => {
+    await createOwnedTask(false);
+
+    await expect(service.canViewTask(otherTeacher, null, taskId)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("allows the creator their own private task", async () => {
+    await createOwnedTask(false);
+
+    await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(true);
+  });
+
+  it("allows any teacher a public task", async () => {
+    await createOwnedTask(true);
+
+    await expect(service.canViewTask(otherTeacher, null, taskId)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("allows an admin another user's private task", async () => {
+    await createOwnedTask(false);
+
+    await expect(service.canViewTask(admin, null, taskId)).resolves.toBe(true);
+  });
+
+  it("denies unauthenticated requests", async () => {
+    await createOwnedTask(true);
+
+    await expect(service.canViewTask(null, null, taskId)).resolves.toBe(false);
+  });
+
+  it("denies a teacher a soft-deleted task they created", async () => {
+    await createOwnedTask(false);
+    await prisma.task.update({
+      where: { id: taskId },
+      data: { deletedAt: new Date() },
+    });
+
+    await expect(service.canViewTask(owner, null, taskId)).resolves.toBe(false);
+  });
+
+  it("allows a student taking part in a lesson that uses the task", async () => {
+    await createOwnedTask(false);
+    const student = await createStudentInLessonWith(false);
+
+    await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("allows a student who joined the lesson anonymously", async () => {
+    // an anonymous participant is on no class roster, so only the anonymous
+    // branch of the participation check can authorize them
+    await createOwnedTask(false);
+    const student = await createStudentInLessonWith(true);
+
+    await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+      true,
+    );
+  });
+
+  it("denies a student a task from a lesson they do not take part in", async () => {
+    await createOwnedTask(false);
+    await createStudentInLessonWith(false);
+
+    // a student who is not in that class or session
+    const outsider = await createStudent(app, { id: 1502 });
+
+    await expect(service.canViewTask(null, outsider, taskId)).resolves.toBe(
+      false,
+    );
+  });
+
+  it("denies a student once the task is removed from their lesson", async () => {
+    await createOwnedTask(false);
+    const student = await createStudentInLessonWith(false);
+
+    await prisma.sessionTask.updateMany({
+      where: { taskId },
+      data: { deletedAt: new Date() },
+    });
+
+    await expect(service.canViewTask(null, student, taskId)).resolves.toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
The task detail, download and with-reference-solutions endpoints never checked who was asking: any teacher could read another teacher's private task - and its reference solutions, i.e. the answers - just by putting its id in the URL. Only update and delete were guarded, and hiding private tasks in the UI is no protection since ids are sequential.

Add AuthorizationService.canViewTask and call it from the three read endpoints, mirroring the rule the task list already applies: a public task is visible to anyone, a private one only to its creator, and an admin sees everything. Students keep their access through a different branch: the solve flow fetches a task by id alone, without naming a session, so a student is authorized when any session they take part in uses the task - otherwise enforcing the owner rule would have locked every student out of every task.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add server-side authorization to task detail, download, and reference-solution reads to prevent teachers from viewing other users’ private tasks. Visibility matches the task list and keeps student access via session participation (anonymous included); soft-deleted tasks stay hidden from students even in active lessons (CRT-460).

- **Bug Fixes**
  - Added AuthorizationService.canViewTask: public → anyone; private → creator; admins → all; students → allowed if in a session using the task (anonymous included).
  - Enforced checks in `findOne`, `downloadOne`, and `findOneWithReferenceSolutions`; return 403 when unauthorized. Students are denied soft-deleted tasks even in active lessons (403 replaces the previous 404).

- **Refactors**
  - Moved DB-backed visibility tests to jest-prisma e2e with transactional rollback; covers soft-deleted tasks and access loss when a task is removed from a lesson. Controller tests remain mocked to verify 403 gating.

<sup>Written for commit 0d17df26db112dfcbeddc2efe093a7c358c5d8d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

