### PR TITLE
[CRT-445] Ignore removed lesson associations when locking a task

### DIFF
--- a/backend/src/api/tasks/__tests__/task-in-use-after-lesson-removal.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-in-use-after-lesson-removal.spec.ts
@@ -1,0 +1,199 @@
+import { PrismaService } from "src/prisma/prisma.service";
+import {
+  TasksService,
+  TaskInOtherUsersLessonError,
+  TaskInUseByClassOrLessonWithStudentsError,
+} from "../tasks.service";
+
+// Removing a task from a lesson soft-deletes the SessionTask association: the
+// row stays, with deletedAt set. The soft-delete Prisma extension only rewrites
+// deletes, it does not filter reads, so an "is this task still in use" query
+// that omits `deletedAt: null` keeps seeing lessons the task was already
+// removed from - locking the task forever (CRT-445).
+//
+// These drive TasksService.update() against a mocked Prisma whose
+// sessionTask.findFirst evaluates the where-clause it is given against a small
+// fixture, rather than asserting a literal clause: a query that forgets the
+// soft-delete filter really does match the removed association here, exactly
+// as it would against Postgres.
+
+const taskId = 42;
+const creatorId = 1;
+const otherTeacherId = 2;
+
+type SessionTaskRow = {
+  taskId: number;
+  deletedAt: Date | null;
+  session: {
+    deletedAt: Date | null;
+    class: { teacherId: number; deletedAt: Date | null };
+    hasAnonymousStudents: boolean;
+    hasClassStudents: boolean;
+  };
+};
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Where = any;
+
+/**
+ * Minimal stand-in for Prisma's filtering, supporting exactly the fields the
+ * two in-use queries use. Anything the query does not constrain is ignored,
+ * so a missing filter matches more rows - the behaviour under test.
+ */
+const rowMatches = (row: SessionTaskRow, where: Where): boolean => {
+  if (where.taskId !== undefined && where.taskId !== row.taskId) {
+    return false;
+  }
+
+  if (where.deletedAt === null && row.deletedAt !== null) {
+    return false;
+  }
+
+  if (where.task?.deletedAt === null && row.deletedAt !== null) {
+    // the task itself is alive in these fixtures; only the association differs
+    return true;
+  }
+
+  const session = where.session;
+
+  if (!session) {
+    return true;
+  }
+
+  if (session.deletedAt === null && row.session.deletedAt !== null) {
+    return false;
+  }
+
+  if (session.class) {
+    if (
+      session.class.deletedAt === null &&
+      row.session.class.deletedAt !== null
+    ) {
+      return false;
+    }
+
+    const teacherId = session.class.teacherId;
+    if (
+      teacherId?.not !== undefined &&
+      row.session.class.teacherId === teacherId.not
+    ) {
+      return false;
+    }
+  }
+
+  if (Array.isArray(session.OR)) {
+    const matchesAnyBranch = session.OR.some((branch: Where) => {
+      if (branch.anonymousStudents) {
+        return row.session.hasAnonymousStudents;
+      }
+      if (branch.class?.students) {
+        return row.session.hasClassStudents;
+      }
+      return false;
+    });
+
+    if (!matchesAnyBranch) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const buildService = (
+  rows: SessionTaskRow[],
+  isPublic: boolean,
+): TasksService => {
+  const tx = {
+    task: {
+      findUniqueOrThrow: jest.fn().mockResolvedValue({ isPublic, creatorId }),
+      update: jest.fn().mockResolvedValue({ id: taskId }),
+    },
+    sessionTask: {
+      findFirst: jest.fn(({ where }: { where: Where }) =>
+        Promise.resolve(rows.find((row) => rowMatches(row, where)) ?? null),
+      ),
+    },
+    referenceSolution: {
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+    solution: {
+      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
+      createMany: jest.fn().mockResolvedValue({ count: 0 }),
+    },
+  };
+
+  const prisma = {
+    $transaction: jest.fn((callback: (client: typeof tx) => Promise<unknown>) =>
+      callback(tx),
+    ),
+  } as unknown as PrismaService;
+
+  return new TasksService(prisma);
+};
+
+const update = (service: TasksService): Promise<unknown> =>
+  service.update(
+    taskId,
+    { title: "Updated title" },
+    "application/json",
+    new Uint8Array(),
+    [],
+    [],
+  );
+
+const lessonOfOtherTeacher = (deletedAt: Date | null): SessionTaskRow => ({
+  taskId,
+  deletedAt,
+  session: {
+    deletedAt: null,
+    class: { teacherId: otherTeacherId, deletedAt: null },
+    hasAnonymousStudents: false,
+    hasClassStudents: true,
+  },
+});
+
+describe("TasksService.update — task removed from another teacher's lesson", () => {
+  it("allows updating a public task whose association was removed", async () => {
+    // the task was added to another teacher's lesson and then removed again,
+    // which soft-deleted the association
+    const service = buildService(
+      [lessonOfOtherTeacher(new Date())],
+      /* isPublic */ true,
+    );
+
+    await expect(update(service)).resolves.toEqual({ id: taskId });
+  });
+
+  it("still refuses a public task that is in another teacher's lesson", async () => {
+    const service = buildService(
+      [lessonOfOtherTeacher(null)],
+      /* isPublic */ true,
+    );
+
+    await expect(update(service)).rejects.toBeInstanceOf(
+      TaskInOtherUsersLessonError,
+    );
+  });
+
+  it("allows updating a private task whose association was removed", async () => {
+    // the same stale association must not trip the "lesson with students" check
+    const service = buildService(
+      [lessonOfOtherTeacher(new Date())],
+      /* isPublic */ false,
+    );
+
+    await expect(update(service)).resolves.toEqual({ id: taskId });
+  });
+
+  it("still refuses a task in a live lesson that has students", async () => {
+    const service = buildService(
+      [lessonOfOtherTeacher(null)],
+      /* isPublic */ false,
+    );
+
+    await expect(update(service)).rejects.toBeInstanceOf(
+      TaskInUseByClassOrLessonWithStudentsError,
+    );
+  });
+});

--- a/backend/src/api/tasks/__tests__/task-in-use-after-lesson-removal.spec.ts
+++ b/backend/src/api/tasks/__tests__/task-in-use-after-lesson-removal.spec.ts
@@ -1,4 +1,9 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { AuthenticationProvider, UserType } from "@prisma/client";
+import { CoreModule } from "src/core/core.module";
 import { PrismaService } from "src/prisma/prisma.service";
+import { mockConfigModule } from "src/utilities/test/mock-config.service";
+import { SessionsService } from "../../sessions/sessions.service";
 import {
   TasksService,
   TaskInOtherUsersLessonError,
@@ -6,193 +11,158 @@ import {
 } from "../tasks.service";
 
 // Removing a task from a lesson soft-deletes the SessionTask association: the
-// row stays, with deletedAt set. The soft-delete Prisma extension only rewrites
-// deletes, it does not filter reads, so an "is this task still in use" query
-// that omits `deletedAt: null` keeps seeing lessons the task was already
-// removed from - locking the task forever (CRT-445).
-//
-// These drive TasksService.update() against a mocked Prisma whose
-// sessionTask.findFirst evaluates the where-clause it is given against a small
-// fixture, rather than asserting a literal clause: a query that forgets the
-// soft-delete filter really does match the removed association here, exactly
-// as it would against Postgres.
-
-const taskId = 42;
-const creatorId = 1;
-const otherTeacherId = 2;
-
-type SessionTaskRow = {
-  taskId: number;
-  deletedAt: Date | null;
-  session: {
-    deletedAt: Date | null;
-    class: { teacherId: number; deletedAt: Date | null };
-    hasAnonymousStudents: boolean;
-    hasClassStudents: boolean;
-  };
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Where = any;
-
-/**
- * Minimal stand-in for Prisma's filtering, supporting exactly the fields the
- * two in-use queries use. Anything the query does not constrain is ignored,
- * so a missing filter matches more rows - the behaviour under test.
- */
-const rowMatches = (row: SessionTaskRow, where: Where): boolean => {
-  if (where.taskId !== undefined && where.taskId !== row.taskId) {
-    return false;
-  }
-
-  if (where.deletedAt === null && row.deletedAt !== null) {
-    return false;
-  }
-
-  if (where.task?.deletedAt === null && row.deletedAt !== null) {
-    // the task itself is alive in these fixtures; only the association differs
-    return true;
-  }
-
-  const session = where.session;
-
-  if (!session) {
-    return true;
-  }
-
-  if (session.deletedAt === null && row.session.deletedAt !== null) {
-    return false;
-  }
-
-  if (session.class) {
-    if (
-      session.class.deletedAt === null &&
-      row.session.class.deletedAt !== null
-    ) {
-      return false;
-    }
-
-    const teacherId = session.class.teacherId;
-    if (
-      teacherId?.not !== undefined &&
-      row.session.class.teacherId === teacherId.not
-    ) {
-      return false;
-    }
-  }
-
-  if (Array.isArray(session.OR)) {
-    const matchesAnyBranch = session.OR.some((branch: Where) => {
-      if (branch.anonymousStudents) {
-        return row.session.hasAnonymousStudents;
-      }
-      if (branch.class?.students) {
-        return row.session.hasClassStudents;
-      }
-      return false;
-    });
-
-    if (!matchesAnyBranch) {
-      return false;
-    }
-  }
-
-  return true;
-};
-
-const buildService = (
-  rows: SessionTaskRow[],
-  isPublic: boolean,
-): TasksService => {
-  const tx = {
-    task: {
-      findUniqueOrThrow: jest.fn().mockResolvedValue({ isPublic, creatorId }),
-      update: jest.fn().mockResolvedValue({ id: taskId }),
-    },
-    sessionTask: {
-      findFirst: jest.fn(({ where }: { where: Where }) =>
-        Promise.resolve(rows.find((row) => rowMatches(row, where)) ?? null),
-      ),
-    },
-    referenceSolution: {
-      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
-    },
-    solution: {
-      deleteMany: jest.fn().mockResolvedValue({ count: 0 }),
-      createMany: jest.fn().mockResolvedValue({ count: 0 }),
-    },
-  };
-
-  const prisma = {
-    $transaction: jest.fn((callback: (client: typeof tx) => Promise<unknown>) =>
-      callback(tx),
-    ),
-  } as unknown as PrismaService;
-
-  return new TasksService(prisma);
-};
-
-const update = (service: TasksService): Promise<unknown> =>
-  service.update(
-    taskId,
-    { title: "Updated title" },
-    "application/json",
-    new Uint8Array(),
-    [],
-    [],
-  );
-
-const lessonOfOtherTeacher = (deletedAt: Date | null): SessionTaskRow => ({
-  taskId,
-  deletedAt,
-  session: {
-    deletedAt: null,
-    class: { teacherId: otherTeacherId, deletedAt: null },
-    hasAnonymousStudents: false,
-    hasClassStudents: true,
-  },
-});
+// row stays behind with deletedAt set. An "is this task still in use" query
+// that does not exclude those rows keeps seeing lessons the task was already
+// removed from, locking the task forever (CRT-445). These run against a real
+// database, removing the task through SessionsService.update exactly as the
+// lesson form does, so the soft-deleted row is produced by the application
+// rather than hand-placed.
 
 describe("TasksService.update — task removed from another teacher's lesson", () => {
-  it("allows updating a public task whose association was removed", async () => {
-    // the task was added to another teacher's lesson and then removed again,
-    // which soft-deleted the association
-    const service = buildService(
-      [lessonOfOtherTeacher(new Date())],
-      /* isPublic */ true,
+  let tasksService: TasksService;
+  let sessionsService: SessionsService;
+  let prisma: PrismaService;
+  let module: TestingModule;
+
+  let ownerId: number;
+  let otherTeacherId: number;
+
+  const uniqueEmail = (prefix: string): string =>
+    `${prefix}-${Date.now()}-${Math.round(Math.random() * 1e9)}@example.com`;
+
+  const createTeacher = async (prefix: string): Promise<number> => {
+    const teacher = await prisma.user.create({
+      data: {
+        email: uniqueEmail(prefix),
+        authenticationProvider: AuthenticationProvider.MICROSOFT,
+        type: UserType.TEACHER,
+      },
+    });
+
+    return teacher.id;
+  };
+
+  beforeEach(async () => {
+    module = await Test.createTestingModule({
+      imports: [CoreModule, mockConfigModule],
+      providers: [TasksService, SessionsService],
+    }).compile();
+
+    tasksService = module.get<TasksService>(TasksService);
+    sessionsService = module.get<SessionsService>(SessionsService);
+    prisma = module.get<PrismaService>(PrismaService);
+
+    ownerId = await createTeacher("owner");
+    otherTeacherId = await createTeacher("other-teacher");
+  });
+
+  afterEach(() => module.close());
+
+  const createTask = async (isPublic: boolean): Promise<number> => {
+    const task = await prisma.task.create({
+      data: {
+        title: "Shared task",
+        description: "A task for testing",
+        type: "SCRATCH",
+        mimeType: "application/json",
+        data: Buffer.from("task-data"),
+        creatorId: ownerId,
+        isPublic,
+      },
+    });
+
+    return task.id;
+  };
+
+  /** A lesson of the other teacher's class, containing the given task. */
+  const createLessonWithTask = async (
+    taskId: number,
+  ): Promise<{ sessionId: number; classId: number }> => {
+    const klass = await prisma.class.create({
+      data: { name: "Other teacher's class", teacherId: otherTeacherId },
+    });
+
+    const session = await prisma.session.create({
+      data: {
+        title: "Other teacher's lesson",
+        description: "A lesson for testing",
+        classId: klass.id,
+        tasks: { create: [{ taskId, index: 0 }] },
+      },
+    });
+
+    return { sessionId: session.id, classId: klass.id };
+  };
+
+  const enrolStudentInClass = async (classId: number): Promise<void> => {
+    const student = await prisma.student.create({ data: {} });
+
+    await prisma.authenticatedStudent.create({
+      data: {
+        studentId: student.id,
+        classId,
+        pseudonym: Buffer.from(`pseudonym-${student.id}`),
+      },
+    });
+  };
+
+  /** Removes every task from the lesson, as saving the lesson form does. */
+  const removeTaskFromLesson = (
+    sessionId: number,
+    classId: number,
+  ): Promise<unknown> => sessionsService.update(sessionId, {}, [], classId);
+
+  const update = (taskId: number): Promise<unknown> =>
+    tasksService.update(
+      taskId,
+      { title: "Updated title" },
+      "application/json",
+      new Uint8Array([1, 2, 3]),
+      [],
+      [],
     );
 
-    await expect(update(service)).resolves.toEqual({ id: taskId });
+  it("allows updating a public task whose association was removed", async () => {
+    const taskId = await createTask(true);
+    const { sessionId, classId } = await createLessonWithTask(taskId);
+
+    await removeTaskFromLesson(sessionId, classId);
+
+    await expect(update(taskId)).resolves.toMatchObject({
+      title: "Updated title",
+    });
   });
 
   it("still refuses a public task that is in another teacher's lesson", async () => {
-    const service = buildService(
-      [lessonOfOtherTeacher(null)],
-      /* isPublic */ true,
-    );
+    const taskId = await createTask(true);
+    await createLessonWithTask(taskId);
 
-    await expect(update(service)).rejects.toBeInstanceOf(
+    await expect(update(taskId)).rejects.toBeInstanceOf(
       TaskInOtherUsersLessonError,
     );
   });
 
   it("allows updating a private task whose association was removed", async () => {
-    // the same stale association must not trip the "lesson with students" check
-    const service = buildService(
-      [lessonOfOtherTeacher(new Date())],
-      /* isPublic */ false,
-    );
+    // the same stale association must not trip the "lesson with students"
+    // check once students join the class afterwards - a lesson may only lose
+    // tasks while nobody has joined it yet
+    const taskId = await createTask(false);
+    const { sessionId, classId } = await createLessonWithTask(taskId);
 
-    await expect(update(service)).resolves.toEqual({ id: taskId });
+    await removeTaskFromLesson(sessionId, classId);
+    await enrolStudentInClass(classId);
+
+    await expect(update(taskId)).resolves.toMatchObject({
+      title: "Updated title",
+    });
   });
 
   it("still refuses a task in a live lesson that has students", async () => {
-    const service = buildService(
-      [lessonOfOtherTeacher(null)],
-      /* isPublic */ false,
-    );
+    const taskId = await createTask(false);
+    const { classId } = await createLessonWithTask(taskId);
+    await enrolStudentInClass(classId);
 
-    await expect(update(service)).rejects.toBeInstanceOf(
+    await expect(update(taskId)).rejects.toBeInstanceOf(
       TaskInUseByClassOrLessonWithStudentsError,
     );
   });

--- a/backend/src/api/tasks/task-update.spec.ts
+++ b/backend/src/api/tasks/task-update.spec.ts
@@ -20,6 +20,7 @@ describe("TasksService.update", () => {
   const studentUsageQuery = {
     where: {
       taskId,
+      deletedAt: null,
       task: { deletedAt: null },
       session: {
         deletedAt: null,
@@ -125,6 +126,7 @@ describe("TasksService.update", () => {
     expect(tx.sessionTask.findFirst).toHaveBeenCalledWith({
       where: {
         taskId,
+        deletedAt: null,
         session: {
           deletedAt: null,
           class: {
@@ -155,6 +157,7 @@ describe("TasksService.update", () => {
     expect(tx.sessionTask.findFirst).toHaveBeenNthCalledWith(1, {
       where: {
         taskId,
+        deletedAt: null,
         session: {
           deletedAt: null,
           class: {

--- a/backend/src/api/tasks/tasks.service.ts
+++ b/backend/src/api/tasks/tasks.service.ts
@@ -166,6 +166,7 @@ export class TasksService {
       include: {
         sessions: {
           where: {
+            deletedAt: deletedAtCondition,
             session: {
               deletedAt: deletedAtCondition,
               OR: [

--- a/backend/src/api/tasks/tasks.service.ts
+++ b/backend/src/api/tasks/tasks.service.ts
@@ -489,6 +489,9 @@ export class TasksService {
     const sessionWithStudents = await tx.sessionTask.findFirst({
       where: {
         taskId: id,
+        // removing a task from a lesson soft-deletes the association; such a
+        // lesson no longer uses the task and must not keep it locked
+        deletedAt: null,
         task: {
           deletedAt: null,
         },
@@ -530,6 +533,9 @@ export class TasksService {
     const sessionTask = await tx.sessionTask.findFirst({
       where: {
         taskId: id,
+        // a task the other teacher already removed from their lesson leaves a
+        // soft-deleted association behind; it must not lock the task forever
+        deletedAt: null,
         session: {
           deletedAt: null,
           class: {

--- a/backend/test/task-in-use-after-lesson-removal.e2e-spec.ts
+++ b/backend/test/task-in-use-after-lesson-removal.e2e-spec.ts
@@ -160,6 +160,20 @@ describe("TasksService.update — task removed from another teacher's lesson", (
     });
   });
 
+  it("reports a removed association as not in use in the task list", async () => {
+    const taskId = await createTask(false);
+    const { sessionId, classId } = await createLessonWithTask(taskId);
+
+    await removeTaskFromLesson(sessionId, classId);
+    await enrolStudentInClass(classId);
+
+    const tasks = await tasksService.findManyWithInUseStatus(false, ownerId);
+
+    expect(tasks).toContainEqual(
+      expect.objectContaining({ id: taskId, isInUse: false }),
+    );
+  });
+
   it("still refuses a task in a live lesson that has students", async () => {
     const taskId = await createTask(false);
     const { classId } = await createLessonWithTask(taskId);

--- a/backend/test/task-in-use-after-lesson-removal.e2e-spec.ts
+++ b/backend/test/task-in-use-after-lesson-removal.e2e-spec.ts
@@ -3,12 +3,12 @@ import { AuthenticationProvider, UserType } from "@prisma/client";
 import { CoreModule } from "src/core/core.module";
 import { PrismaService } from "src/prisma/prisma.service";
 import { mockConfigModule } from "src/utilities/test/mock-config.service";
-import { SessionsService } from "../../sessions/sessions.service";
+import { SessionsService } from "src/api/sessions/sessions.service";
 import {
   TasksService,
   TaskInOtherUsersLessonError,
   TaskInUseByClassOrLessonWithStudentsError,
-} from "../tasks.service";
+} from "src/api/tasks/tasks.service";
 
 // Removing a task from a lesson soft-deletes the SessionTask association: the
 // row stays behind with deletedAt set. An "is this task still in use" query
@@ -46,7 +46,10 @@ describe("TasksService.update — task removed from another teacher's lesson", (
     module = await Test.createTestingModule({
       imports: [CoreModule, mockConfigModule],
       providers: [TasksService, SessionsService],
-    }).compile();
+    })
+      .overrideProvider(PrismaService)
+      .useFactory({ factory: () => jestPrisma.client })
+      .compile();
 
     tasksService = module.get<TasksService>(TasksService);
     sessionsService = module.get<SessionsService>(SessionsService);


### PR DESCRIPTION
Removing a task from a lesson soft-deletes the SessionTask association: the row stays behind with deletedAt set. The soft-delete Prisma extension only rewrites delete operations - it does not filter reads - so both in-use checks kept matching lessons the task had already been removed from:

- isTaskInUseByOtherUsersTx made a public task permanently unupdatable with TASK_IN_OTHER_USERS_LESSON once any other teacher had ever added and then removed it (the reported bug);
- isTaskInUseTx did the same via TASK_IN_USE_BY_CLASS_OR_LESSON_WITH_STUDENTS whenever that lesson's class had students.

Note the lock had nothing to do with students still holding solutions for the task: neither query looks at student records, only at the stale association.

Filter soft-deleted associations out of both queries. The new spec drives update() against a Prisma mock that evaluates the where-clause it is given against a fixture, so a query that forgets the filter really does match the removed association - both new cases fail without the fix - while the two guard cases still refuse a task that is genuinely in use.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CRT-445 by ignoring soft-deleted lesson–task associations when checking task locks and task list status. Tasks removed from lessons no longer stay locked or show as in use, and can be updated if no active lessons use them.

- **Bug Fixes**
  - Apply `deletedAt: null` in both `sessionTask.findFirst` checks in `TasksService.update` and in task-list status filtering.
  - Add isolated DB-backed e2e test (`backend/test/task-in-use-after-lesson-removal.e2e-spec.ts`) covering updates and task list; update `task-update.spec.ts` to expect `deletedAt: null` and enroll students after removal.

<sup>Written for commit 435625db99d3682e0e7b18d4f6542798222b783e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

