### PR TITLE
[CRT-379] Handle replayed student activities

### DIFF
--- a/backend/src/api/student-activity/student-activity.service.spec.ts
+++ b/backend/src/api/student-activity/student-activity.service.spec.ts
@@ -1,0 +1,148 @@
+import {
+  AstVersion,
+  Prisma,
+  Solution,
+  Student,
+  StudentActivityType,
+} from "@prisma/client";
+import { PrismaService } from "src/prisma/prisma.service";
+import { TasksService } from "../tasks/tasks.service";
+import { SolutionAnalysisService } from "../solutions/solution-analysis.service";
+import {
+  SolutionInput,
+  StudentActivityInput,
+  StudentActivityService,
+  StudentActivityWithSolution,
+} from "./student-activity.service";
+
+describe("StudentActivityService", () => {
+  const student: Student = { id: 1, deletedAt: null };
+  const happenedAt = new Date("2026-08-05T08:00:00.000Z");
+  const solutionHash = Buffer.from("solution-hash");
+  const solutionInput: SolutionInput = {
+    data: Buffer.from("submitted solution"),
+    mimeType: "application/json",
+  };
+
+  const activity: StudentActivityInput = {
+    type: StudentActivityType.TASK_RUN_SOLUTION,
+    happenedAt,
+    happenedAtCounter: 3,
+    sessionId: 2,
+    taskId: 4,
+    appActivity: null,
+  };
+
+  const storedSolution: Solution = {
+    taskId: activity.taskId,
+    hash: solutionHash,
+    data: Buffer.from("stored solution"),
+    mimeType: solutionInput.mimeType,
+    failedAnalyses: 0,
+    deletedAt: null,
+  };
+
+  const storedActivity: StudentActivityWithSolution = {
+    id: 5,
+    createdAt: new Date("2026-08-05T08:00:01.000Z"),
+    type: activity.type,
+    happenedAt,
+    happenedAtCounter: activity.happenedAtCounter,
+    deletedAt: null,
+    studentId: student.id,
+    sessionId: activity.sessionId,
+    taskId: activity.taskId,
+    solutionHash,
+    solution: storedSolution,
+  };
+
+  const uniqueConstraintError = (): Prisma.PrismaClientKnownRequestError =>
+    new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+      code: "P2002",
+      clientVersion: "6.6.0",
+    });
+
+  let createActivity: jest.Mock;
+  let findActivity: jest.Mock;
+  let performAnalysis: jest.Mock;
+  let service: StudentActivityService;
+
+  beforeEach(() => {
+    createActivity = jest.fn();
+    findActivity = jest.fn();
+    performAnalysis = jest.fn();
+
+    const prisma = {
+      studentActivity: {
+        create: createActivity,
+        findUnique: findActivity,
+      },
+    } as unknown as PrismaService;
+
+    const tasksService = {
+      computeSolutionHash: jest.fn().mockReturnValue(solutionHash),
+    } as unknown as TasksService;
+
+    const analysisService = {
+      performAnalysis,
+    } as unknown as SolutionAnalysisService;
+
+    service = new StudentActivityService(prisma, tasksService, analysisService);
+  });
+
+  it("returns an existing replay without triggering analysis again", async () => {
+    createActivity.mockRejectedValue(uniqueConstraintError());
+    findActivity.mockResolvedValue(storedActivity);
+
+    await expect(
+      service.create(student, activity, solutionInput),
+    ).resolves.toBe(storedActivity);
+
+    expect(createActivity).toHaveBeenCalledTimes(1);
+
+    expect(findActivity).toHaveBeenCalledWith({
+      where: {
+        uniqueStudentActivityPerTypeAndTime: {
+          studentId: student.id,
+          type: activity.type,
+          happenedAt: activity.happenedAt,
+          happenedAtCounter: activity.happenedAtCounter,
+        },
+      },
+      include: { solution: true },
+    });
+
+    expect(performAnalysis).not.toHaveBeenCalled();
+  });
+
+  it("retries once when concurrent solution creation caused the conflict", async () => {
+    createActivity
+      .mockRejectedValueOnce(uniqueConstraintError())
+      .mockResolvedValueOnce(storedActivity);
+
+    findActivity.mockResolvedValue(null);
+
+    await expect(
+      service.create(student, activity, solutionInput),
+    ).resolves.toBe(storedActivity);
+
+    expect(createActivity).toHaveBeenCalledTimes(2);
+    expect(findActivity).toHaveBeenCalledTimes(1);
+    expect(performAnalysis).toHaveBeenCalledWith(storedSolution, AstVersion.v1);
+  });
+
+  it("rethrows a persistent unrelated unique conflict after one retry", async () => {
+    const error = uniqueConstraintError();
+
+    createActivity.mockRejectedValue(error);
+    findActivity.mockResolvedValue(null);
+
+    await expect(service.create(student, activity, solutionInput)).rejects.toBe(
+      error,
+    );
+
+    expect(createActivity).toHaveBeenCalledTimes(2);
+    expect(findActivity).toHaveBeenCalledTimes(2);
+    expect(performAnalysis).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/api/student-activity/student-activity.service.ts
+++ b/backend/src/api/student-activity/student-activity.service.ts
@@ -20,8 +20,9 @@ export type AppActivityInput = Omit<
 
 export type StudentActivityInput = Omit<
   Prisma.StudentActivityUncheckedCreateInput,
-  "solutionHash" | "appActivity" | "studentId"
+  "solutionHash" | "appActivity" | "studentId" | "happenedAtCounter"
 > & {
+  happenedAtCounter: number;
   appActivity: AppActivityInput | null;
 };
 
@@ -40,20 +41,11 @@ export class StudentActivityService {
       solution: SolutionInput;
     }[],
   ): Promise<StudentActivity[]> {
-    const results = await this.prisma.$transaction(
-      activityWithSolution.map(({ activity, solution }) =>
-        this.prisma.studentActivity.create({
-          data: this.buildActivityInput(student, activity, solution),
-          include: { solution: true },
-        }),
-      ),
-    );
+    const results: StudentActivity[] = [];
 
-    results.forEach((result) =>
-      // do not wait for the promise to resolve
-      // this will happen in the background
-      this.analysisService.performAnalysis(result.solution, latestAstVersion),
-    );
+    for (const { activity, solution } of activityWithSolution) {
+      results.push(await this.create(student, activity, solution));
+    }
 
     return results;
   }
@@ -63,10 +55,46 @@ export class StudentActivityService {
     activity: StudentActivityInput,
     solution: SolutionInput,
   ): Promise<StudentActivity> {
-    const result = await this.prisma.studentActivity.create({
-      data: this.buildActivityInput(student, activity, solution),
-      include: { solution: true },
-    });
+    let result: Prisma.StudentActivityGetPayload<{
+      include: { solution: true };
+    }>;
+
+    try {
+      result = await this.prisma.studentActivity.create({
+        data: this.buildActivityInput(student, activity, solution),
+        include: { solution: true },
+      });
+    } catch (error) {
+      if (
+        !(
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        )
+      ) {
+        throw error;
+      }
+
+      // the client may replay an activity after a timeout, reload, or concurrent requests
+      // treat the activity's unique key as an idempotency key
+      // look it up to ensure that an unrelated unique violation is not suppressed
+      const existingActivity = await this.prisma.studentActivity.findUnique({
+        where: {
+          uniqueStudentActivityPerTypeAndTime: {
+            studentId: student.id,
+            type: activity.type,
+            happenedAt: activity.happenedAt,
+            happenedAtCounter: activity.happenedAtCounter,
+          },
+        },
+        include: { solution: true },
+      });
+
+      if (!existingActivity) {
+        throw error;
+      }
+
+      return existingActivity;
+    }
 
     // do not wait for the promise to resolve
     // this will happen in the background

--- a/backend/src/api/student-activity/student-activity.service.ts
+++ b/backend/src/api/student-activity/student-activity.service.ts
@@ -61,15 +61,19 @@ export class StudentActivityService {
     solution: SolutionInput,
   ): Promise<StudentActivity> {
     const data = this.buildActivityInput(student, activity, solution);
-    let result: StudentActivityWithSolution | null = null;
 
-    for (let attempt = 1; attempt <= activityCreateAttempts; attempt++) {
+    for (let attempt = 1; ; attempt++) {
       try {
-        result = await this.prisma.studentActivity.create({
+        const result = await this.prisma.studentActivity.create({
           data,
           include: { solution: true },
         });
-        break;
+
+        // do not wait for the promise to resolve
+        // this will happen in the background
+        this.analysisService.performAnalysis(result.solution, latestAstVersion);
+
+        return result;
       } catch (error) {
         if (
           !(
@@ -108,16 +112,6 @@ export class StudentActivityService {
         }
       }
     }
-
-    if (!result) {
-      throw new Error("Student activity creation did not return a result");
-    }
-
-    // do not wait for the promise to resolve
-    // this will happen in the background
-    this.analysisService.performAnalysis(result.solution, latestAstVersion);
-
-    return result;
   }
 
   private buildActivityInput(

--- a/backend/src/api/student-activity/student-activity.service.ts
+++ b/backend/src/api/student-activity/student-activity.service.ts
@@ -5,6 +5,11 @@ import { TasksService } from "../tasks/tasks.service";
 import { SolutionAnalysisService } from "../solutions/solution-analysis.service";
 
 const latestAstVersion = AstVersion.v1;
+const activityCreateAttempts = 2;
+
+type StudentActivityWithSolution = Prisma.StudentActivityGetPayload<{
+  include: { solution: true };
+}>;
 
 export type SolutionInput = Pick<
   Prisma.SolutionUncheckedCreateInput,
@@ -55,45 +60,57 @@ export class StudentActivityService {
     activity: StudentActivityInput,
     solution: SolutionInput,
   ): Promise<StudentActivity> {
-    let result: Prisma.StudentActivityGetPayload<{
-      include: { solution: true };
-    }>;
+    const data = this.buildActivityInput(student, activity, solution);
+    let result: StudentActivityWithSolution | null = null;
 
-    try {
-      result = await this.prisma.studentActivity.create({
-        data: this.buildActivityInput(student, activity, solution),
-        include: { solution: true },
-      });
-    } catch (error) {
-      if (
-        !(
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        )
-      ) {
-        throw error;
-      }
+    for (let attempt = 1; attempt <= activityCreateAttempts; attempt++) {
+      try {
+        result = await this.prisma.studentActivity.create({
+          data,
+          include: { solution: true },
+        });
+        break;
+      } catch (error) {
+        if (
+          !(
+            error instanceof Prisma.PrismaClientKnownRequestError &&
+            error.code === "P2002"
+          )
+        ) {
+          throw error;
+        }
 
-      // the client may replay an activity after a timeout, reload, or concurrent requests
-      // treat the activity's unique key as an idempotency key
-      // look it up to ensure that an unrelated unique violation is not suppressed
-      const existingActivity = await this.prisma.studentActivity.findUnique({
-        where: {
-          uniqueStudentActivityPerTypeAndTime: {
-            studentId: student.id,
-            type: activity.type,
-            happenedAt: activity.happenedAt,
-            happenedAtCounter: activity.happenedAtCounter,
+        // the client may replay an activity after a timeout, reload, or concurrent requests
+        // treat the activity's unique key as an idempotency key
+        // look it up to ensure that an unrelated unique violation is not suppressed
+        const existingActivity = await this.prisma.studentActivity.findUnique({
+          where: {
+            uniqueStudentActivityPerTypeAndTime: {
+              studentId: student.id,
+              type: activity.type,
+              happenedAt: activity.happenedAt,
+              happenedAtCounter: activity.happenedAtCounter,
+            },
           },
-        },
-        include: { solution: true },
-      });
+          include: { solution: true },
+        });
 
-      if (!existingActivity) {
-        throw error;
+        if (existingActivity) {
+          // A replay may contain different solution data, but comparing or replacing it would complicate replay
+          // handling and could trigger analysis more than once
+          return existingActivity;
+        }
+
+        // connectOrCreate can race when another request creates the same solution
+        // once that request commits, one retry can connect to the solution instead
+        if (attempt === activityCreateAttempts) {
+          throw error;
+        }
       }
+    }
 
-      return existingActivity;
+    if (!result) {
+      throw new Error("Student activity creation did not return a result");
     }
 
     // do not wait for the promise to resolve

--- a/backend/src/api/student-activity/student-activity.service.ts
+++ b/backend/src/api/student-activity/student-activity.service.ts
@@ -7,7 +7,7 @@ import { SolutionAnalysisService } from "../solutions/solution-analysis.service"
 const latestAstVersion = AstVersion.v1;
 const activityCreateAttempts = 2;
 
-type StudentActivityWithSolution = Prisma.StudentActivityGetPayload<{
+export type StudentActivityWithSolution = Prisma.StudentActivityGetPayload<{
   include: { solution: true };
 }>;
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make student activity creation idempotent to stop crashes from replayed client events (CRT-379). Simplified retry flow: on unique conflicts, return the existing activity or retry once for concurrent writes.

- **Bug Fixes**
  - Treat (`studentId`, `type`, `happenedAt`, `happenedAtCounter`) as an idempotency key; on `P2002`, find via `uniqueStudentActivityPerTypeAndTime`, return existing, and skip analysis.
  - Add `happenedAtCounter` to `StudentActivityInput` and the unique lookup.
  - Replace transactional batch creation with per-item `create()` so idempotency and a single retry run per activity; rethrow persistent conflicts; add tests for replays and concurrent solution races.

<sup>Written for commit 1cb98bc57ec4c909e8840d0b2bb0f1fdffe8d0df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

