### PR TITLE
[CRT-388] Prevent pasting a stack containing a block at its usage limit

### DIFF
--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -240,16 +240,13 @@ test.describe("/solve", () => {
     const blockCountBeforeRejectedPaste =
       await page.blocksOfCurrentTarget.count();
 
-    const rejectionLogged = pwPage.waitForEvent("console", (message) =>
-      message.text().includes("Block limit reached for motion_movesteps"),
-    );
-
     await page.pasteStack();
-    await rejectionLogged;
 
     await expect(page.blocksOfCurrentTarget).toHaveCount(
       blockCountBeforeRejectedPaste,
     );
+
+    await expect(page.enabledBlockConfigButtons.moveSteps).toHaveText("0");
   });
 
   test("removing student-added blocks increases the limit", async ({

--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -206,6 +206,36 @@ test.describe("/solve", () => {
     );
   });
 
+  test("cannot paste a stack containing a block at its usage limit", async ({
+    page: pwPage,
+  }) => {
+    const { page, task } = await TestTaskPage.load(pwPage);
+    const moveStepsAllowedCount =
+      task.crtConfig.allowedBlocks["motion_movesteps"]!;
+
+    const stack = await page.createNewStack("motion_goto");
+    await page.appendNewBlockTo("motion_movesteps", stack);
+
+    for (let i = 1; i < moveStepsAllowedCount; i++) {
+      await page.appendNewBlockTo(
+        "motion_movesteps",
+        page.taskBlocks.catActor.editableBlock,
+      );
+    }
+
+    await expect(page.enabledBlockConfigButtons.moveSteps).toHaveText("0");
+
+    const blockCountBeforePaste = await page.blocksOfCurrentTarget.count();
+
+    await stack.click({ force: true, position: { x: 10, y: 10 } });
+    await pwPage.keyboard.press("Control+C");
+    await pwPage.keyboard.press("Control+V");
+
+    // give Scratch's create-event listener time to reject and undo the paste
+    await pwPage.waitForTimeout(500);
+    await expect(page.blocksOfCurrentTarget).toHaveCount(blockCountBeforePaste);
+  });
+
   test("removing student-added blocks increases the limit", async ({
     page: pwPage,
   }) => {

--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -216,24 +216,40 @@ test.describe("/solve", () => {
     const stack = await page.createNewStack("motion_goto");
     await page.appendNewBlockTo("motion_movesteps", stack);
 
-    for (let i = 1; i < moveStepsAllowedCount; i++) {
+    for (let i = 1; i < moveStepsAllowedCount - 1; i++) {
       await page.appendNewBlockTo(
         "motion_movesteps",
         page.taskBlocks.catActor.editableBlock,
       );
     }
 
+    await expect(page.enabledBlockConfigButtons.moveSteps).toHaveText("1");
+
+    const blockCountBeforeAllowedPaste =
+      await page.blocksOfCurrentTarget.count();
+
+    await page.copyStack(stack);
+    await page.pasteStack();
+
+    await expect(page.blocksOfCurrentTarget).toHaveCount(
+      blockCountBeforeAllowedPaste + 2,
+    );
+
     await expect(page.enabledBlockConfigButtons.moveSteps).toHaveText("0");
 
-    const blockCountBeforePaste = await page.blocksOfCurrentTarget.count();
+    const blockCountBeforeRejectedPaste =
+      await page.blocksOfCurrentTarget.count();
 
-    await stack.click({ force: true, position: { x: 10, y: 10 } });
-    await pwPage.keyboard.press("Control+C");
-    await pwPage.keyboard.press("Control+V");
+    const rejectionLogged = pwPage.waitForEvent("console", (message) =>
+      message.text().includes("Block limit reached for motion_movesteps"),
+    );
 
-    // give Scratch's create-event listener time to reject and undo the paste
-    await pwPage.waitForTimeout(500);
-    await expect(page.blocksOfCurrentTarget).toHaveCount(blockCountBeforePaste);
+    await page.pasteStack();
+    await rejectionLogged;
+
+    await expect(page.blocksOfCurrentTarget).toHaveCount(
+      blockCountBeforeRejectedPaste,
+    );
   });
 
   test("removing student-added blocks increases the limit", async ({

--- a/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
+++ b/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 import { randomBytes } from "crypto";
-import { Locator, Page } from "playwright/test";
+import { expect, Locator, Page } from "playwright/test";
 import {
   getAllTargetBlocksSelector,
   getBlockCanvasSelector,
@@ -201,6 +201,11 @@ export class ScratchEditorPage {
   }
 
   async createNewStack(opcode: string) {
+    const stackDropMargin = 150;
+
+    const getStackDropCoordinate = (canvasSize: number) =>
+      canvasSize - Math.min(stackDropMargin, canvasSize / 2);
+
     const topBlocks = this.page.locator(isVisualTopOfStack);
     const existingTopBlockIds = await topBlocks.evaluateAll((blocks) =>
       blocks.map((block) => block.getAttribute("data-id")),
@@ -214,8 +219,10 @@ export class ScratchEditorPage {
     await this.getBlockInToolbox(opcode).dragTo(this.blockCanvas, {
       force: true,
       targetPosition: {
-        x: canvasBounds.width - 150,
-        y: canvasBounds.height - 150,
+        // keep the new stack away from the toolbox
+        // on a workspace thinner than twice the margin, fallback to its midpoint
+        x: getStackDropCoordinate(canvasBounds.width),
+        y: getStackDropCoordinate(canvasBounds.height),
       },
     });
 
@@ -235,12 +242,22 @@ export class ScratchEditorPage {
   }
 
   async copyStack(stack: Locator) {
-    await stack.locator(".blocklyPath").first().click({ force: true });
-    await this.page.keyboard.press("Control+C");
+    const blockPath = stack.locator(".blocklyPath").first();
+
+    // blockly selects a block on mouse down. it is dispatched directly because an SVG
+    // stack can be outside of the mobile viewport even though it is present in the workspace
+    await blockPath.dispatchEvent("mousedown", { button: 0, buttons: 1 });
+    await this.page.locator("body").dispatchEvent("mouseup", {
+      button: 0,
+      buttons: 0,
+    });
+
+    await expect(stack).toHaveClass(/blocklySelected/);
+    await this.page.keyboard.press("ControlOrMeta+C");
   }
 
   async pasteStack() {
-    await this.page.keyboard.press("Control+V");
+    await this.page.keyboard.press("ControlOrMeta+V");
   }
 
   async appendNewBlockTo(opcode: string, block: Locator) {

--- a/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
+++ b/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
@@ -205,10 +205,18 @@ export class ScratchEditorPage {
     const existingTopBlockIds = await topBlocks.evaluateAll((blocks) =>
       blocks.map((block) => block.getAttribute("data-id")),
     );
+    const canvasBounds = await this.blockCanvas.boundingBox();
+
+    if (!canvasBounds) {
+      throw new Error("Failed to find the block canvas");
+    }
 
     await this.getBlockInToolbox(opcode).dragTo(this.blockCanvas, {
       force: true,
-      targetPosition: { x: 400, y: 200 },
+      targetPosition: {
+        x: canvasBounds.width - 150,
+        y: canvasBounds.height - 150,
+      },
     });
 
     const newTopBlockId = await topBlocks.evaluateAll(
@@ -227,7 +235,7 @@ export class ScratchEditorPage {
   }
 
   async copyStack(stack: Locator) {
-    await stack.click({ force: true, position: { x: 10, y: 10 } });
+    await stack.locator(".blocklyPath").first().click({ force: true });
     await this.page.keyboard.press("Control+C");
   }
 

--- a/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
+++ b/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
@@ -226,6 +226,15 @@ export class ScratchEditorPage {
     return this.page.locator(getBlockSelector(newTopBlockId));
   }
 
+  async copyStack(stack: Locator) {
+    await stack.click({ force: true, position: { x: 10, y: 10 } });
+    await this.page.keyboard.press("Control+C");
+  }
+
+  async pasteStack() {
+    await this.page.keyboard.press("Control+V");
+  }
+
   async appendNewBlockTo(opcode: string, block: Locator) {
     await this.scrollBlockIntoView(block);
 

--- a/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
+++ b/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
@@ -5,6 +5,7 @@ import {
   getAllTargetBlocksSelector,
   getBlockCanvasSelector,
   getBlockConfigButtonSelector,
+  getBlockSelector,
   getBlockConfigFormSelector,
   getFlyoutSelector,
 } from "../locators";
@@ -197,6 +198,32 @@ export class ScratchEditorPage {
         y: 50,
       },
     });
+  }
+
+  async createNewStack(opcode: string) {
+    const topBlocks = this.page.locator(isVisualTopOfStack);
+    const existingTopBlockIds = await topBlocks.evaluateAll((blocks) =>
+      blocks.map((block) => block.getAttribute("data-id")),
+    );
+
+    await this.getBlockInToolbox(opcode).dragTo(this.blockCanvas, {
+      force: true,
+      targetPosition: { x: 400, y: 200 },
+    });
+
+    const newTopBlockId = await topBlocks.evaluateAll(
+      (blocks, existingIds) =>
+        blocks
+          .map((block) => block.getAttribute("data-id"))
+          .find((id) => id !== null && !existingIds.includes(id)),
+      existingTopBlockIds,
+    );
+
+    if (!newTopBlockId) {
+      throw new Error(`Failed to create a new ${opcode} stack`);
+    }
+
+    return this.page.locator(getBlockSelector(newTopBlockId));
   }
 
   async appendNewBlockTo(opcode: string, block: Locator) {

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -190,6 +190,24 @@ const getAllowedBlockCount = (
   return config.allowedBlocks[blockType] || 0;
 };
 
+const countBlocksByType = (
+  blocks: ScratchBlocksExtended.Block[],
+): Record<string, number> => {
+  const counts: Record<string, number> = {};
+
+  for (const block of blocks) {
+    counts[block.type] = (counts[block.type] ?? 0) + 1;
+  }
+
+  return counts;
+};
+
+const countStackBlocksInRuntimeByType = (
+  vm: VMExtended,
+  blocks: ScratchBlocksExtended.Block[],
+): Record<string, number> =>
+  countBlocksByType(blocks.filter((block) => findBlockInRuntime(vm, block.id)));
+
 /**
  * Check if adding blocks from the flyout would exceed the limits set in the config.
  * It checks the number of blocks currently used in the workspace and the number of blocks being added, and compares it to the limits set in the config.
@@ -211,33 +229,39 @@ export const wouldExceedLimits = (
   // using the workspace count would always include the new block, this causes the flyout drags to be blocked
   const usedBlocks = countUsedBlocks(vm);
 
-  const allowed = getAllowedBlockCount(config, block.type);
-  let count = usedBlocks[block.type];
+  const blocksInStack = block.getDescendants(false, true);
+  const pastedBlockCounts = countBlocksByType(blocksInStack);
 
-  if (excludeBlockId && findBlockInRuntime(vm, excludeBlockId)) {
-    count -= 1;
-  }
+  // record temporary blocks added during flyout-to-sprite drag so we can subtract
+  // them from usedBlocks and avoid counting the dragged stack twice
+  const stackBlockCountsInRuntime = excludeBlockId
+    ? countStackBlocksInRuntimeByType(vm, blocksInStack)
+    : {};
 
-  const isPreventedEntirely = allowed === 0;
+  for (const [blockType, pastedCount] of Object.entries(pastedBlockCounts)) {
+    const allowed = getAllowedBlockCount(config, blockType);
 
-  if (isPreventedEntirely) {
-    console.debug(
-      `${logModule} Block ${block.type} is not allowed, blocking addition of blocks`,
-    );
-    return true;
-  }
+    const currentlyUsed =
+      (usedBlocks[blockType] ?? 0) -
+      (stackBlockCountsInRuntime[blockType] ?? 0);
 
-  // if allowed is a number, the block has a limit, it doesn't for every other type
-  const hasLimit = typeof allowed === "number" && allowed >= 0;
+    const countAfterPaste = currentlyUsed + pastedCount;
 
-  // the create event fires on the main workspace before vm.blockListener updates target.blocks._blocks, so
-  // countUsedBlocks does not yet include the new block.
-  // we use >= to prevent going over the limit by one.
-  if (hasLimit && count >= allowed) {
-    console.debug(
-      `${logModule} Block limit reached for ${block.type}: ${count} >= ${allowed}`,
-    );
-    return true;
+    if (allowed === 0) {
+      console.debug(
+        `${logModule} Block ${blockType} is not allowed, blocking addition of stack`,
+      );
+      return true;
+    }
+
+    // if allowed is a number, the block has a limit, it doesn't for every other type
+    const hasLimit = typeof allowed === "number" && allowed >= 0;
+    if (hasLimit && countAfterPaste > allowed) {
+      console.debug(
+        `${logModule} Block limit reached for ${blockType}: ${currentlyUsed} + ${pastedCount} > ${allowed}`,
+      );
+      return true;
+    }
   }
 
   return false;

--- a/apps/scratch/src/blocks/helpers.ts
+++ b/apps/scratch/src/blocks/helpers.ts
@@ -62,12 +62,10 @@ const shouldPreventBlockCreation = (
 
   const eventBlockId = event.blockId ?? "";
 
-  const excludeBlockId =
-    isBlockDraggedToSprite && blockCreatedInCurrentGesture === eventBlockId
-      ? event.blockId
-      : undefined;
+  const excludeStackBlocksInRuntime =
+    isBlockDraggedToSprite && blockCreatedInCurrentGesture === eventBlockId;
 
-  if (!wouldExceedLimits(vm, block, excludeBlockId)) {
+  if (!wouldExceedLimits(vm, block, excludeStackBlocksInRuntime)) {
     if (isBlockCreated) {
       blockCreatedInCurrentGesture = eventBlockId;
     } else if (isBlockDraggedToSprite) {
@@ -215,8 +213,7 @@ const countStackBlocksInRuntimeByType = (
 export const wouldExceedLimits = (
   vm: VMExtended,
   block: ScratchBlocksExtended.Block,
-  // id of a block that is already included in the VM counts but should not be counted against the limit
-  excludeBlockId?: string,
+  excludeStackBlocksInRuntime = false,
 ): boolean => {
   const config = vm.crtConfig;
   if (!config) {
@@ -234,7 +231,7 @@ export const wouldExceedLimits = (
 
   // record temporary blocks added during flyout-to-sprite drag so we can subtract
   // them from usedBlocks and avoid counting the dragged stack twice
-  const stackBlockCountsInRuntime = excludeBlockId
+  const stackBlockCountsInRuntime = excludeStackBlocksInRuntime
     ? countStackBlocksInRuntimeByType(vm, blocksInStack)
     : {};
 

--- a/apps/scratch/types/scratch-blocks.d.ts
+++ b/apps/scratch/types/scratch-blocks.d.ts
@@ -33,6 +33,7 @@ declare namespace ScratchBlocksExtended {
     getNextBlock: () => Block | null;
     getParent: () => Block | null;
     getChildren: () => Block[];
+    getDescendants: (ordered: boolean, ignoreShadows?: boolean) => Block[];
     id: string;
     type: string;
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents pasting a stack when any block inside would exceed its per‑type limit, including nested stacks, closing the CRT-388 copy/paste bypass.

- **Bug Fixes**
  - Count all descendant blocks in the pasted stack and block when any type is disallowed or would exceed its limit; handles stacked stacks.
  - Avoid double counting during flyout-to-sprite drags by subtracting temporary runtime stack blocks; rename flag to `excludeStackBlocksInRuntime`.
  - Add and stabilize a regression test that pastes up to the limit and rejects the next paste (UI indicator stays correct); add `createNewStack`, `copyStack`, `pasteStack` helpers and declare `getDescendants`.

<sup>Written for commit f96d1035b447fd58c283193190503eb661718e5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

