### PR TITLE
Prevent invalid syntax from flooding jupyter

### DIFF
--- a/backend/src/api/solutions/solution-analysis.constants.spec.ts
+++ b/backend/src/api/solutions/solution-analysis.constants.spec.ts
@@ -1,0 +1,12 @@
+import {
+  maximumNumberOfAnalysisRetries,
+  permanentlyFailedAnalysisCount,
+} from "./solution-analysis.constants";
+
+describe("solution analysis constants", () => {
+  it("keeps permanent failures above the retry ceiling", () => {
+    expect(permanentlyFailedAnalysisCount).toBeGreaterThan(
+      maximumNumberOfAnalysisRetries,
+    );
+  });
+});

--- a/backend/src/api/solutions/solution-analysis.constants.ts
+++ b/backend/src/api/solutions/solution-analysis.constants.ts
@@ -1,1 +1,3 @@
 export const maximumNumberOfAnalysisRetries = 3;
+
+export const permanentlyFailedAnalysisCount = 9999;

--- a/backend/src/api/solutions/solution-analysis.constants.ts
+++ b/backend/src/api/solutions/solution-analysis.constants.ts
@@ -1,0 +1,1 @@
+export const maximumNumberOfAnalysisRetries = 3;

--- a/backend/src/api/solutions/solution-analysis.service.spec.ts
+++ b/backend/src/api/solutions/solution-analysis.service.spec.ts
@@ -1,0 +1,68 @@
+import { Logger } from "@nestjs/common";
+import { AstVersion, Solution, TaskType } from "@prisma/client";
+import { AstConversionService } from "src/ast/ast-conversion.service";
+import { SolutionConversionStatus } from "src/ast/converters/solution-conversion-result";
+import { PrismaService } from "src/prisma/prisma.service";
+import { TasksService } from "../tasks/tasks.service";
+import { permanentlyFailedAnalysisCount } from "./solution-analysis.constants";
+import { SolutionAnalysisService } from "./solution-analysis.service";
+
+describe("SolutionAnalysisService", () => {
+  const solution: Solution = {
+    taskId: 1,
+    hash: Buffer.from("invalid-solution"),
+    data: Buffer.from("invalid"),
+    mimeType: "application/json",
+    failedAnalyses: 0,
+    deletedAt: null,
+  };
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it("logs invalid input, marks it permanently failed, and resolves null", async () => {
+    const updateSolution = jest.fn().mockResolvedValue(solution);
+    const upsertAnalysis = jest.fn();
+    const incrementFailedAnalysis = jest.fn();
+    const findTask = jest.fn().mockResolvedValue({
+      id: solution.taskId,
+      type: TaskType.JUPYTER,
+    });
+    const conversionErrors = [
+      { message: "invalid syntax", line: 2, column: 4 },
+    ];
+    const convertSolutionToAst = jest.fn().mockResolvedValue({
+      status: SolutionConversionStatus.InvalidInput,
+      errors: conversionErrors,
+    });
+    const warn = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+
+    const service = new SolutionAnalysisService(
+      {
+        solution: { update: updateSolution },
+        solutionAnalysis: { upsert: upsertAnalysis },
+        $queryRawTyped: incrementFailedAnalysis,
+      } as unknown as PrismaService,
+      { findByIdOrThrow: findTask } as unknown as TasksService,
+      { convertSolutionToAst } as unknown as AstConversionService,
+    );
+
+    await expect(
+      service.performAnalysis(solution, AstVersion.v1),
+    ).resolves.toBeNull();
+
+    expect(updateSolution).toHaveBeenCalledWith({
+      data: { failedAnalyses: permanentlyFailedAnalysisCount },
+      where: {
+        taskId_hash: {
+          taskId: solution.taskId,
+          hash: solution.hash,
+        },
+      },
+    });
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(JSON.stringify(conversionErrors)),
+    );
+    expect(upsertAnalysis).not.toHaveBeenCalled();
+    expect(incrementFailedAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/api/solutions/solution-analysis.service.spec.ts
+++ b/backend/src/api/solutions/solution-analysis.service.spec.ts
@@ -34,7 +34,7 @@ describe("SolutionAnalysisService", () => {
       status: SolutionConversionStatus.InvalidInput,
       errors: conversionErrors,
     });
-    const warn = jest.spyOn(Logger.prototype, "warn").mockImplementation();
+    const debug = jest.spyOn(Logger.prototype, "debug").mockImplementation();
 
     const service = new SolutionAnalysisService(
       {
@@ -59,7 +59,7 @@ describe("SolutionAnalysisService", () => {
         },
       },
     });
-    expect(warn).toHaveBeenCalledWith(
+    expect(debug).toHaveBeenCalledWith(
       expect.stringContaining(JSON.stringify(conversionErrors)),
     );
     expect(upsertAnalysis).not.toHaveBeenCalled();

--- a/backend/src/api/solutions/solution-analysis.service.ts
+++ b/backend/src/api/solutions/solution-analysis.service.ts
@@ -1,11 +1,11 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { AstVersion, Prisma, Solution, SolutionAnalysis } from "@prisma/client";
 import { AstConversionService } from "src/ast/ast-conversion.service";
 import { SolutionConversionStatus } from "src/ast/converters/solution-conversion-result";
 import { PrismaService } from "src/prisma/prisma.service";
 import { incrementFailedAnalysis } from "@prisma/client/sql";
 import { TasksService } from "../tasks/tasks.service";
-import { maximumNumberOfAnalysisRetries } from "./solution-analysis.constants";
+import { permanentlyFailedAnalysisCount } from "./solution-analysis.constants";
 
 export type SolutionAnalysisCreateInput = Omit<
   Prisma.SolutionAnalysisUncheckedCreateInput,
@@ -14,6 +14,8 @@ export type SolutionAnalysisCreateInput = Omit<
 
 @Injectable()
 export class SolutionAnalysisService {
+  private readonly logger = new Logger(SolutionAnalysisService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly tasksService: TasksService,
@@ -32,10 +34,14 @@ export class SolutionAnalysisService {
         solution,
       );
 
-      if (conversion.status === SolutionConversionStatus.InvalidSyntax) {
-        // invalid syntax is an expected state while a student is editing
+      if (conversion.status === SolutionConversionStatus.InvalidInput) {
+        // invalid input is an expected state while a student is editing
+        this.logger.warn(
+          `Skipping analysis for invalid solution (task id: ${solution.taskId}, hash: ${Buffer.from(solution.hash).toString("hex")}): ${JSON.stringify(conversion.errors)}`,
+        );
+
         await this.prisma.solution.update({
-          data: { failedAnalyses: maximumNumberOfAnalysisRetries },
+          data: { failedAnalyses: permanentlyFailedAnalysisCount },
           where: {
             taskId_hash: {
               taskId: solution.taskId,

--- a/backend/src/api/solutions/solution-analysis.service.ts
+++ b/backend/src/api/solutions/solution-analysis.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from "@nestjs/common";
 import { AstVersion, Prisma, Solution, SolutionAnalysis } from "@prisma/client";
 import { AstConversionService } from "src/ast/ast-conversion.service";
+import { SolutionConversionStatus } from "src/ast/converters/solution-conversion-result";
 import { PrismaService } from "src/prisma/prisma.service";
 import { incrementFailedAnalysis } from "@prisma/client/sql";
 import { TasksService } from "../tasks/tasks.service";
+import { maximumNumberOfAnalysisRetries } from "./solution-analysis.constants";
 
 export type SolutionAnalysisCreateInput = Omit<
   Prisma.SolutionAnalysisUncheckedCreateInput,
@@ -21,16 +23,32 @@ export class SolutionAnalysisService {
   async performAnalysis(
     solution: Solution,
     newAstVersion: AstVersion,
-  ): Promise<SolutionAnalysis> {
+  ): Promise<SolutionAnalysis | null> {
     const task = await this.tasksService.findByIdOrThrow(solution.taskId);
 
     try {
-      const ast = await this.astConversionService.convertSolutionToAst(
+      const conversion = await this.astConversionService.convertSolutionToAst(
         task,
         solution,
       );
 
-      const genericAst = JSON.stringify(ast);
+      if (conversion.status === SolutionConversionStatus.InvalidSyntax) {
+        // invalid syntax is an expected state while a student is editing
+        await this.prisma.solution.update({
+          data: { failedAnalyses: maximumNumberOfAnalysisRetries },
+          where: {
+            taskId_hash: {
+              taskId: solution.taskId,
+              hash: solution.hash,
+            },
+          },
+        });
+
+        // resolve normally so sentry does not receive an unhandled rejection
+        return null;
+      }
+
+      const genericAst = JSON.stringify(conversion.ast);
 
       // use an upsert to handle the case where the analysis has already been performed
       // this may happen if a re-analysis is triggered  because the initial analysis takes

--- a/backend/src/api/solutions/solution-analysis.service.ts
+++ b/backend/src/api/solutions/solution-analysis.service.ts
@@ -36,7 +36,7 @@ export class SolutionAnalysisService {
 
       if (conversion.status === SolutionConversionStatus.InvalidInput) {
         // invalid input is an expected state while a student is editing
-        this.logger.warn(
+        this.logger.debug(
           `Skipping analysis for invalid solution (task id: ${solution.taskId}, hash: ${Buffer.from(solution.hash).toString("hex")}): ${JSON.stringify(conversion.errors)}`,
         );
 

--- a/backend/src/api/solutions/solutions-cron.spec.ts
+++ b/backend/src/api/solutions/solutions-cron.spec.ts
@@ -1,0 +1,58 @@
+import { Solution } from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { TasksService } from "../tasks/tasks.service";
+import { SolutionAnalysisService } from "./solution-analysis.service";
+import { SolutionsService } from "./solutions.service";
+
+describe("SolutionsService analysis cron jobs", () => {
+  const solution: Solution = {
+    taskId: 1,
+    hash: Buffer.from("solution"),
+    data: Buffer.from("data"),
+    mimeType: "application/json",
+    failedAnalyses: 0,
+    deletedAt: null,
+  };
+
+  const buildService = (): {
+    service: SolutionsService;
+    findSolutions: jest.Mock;
+    findAnalyses: jest.Mock;
+    performAnalysis: jest.Mock;
+  } => {
+    const findSolutions = jest.fn();
+    const findAnalyses = jest.fn();
+    const performAnalysis = jest
+      .fn()
+      .mockRejectedValue(new Error("conversion failed"));
+
+    const service = new SolutionsService(
+      {
+        solution: { findMany: findSolutions },
+        solutionAnalysis: { findMany: findAnalyses },
+      } as unknown as PrismaService,
+      {} as TasksService,
+      { performAnalysis } as unknown as SolutionAnalysisService,
+    );
+
+    return { service, findSolutions, findAnalyses, performAnalysis };
+  };
+
+  it("continues when an unperformed analysis rejects", async () => {
+    const { service, findSolutions, performAnalysis } = buildService();
+    findSolutions.mockResolvedValue([solution]);
+
+    await expect(service.runUnperformedAnalyes()).resolves.toBeUndefined();
+
+    expect(performAnalysis).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues when an analysis upgrade rejects", async () => {
+    const { service, findAnalyses, performAnalysis } = buildService();
+    findAnalyses.mockResolvedValue([{ solution }]);
+
+    await expect(service.runUpgradeAnalyes()).resolves.toBeUndefined();
+
+    expect(performAnalysis).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/api/solutions/solutions.service.ts
+++ b/backend/src/api/solutions/solutions.service.ts
@@ -700,8 +700,9 @@ export class SolutionsService {
       solutionsWithoutAnalysis.map((solution) =>
         this.analysisService
           .performAnalysis(solution, latestAstVersion)
-          // ignore exceptions, we'll just re-try
-          .catch(),
+          // consume the rejection so one failed analysis does not reject the
+          // entire Promise.all batch as it will be retried by the next run
+          .catch(() => undefined),
       ),
     );
   }
@@ -755,8 +756,9 @@ export class SolutionsService {
       solutionsWithoutAnalysis.map(({ solution }) =>
         this.analysisService
           .performAnalysis(solution, latestAstVersion)
-          // ignore exceptions, we'll just re-try
-          .catch(),
+          // consume the rejection so one failed analysis does not reject the
+          // entire Promise.all batch as it will be retried by the next run
+          .catch(() => undefined),
       ),
     );
   }

--- a/backend/src/api/solutions/solutions.service.ts
+++ b/backend/src/api/solutions/solutions.service.ts
@@ -22,6 +22,7 @@ import { TaskId } from "../tasks/dto";
 import { TasksService } from "../tasks/tasks.service";
 import { SessionId } from "../sessions/dto";
 import { SolutionAnalysisService } from "./solution-analysis.service";
+import { maximumNumberOfAnalysisRetries } from "./solution-analysis.constants";
 import { StudentSolutionId } from "./dto/existing-student-solution.dto";
 import { ReferenceSolutionId } from "./dto/existing-reference-solution.dto";
 
@@ -99,8 +100,6 @@ export type ReferenceAnalysis = AnalysisWithoutId & {
 };
 
 type NullablePartial<T> = { [K in keyof T]?: T[K] | null };
-
-const maximumNumberOfAnalysisRetries = 3;
 
 const omitData = { data: true };
 

--- a/backend/src/ast/ast-conversion.service.ts
+++ b/backend/src/ast/ast-conversion.service.ts
@@ -4,8 +4,8 @@ import { Solution } from "@prisma/client";
 import { Piscina } from "piscina";
 import { TaskWithoutData } from "src/api/tasks/tasks.service";
 import { getPiscinaPath } from "src/utilities/is-test";
-import { GeneralAst } from "./types/general-ast";
 import SolutionConversionWorker from "./converters/solution-conversion-worker.piscina";
+import { SolutionConversionResult } from "./converters/solution-conversion-result";
 
 type ConversionWorker = typeof SolutionConversionWorker;
 
@@ -35,7 +35,7 @@ export class AstConversionService implements OnModuleDestroy {
   async convertSolutionToAst(
     task: TaskWithoutData,
     solution: Solution,
-  ): Promise<GeneralAst> {
+  ): Promise<SolutionConversionResult> {
     return this.conversionWorker.run({
       solution,
       taskType: task.type,

--- a/backend/src/ast/converters/jupyter/index.ts
+++ b/backend/src/ast/converters/jupyter/index.ts
@@ -12,24 +12,28 @@ import {
 } from "src/ast/types/general-ast/ast-nodes";
 import { match } from "ts-pattern";
 import { convertPythonToStatement } from "../python";
+import { ConversionError } from "../solution-conversion-result";
 import { StatementWithFunctions } from "../statement-with-functions";
 import { SupportedLanguage } from "./supported-languages";
 
 export const convertJupyterToGeneralAst = (input: JupyterInput): GeneralAst => {
   if (!input.metadata.language_info) {
-    throw new Error("Jupyter notebook is missing language info in metadata");
+    const message = "Jupyter notebook is missing language info in metadata";
+    throw new ConversionError(message, [{ message }]);
   }
 
   const language = input.metadata.language_info.name as SupportedLanguage;
 
   if (!Object.values(SupportedLanguage).includes(language)) {
-    throw new Error(`Language ${language} is not supported`);
+    const message = `Language ${language} is not supported`;
+    throw new ConversionError(message, [{ message }]);
   }
 
   const version = input.metadata.language_info.version;
 
   if (typeof version !== "string" && version !== undefined) {
-    throw new Error(`Language version ${version} is not supported`);
+    const message = `Language version ${version} is not supported`;
+    throw new ConversionError(message, [{ message }]);
   }
 
   const getCellSource = (cell: { source: string | string[] }): string =>

--- a/backend/src/ast/converters/python/python-syntax-error.ts
+++ b/backend/src/ast/converters/python/python-syntax-error.ts
@@ -1,4 +1,9 @@
-export interface PythonSyntaxErrorDetail {
+import {
+  ConversionError,
+  ConversionErrorDetail,
+} from "../solution-conversion-result";
+
+export interface PythonSyntaxErrorDetail extends ConversionErrorDetail {
   line: number;
   column: number;
   message: string;
@@ -10,12 +15,13 @@ export interface PythonSyntaxErrorDetail {
  * recovery tree leaves mandatory children null) or - worse - silently
  * converted into a garbage AST that polluted the similarity analysis.
  */
-export class PythonSyntaxError extends Error {
-  constructor(readonly errors: PythonSyntaxErrorDetail[]) {
+export class PythonSyntaxError extends ConversionError<PythonSyntaxErrorDetail> {
+  constructor(errors: PythonSyntaxErrorDetail[]) {
     super(
       `Input is not valid Python: ${errors
         .map((e) => `line ${e.line}:${e.column} ${e.message}`)
         .join("; ")}`,
+      errors,
     );
     this.name = "PythonSyntaxError";
   }

--- a/backend/src/ast/converters/solution-conversion-result.ts
+++ b/backend/src/ast/converters/solution-conversion-result.ts
@@ -1,14 +1,29 @@
 import { GeneralAst } from "../types/general-ast";
-import { PythonSyntaxErrorDetail } from "./python/python-syntax-error";
+
+export interface ConversionErrorDetail {
+  message: string;
+}
+
+export class ConversionError<
+  TDetail extends ConversionErrorDetail = ConversionErrorDetail,
+> extends Error {
+  constructor(
+    message: string,
+    readonly errors: TDetail[],
+  ) {
+    super(message);
+    this.name = "ConversionError";
+  }
+}
 
 export enum SolutionConversionStatus {
   Success = "success",
-  InvalidSyntax = "invalid-syntax",
+  InvalidInput = "invalid-input",
 }
 
 export type SolutionConversionResult =
   | { status: SolutionConversionStatus.Success; ast: GeneralAst }
   | {
-      status: SolutionConversionStatus.InvalidSyntax;
-      errors: PythonSyntaxErrorDetail[];
+      status: SolutionConversionStatus.InvalidInput;
+      errors: ConversionErrorDetail[];
     };

--- a/backend/src/ast/converters/solution-conversion-result.ts
+++ b/backend/src/ast/converters/solution-conversion-result.ts
@@ -1,0 +1,14 @@
+import { GeneralAst } from "../types/general-ast";
+import { PythonSyntaxErrorDetail } from "./python/python-syntax-error";
+
+export enum SolutionConversionStatus {
+  Success = "success",
+  InvalidSyntax = "invalid-syntax",
+}
+
+export type SolutionConversionResult =
+  | { status: SolutionConversionStatus.Success; ast: GeneralAst }
+  | {
+      status: SolutionConversionStatus.InvalidSyntax;
+      errors: PythonSyntaxErrorDetail[];
+    };

--- a/backend/src/ast/converters/solution-conversion-worker.piscina.spec.ts
+++ b/backend/src/ast/converters/solution-conversion-worker.piscina.spec.ts
@@ -82,4 +82,19 @@ describe("SolutionConversionWorker", () => {
       ]);
     }
   });
+
+  it.each([TaskType.JUPYTER, TaskType.SCRATCH])(
+    "returns an invalid-input result for %s JSON with the wrong root shape",
+    (taskType) => {
+      const result = SolutionConversionWorker({
+        solution: buildSolution(null),
+        taskType,
+      });
+
+      expect(result).toEqual({
+        status: SolutionConversionStatus.InvalidInput,
+        errors: [{ message: `Invalid ${taskType} solution JSON structure` }],
+      });
+    },
+  );
 });

--- a/backend/src/ast/converters/solution-conversion-worker.piscina.spec.ts
+++ b/backend/src/ast/converters/solution-conversion-worker.piscina.spec.ts
@@ -1,0 +1,85 @@
+import { Solution, TaskType } from "@prisma/client";
+import SolutionConversionWorker from "./solution-conversion-worker.piscina";
+import { SolutionConversionStatus } from "./solution-conversion-result";
+
+const buildSolution = (
+  data: unknown,
+  mimeType = "application/json",
+): Solution => ({
+  taskId: 1,
+  hash: Buffer.from("solution"),
+  data: Buffer.from(JSON.stringify(data)),
+  mimeType,
+  failedAnalyses: 0,
+  deletedAt: null,
+});
+
+describe("SolutionConversionWorker", () => {
+  it("returns generic conversion details for invalid Python", () => {
+    const solution = buildSolution({
+      nbformat: 4,
+      nbformat_minor: 0,
+      metadata: {
+        language_info: { name: "python", version: "3.10.4" },
+      },
+      cells: [
+        {
+          id: "invalid",
+          cell_type: "code",
+          source: "x = +\n",
+          outputs: [],
+          execution_count: 0,
+          metadata: {},
+        },
+      ],
+    });
+
+    const result = SolutionConversionWorker({
+      solution,
+      taskType: TaskType.JUPYTER,
+    });
+
+    expect(result.status).toBe(SolutionConversionStatus.InvalidInput);
+    if (result.status === SolutionConversionStatus.InvalidInput) {
+      expect(result.errors).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ message: expect.any(String) }),
+        ]),
+      );
+    }
+  });
+
+  it("returns an invalid-input result for an unsupported MIME type", () => {
+    const result = SolutionConversionWorker({
+      solution: buildSolution({}, "text/plain"),
+      taskType: TaskType.SCRATCH,
+    });
+
+    expect(result).toEqual({
+      status: SolutionConversionStatus.InvalidInput,
+      errors: [
+        {
+          message:
+            "Unsupported (task, solution mime type) tuple '(SCRATCH, text/plain)'",
+        },
+      ],
+    });
+  });
+
+  it("returns an invalid-input result for malformed JSON", () => {
+    const solution = buildSolution({});
+    solution.data = Buffer.from("{");
+
+    const result = SolutionConversionWorker({
+      solution,
+      taskType: TaskType.JUPYTER,
+    });
+
+    expect(result.status).toBe(SolutionConversionStatus.InvalidInput);
+    if (result.status === SolutionConversionStatus.InvalidInput) {
+      expect(result.errors).toEqual([
+        expect.objectContaining({ message: expect.any(String) }),
+      ]);
+    }
+  });
+});

--- a/backend/src/ast/converters/solution-conversion-worker.piscina.ts
+++ b/backend/src/ast/converters/solution-conversion-worker.piscina.ts
@@ -3,11 +3,23 @@ import * as Sentry from "@sentry/node";
 import { GeneralAst } from "../types/general-ast";
 import { convertScratchToGeneralAst } from "./scratch";
 import { convertJupyterToGeneralAst } from "./jupyter";
-import { PythonSyntaxError } from "./python/python-syntax-error";
 import {
+  ConversionError,
   SolutionConversionResult,
   SolutionConversionStatus,
 } from "./solution-conversion-result";
+
+const parseSolutionJson = <T>(solution: Solution): T => {
+  try {
+    return JSON.parse(new TextDecoder("utf-8").decode(solution.data)) as T;
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      throw new ConversionError(error.message, [{ message: error.message }]);
+    }
+
+    throw error;
+  }
+};
 
 const SolutionConversionWorker = ({
   solution,
@@ -31,27 +43,28 @@ const SolutionConversionWorker = ({
         taskType === TaskType.SCRATCH &&
         solution.mimeType === "application/json"
       ) {
-        ast = convertScratchToGeneralAst(
-          JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
-        );
+        ast = convertScratchToGeneralAst(parseSolutionJson(solution));
       } else if (
         taskType === TaskType.JUPYTER &&
         solution.mimeType === "application/json"
       ) {
-        ast = convertJupyterToGeneralAst(
-          JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
-        );
+        ast = convertJupyterToGeneralAst(parseSolutionJson(solution));
       } else {
-        throw new Error(
-          `Unsupported (task, solution mime type) tuple '(${taskType}, ${solution.mimeType})'`,
-        );
+        return {
+          status: SolutionConversionStatus.InvalidInput,
+          errors: [
+            {
+              message: `Unsupported (task, solution mime type) tuple '(${taskType}, ${solution.mimeType})'`,
+            },
+          ],
+        };
       }
 
       return { status: SolutionConversionStatus.Success, ast };
     } catch (error) {
-      if (error instanceof PythonSyntaxError) {
+      if (error instanceof ConversionError) {
         return {
-          status: SolutionConversionStatus.InvalidSyntax,
+          status: SolutionConversionStatus.InvalidInput,
           errors: error.errors,
         };
       }

--- a/backend/src/ast/converters/solution-conversion-worker.piscina.ts
+++ b/backend/src/ast/converters/solution-conversion-worker.piscina.ts
@@ -3,6 +3,11 @@ import * as Sentry from "@sentry/node";
 import { GeneralAst } from "../types/general-ast";
 import { convertScratchToGeneralAst } from "./scratch";
 import { convertJupyterToGeneralAst } from "./jupyter";
+import { PythonSyntaxError } from "./python/python-syntax-error";
+import {
+  SolutionConversionResult,
+  SolutionConversionStatus,
+} from "./solution-conversion-result";
 
 const SolutionConversionWorker = ({
   solution,
@@ -10,7 +15,7 @@ const SolutionConversionWorker = ({
 }: {
   taskType: TaskType;
   solution: Solution;
-}): GeneralAst => {
+}): SolutionConversionResult => {
   return Sentry.withScope((scope) => {
     const hashHexVal = Buffer.from(solution.hash).toString("hex");
 
@@ -19,29 +24,40 @@ const SolutionConversionWorker = ({
     scope.setTag("solution.taskType", taskType);
     scope.setTag("solution.mimeType", solution.mimeType);
 
-    let ast: GeneralAst;
+    try {
+      let ast: GeneralAst;
 
-    if (
-      taskType === TaskType.SCRATCH &&
-      solution.mimeType === "application/json"
-    ) {
-      ast = convertScratchToGeneralAst(
-        JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
-      );
-    } else if (
-      taskType === TaskType.JUPYTER &&
-      solution.mimeType === "application/json"
-    ) {
-      ast = convertJupyterToGeneralAst(
-        JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
-      );
-    } else {
-      throw new Error(
-        `Unsupported (task, solution mime type) tuple '(${taskType}, ${solution.mimeType})'`,
-      );
+      if (
+        taskType === TaskType.SCRATCH &&
+        solution.mimeType === "application/json"
+      ) {
+        ast = convertScratchToGeneralAst(
+          JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
+        );
+      } else if (
+        taskType === TaskType.JUPYTER &&
+        solution.mimeType === "application/json"
+      ) {
+        ast = convertJupyterToGeneralAst(
+          JSON.parse(new TextDecoder("utf-8").decode(solution.data)),
+        );
+      } else {
+        throw new Error(
+          `Unsupported (task, solution mime type) tuple '(${taskType}, ${solution.mimeType})'`,
+        );
+      }
+
+      return { status: SolutionConversionStatus.Success, ast };
+    } catch (error) {
+      if (error instanceof PythonSyntaxError) {
+        return {
+          status: SolutionConversionStatus.InvalidSyntax,
+          errors: error.errors,
+        };
+      }
+
+      throw error;
     }
-
-    return ast;
   });
 };
 

--- a/backend/src/ast/converters/solution-conversion-worker.piscina.ts
+++ b/backend/src/ast/converters/solution-conversion-worker.piscina.ts
@@ -1,6 +1,8 @@
 import { Solution, TaskType } from "@prisma/client";
 import * as Sentry from "@sentry/node";
 import { GeneralAst } from "../types/general-ast";
+import JupyterInput from "../types/input/jupyter";
+import ScratchInput from "../types/input/scratch";
 import { convertScratchToGeneralAst } from "./scratch";
 import { convertJupyterToGeneralAst } from "./jupyter";
 import {
@@ -9,9 +11,9 @@ import {
   SolutionConversionStatus,
 } from "./solution-conversion-result";
 
-const parseSolutionJson = <T>(solution: Solution): T => {
+const parseSolutionJson = (solution: Solution): unknown => {
   try {
-    return JSON.parse(new TextDecoder("utf-8").decode(solution.data)) as T;
+    return JSON.parse(new TextDecoder("utf-8").decode(solution.data));
   } catch (error) {
     if (error instanceof SyntaxError) {
       throw new ConversionError(error.message, [{ message: error.message }]);
@@ -19,6 +21,22 @@ const parseSolutionJson = <T>(solution: Solution): T => {
 
     throw error;
   }
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// TODO: Tighten this to validate the decoded value against the Jupyter notebook format
+const isJupyterInput = (value: unknown): value is JupyterInput =>
+  isRecord(value) && isRecord(value.metadata) && Array.isArray(value.cells);
+
+// TODO: Tighten this to validate the decoded value against the Scratch project format
+const isScratchInput = (value: unknown): value is ScratchInput =>
+  isRecord(value) && Array.isArray(value.targets);
+
+const invalidStructure = (taskType: TaskType): ConversionError => {
+  const message = `Invalid ${taskType} solution JSON structure`;
+  return new ConversionError(message, [{ message }]);
 };
 
 const SolutionConversionWorker = ({
@@ -43,12 +61,24 @@ const SolutionConversionWorker = ({
         taskType === TaskType.SCRATCH &&
         solution.mimeType === "application/json"
       ) {
-        ast = convertScratchToGeneralAst(parseSolutionJson(solution));
+        const input = parseSolutionJson(solution);
+
+        if (!isScratchInput(input)) {
+          throw invalidStructure(taskType);
+        }
+
+        ast = convertScratchToGeneralAst(input);
       } else if (
         taskType === TaskType.JUPYTER &&
         solution.mimeType === "application/json"
       ) {
-        ast = convertJupyterToGeneralAst(parseSolutionJson(solution));
+        const input = parseSolutionJson(solution);
+
+        if (!isJupyterInput(input)) {
+          throw invalidStructure(taskType);
+        }
+
+        ast = convertJupyterToGeneralAst(input);
       } else {
         return {
           status: SolutionConversionStatus.InvalidInput,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Handle invalid input during solution-to-AST conversion to stop re-analysis loops that flood Jupyter and spam Sentry. We detect invalid Python, malformed JSON, wrong JSON root shapes, and unsupported (task, mime) tuples; then mark the solution hash as permanently failed and skip analysis.

- **Bug Fixes**
  - Worker returns InvalidInput with error details for invalid Python, malformed JSON, invalid JSON root structure (Jupyter/Scratch), or unsupported (task, mime); analysis logs at debug level, sets failedAnalyses to permanentlyFailedAnalysisCount, and returns null to halt retries.
  - Cron jobs now consume analysis rejections so a single failure doesn’t abort the batch, preventing repeated conversions and unhandled rejections.

- **Refactors**
  - Introduced `ConversionError`, `SolutionConversionResult`, and `SolutionConversionStatus`; Jupyter converter and `PythonSyntaxError` now throw `ConversionError`; `AstConversionService.convertSolutionToAst` returns `SolutionConversionResult`.
  - Centralized `maximumNumberOfAnalysisRetries` and `permanentlyFailedAnalysisCount`; added tests for constants, worker (including malformed JSON and JSON root validation), cron, and analysis behavior.

<sup>Written for commit 6f40d2f5f687db399c59ae51621cdc0c489b0246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

