### PR TITLE
Install curl in backend docker container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM node:22-trixie-slim
 WORKDIR /app
 
 # install dependencies
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y openssl
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y openssl curl
 
 # copy over the data
 COPY . .


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Install `curl` in the backend Docker image to enable HTTP requests for health checks, diagnostics, and integration scripts.

<sup>Written for commit e3ab32f125bd547945a52adad264a416b0978fb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

