### PR TITLE
Derive sentry environment from CI

### DIFF
--- a/.github/workflows/deploy_collimator.yml
+++ b/.github/workflows/deploy_collimator.yml
@@ -170,6 +170,8 @@ jobs:
 
       - name: Build jupyter app
         run: task apps:jupyter:build
+        env:
+          SENTRY_ENVIRONMENT: ${{ env.SENTRY_ENVIRONMENT }}
 
       - name: Upload jupyter app source maps
         run: task apps:jupyter:sourcemap:upload

--- a/.github/workflows/deploy_collimator.yml
+++ b/.github/workflows/deploy_collimator.yml
@@ -154,12 +154,14 @@ jobs:
           NEXT_PUBLIC_OPEN_ID_CONNECT_MICROSOFT_SERVER: https://login.microsoftonline.com/common/v2.0/
           NEXT_PUBLIC_OPEN_ID_CONNECT_MICROSOFT_CLIENT_ID: ${{ env.ENTRA_ID_CLIENT_ID }}
           NEXT_PUBLIC_SENTRY_DSN: ${{ env.FRONTEND_SENTRY_DSN }}
+          NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ env.SENTRY_ENVIRONMENT }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
       - name: Build scratch app
         run: task apps:scratch:build
         env:
           NEXT_PUBLIC_SENTRY_DSN: ${{ env.APP_SCRATCH_SENTRY_DSN }}
+          NEXT_PUBLIC_SENTRY_ENVIRONMENT: ${{ env.SENTRY_ENVIRONMENT }}
 
       - name: Upload scratch app source maps
         run: task apps:scratch:sourcemap:upload

--- a/apps/jupyter/extensions/notebook-runner/scripts/create-version.js
+++ b/apps/jupyter/extensions/notebook-runner/scripts/create-version.js
@@ -2,6 +2,9 @@ const { version } = require("../package.json");
 
 const fs = require("node:fs");
 const path = require("node:path");
-const content = `export const VERSION = "${version}";\n`;
+const sentryEnvironment = process.env.SENTRY_ENVIRONMENT ?? "development";
+const content = `export const VERSION = ${JSON.stringify(version)};
+export const SENTRY_ENVIRONMENT = ${JSON.stringify(sentryEnvironment)};
+`;
 
 fs.writeFileSync(path.resolve(__dirname, "../src/version.ts"), content);

--- a/apps/jupyter/extensions/notebook-runner/src/sentry.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/sentry.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/browser";
-import { VERSION } from "./version";
+import { SENTRY_ENVIRONMENT, VERSION } from "./version";
 
 export const enableSentry = (): void => {
   // Check if running on localhost, i.e. in a development environment
@@ -18,6 +18,6 @@ export const enableSentry = (): void => {
     // if your build tool supports it.
     release: `crt-jupyter@${VERSION}`,
     enabled: isProductionEnvironment,
-    environment: isProductionEnvironment ? "production" : "development",
+    environment: SENTRY_ENVIRONMENT,
   });
 };

--- a/apps/scratch/instrumentation-client.ts
+++ b/apps/scratch/instrumentation-client.ts
@@ -3,10 +3,15 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { sentryDsn, isDevelopment } from "./src/utilities/constants";
+import {
+  sentryDsn,
+  isDevelopment,
+  sentryEnvironment,
+} from "./src/utilities/constants";
 
 Sentry.init({
   dsn: sentryDsn,
+  environment: sentryEnvironment,
 
   // Add optional integrations for additional features
   integrations: [

--- a/apps/scratch/sentry.edge.config.ts
+++ b/apps/scratch/sentry.edge.config.ts
@@ -4,9 +4,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { sentryDsn, sentryEnvironment } from "./src/utilities/constants";
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: sentryDsn,
+  environment: sentryEnvironment,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/apps/scratch/sentry.server.config.ts
+++ b/apps/scratch/sentry.server.config.ts
@@ -3,9 +3,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { sentryDsn, sentryEnvironment } from "./src/utilities/constants";
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: sentryDsn,
+  environment: sentryEnvironment,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/apps/scratch/src/utilities/constants.ts
+++ b/apps/scratch/src/utilities/constants.ts
@@ -5,4 +5,9 @@ export const isDevelopment =
 export const sentryDsn = process.env
   .NEXT_PUBLIC_SENTRY_DSN as unknown as string;
 
+export const sentryEnvironment =
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "prod"
+    ? "production"
+    : "development";
+
 export const defaultMaximumExecutionTimeInMs = 1000 * 30;

--- a/apps/scratch/src/utilities/constants.ts
+++ b/apps/scratch/src/utilities/constants.ts
@@ -6,8 +6,6 @@ export const sentryDsn = process.env
   .NEXT_PUBLIC_SENTRY_DSN as unknown as string;
 
 export const sentryEnvironment =
-  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "prod"
-    ? "production"
-    : "development";
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? "development";
 
 export const defaultMaximumExecutionTimeInMs = 1000 * 30;

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -1,12 +1,8 @@
 import * as Sentry from "@sentry/nestjs";
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
 
-const sentryEnvironment =
-  process.env.SENTRY_ENVIRONMENT === "prod" ? "production" : "development";
-
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
-  environment: sentryEnvironment,
   integrations: [
     // use Sentry.profiler.startProfiler(); and Sentry.profiler.stopProfiler(); to profile the code in between
     nodeProfilingIntegration(),

--- a/backend/src/instrument.ts
+++ b/backend/src/instrument.ts
@@ -1,8 +1,12 @@
 import * as Sentry from "@sentry/nestjs";
 import { nodeProfilingIntegration } from "@sentry/profiling-node";
 
+const sentryEnvironment =
+  process.env.SENTRY_ENVIRONMENT === "prod" ? "production" : "development";
+
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
+  environment: sentryEnvironment,
   integrations: [
     // use Sentry.profiler.startProfiler(); and Sentry.profiler.stopProfiler(); to profile the code in between
     nodeProfilingIntegration(),

--- a/frontend/instrumentation-client.ts
+++ b/frontend/instrumentation-client.ts
@@ -3,10 +3,15 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
-import { backendHostName, sentryDsn } from "./src/utilities/constants";
+import {
+  backendHostName,
+  sentryDsn,
+  sentryEnvironment,
+} from "./src/utilities/constants";
 
 Sentry.init({
   dsn: sentryDsn,
+  environment: sentryEnvironment,
 
   // Add optional integrations for additional features
   integrations: [

--- a/frontend/sentry.edge.config.ts
+++ b/frontend/sentry.edge.config.ts
@@ -4,9 +4,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { sentryDsn, sentryEnvironment } from "./src/utilities/constants";
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: sentryDsn,
+  environment: sentryEnvironment,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/frontend/sentry.server.config.ts
+++ b/frontend/sentry.server.config.ts
@@ -3,9 +3,11 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { sentryDsn, sentryEnvironment } from "./src/utilities/constants";
 
 Sentry.init({
-  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
+  dsn: sentryDsn,
+  environment: sentryEnvironment,
 
   // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
   tracesSampleRate: 1,

--- a/frontend/src/utilities/constants.ts
+++ b/frontend/src/utilities/constants.ts
@@ -19,6 +19,4 @@ export const sentryDsn = process.env
   .NEXT_PUBLIC_SENTRY_DSN as unknown as string;
 
 export const sentryEnvironment =
-  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "prod"
-    ? "production"
-    : "development";
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT ?? "development";

--- a/frontend/src/utilities/constants.ts
+++ b/frontend/src/utilities/constants.ts
@@ -17,3 +17,8 @@ export const openIdConnectMicrosoftClientId = process.env
 
 export const sentryDsn = process.env
   .NEXT_PUBLIC_SENTRY_DSN as unknown as string;
+
+export const sentryEnvironment =
+  process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === "prod"
+    ? "production"
+    : "development";


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Derive the Sentry environment from CI so events are tagged correctly across frontend, scratch, and Jupyter. Threads the value through build and runtime across all apps.

- **New Features**
  - Use `SENTRY_ENVIRONMENT`/`NEXT_PUBLIC_SENTRY_ENVIRONMENT` from CI; default to `development`.
  - Set `environment` in all Sentry initializers: `@sentry/nextjs` (frontend and scratch: client, edge, server) and `@sentry/browser` (Jupyter notebook runner).
  - Pass `NEXT_PUBLIC_SENTRY_ENVIRONMENT` for frontend/scratch and `SENTRY_ENVIRONMENT` for Jupyter in the deploy workflow; export `SENTRY_ENVIRONMENT` in Jupyter `sentry-config.ts`.

<sup>Written for commit eec3221618f1d911e4af9aa41e524b031d15fc47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

