### PR TITLE
[CRT-440] Use transactions in backend to prevent toctou errors

### DIFF
--- a/backend/src/api/authentication/authentication.service.ts
+++ b/backend/src/api/authentication/authentication.service.ts
@@ -4,12 +4,12 @@ import {
   AnonymousStudent,
   AuthenticatedStudent,
   AuthenticationProvider,
-  Prisma,
   Student as PrismaStudent,
   User,
   UserType,
 } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
+import { runSerializableTransaction } from "src/prisma/transactions";
 import { PrismaTransactionClient } from "src/prisma/types";
 import * as jose from "jose";
 import { ConfigService } from "@nestjs/config";
@@ -29,8 +29,6 @@ const slidingTokenLifetime = 1000 * 60 * 60 * 4; // 4 hours
 const lastUsedAccuracy = 1000 * 60 * 10; // 10 minutes
 
 const registrationTokenLifetime = 1000 * 60 * 60 * 24 * 5; // 5 days
-
-const serializableTransactionMaxAttempts = 3;
 
 export type PublicKey = {
   id: number;
@@ -262,34 +260,6 @@ export class AuthenticationService {
     });
   }
 
-  private async runSerializableTransaction<T>(
-    callback: (prisma: PrismaTransactionClient) => Promise<T>,
-  ): Promise<T> {
-    for (
-      let attempt = 1;
-      attempt <= serializableTransactionMaxAttempts;
-      attempt++
-    ) {
-      try {
-        return await this.prisma.$transaction(callback, {
-          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
-        });
-      } catch (error) {
-        // PostgreSQL can report a concurrent unique insert as P2002 even at
-        // serializable isolation. Retrying lets the lookup see the committed row.
-        const shouldRetry =
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          (error.code === "P2002" || error.code === "P2034");
-
-        if (!shouldRetry || attempt === serializableTransactionMaxAttempts) {
-          throw error;
-        }
-      }
-    }
-
-    throw new Error("Serializable transaction exhausted its retry attempts");
-  }
-
   /**
    * Tries to sign in a user with the given JWT token.
    * @param jwt The JWT token to sign in with.
@@ -415,12 +385,12 @@ export class AuthenticationService {
   }
 
   private async findAuthenticatedStudent(
-    prisma: PrismaTransactionClient,
+    txClient: PrismaTransactionClient,
     classId: number,
     rawPseudonym: Buffer,
     rawIdentifier: Buffer,
   ): Promise<AuthenticatedStudent | null> {
-    const byIdentifier = await prisma.authenticatedStudent.findUnique({
+    const byIdentifier = await txClient.authenticatedStudent.findUnique({
       where: {
         studentIdentifierUniquePerClass: {
           classId,
@@ -434,7 +404,7 @@ export class AuthenticationService {
       return byIdentifier;
     }
 
-    const byPseudonym = await prisma.authenticatedStudent.findUnique({
+    const byPseudonym = await txClient.authenticatedStudent.findUnique({
       where: {
         pseudonymUniquePerClass: { classId, pseudonym: rawPseudonym },
         deletedAt: null,
@@ -442,7 +412,7 @@ export class AuthenticationService {
     });
 
     if (byPseudonym && byPseudonym.studentIdentifier === null) {
-      return prisma.authenticatedStudent.update({
+      return txClient.authenticatedStudent.update({
         where: { studentId: byPseudonym.studentId },
         data: { studentIdentifier: rawIdentifier },
       });
@@ -473,7 +443,7 @@ export class AuthenticationService {
     // before signing in, delete all expired tokens
     await this.deleteExpiredTokens();
 
-    const result = await this.runSerializableTransaction(async (tx) => {
+    const result = await runSerializableTransaction(this.prisma, async (tx) => {
       const authenticatedStudent = await this.findAuthenticatedStudent(
         tx,
         classId,

--- a/backend/src/api/authentication/authentication.service.ts
+++ b/backend/src/api/authentication/authentication.service.ts
@@ -10,6 +10,7 @@ import {
   UserType,
 } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
+import { PrismaTransactionClient } from "src/prisma/types";
 import * as jose from "jose";
 import { ConfigService } from "@nestjs/config";
 
@@ -28,6 +29,8 @@ const slidingTokenLifetime = 1000 * 60 * 60 * 4; // 4 hours
 const lastUsedAccuracy = 1000 * 60 * 10; // 10 minutes
 
 const registrationTokenLifetime = 1000 * 60 * 60 * 24 * 5; // 5 days
+
+const serializableTransactionMaxAttempts = 3;
 
 export type PublicKey = {
   id: number;
@@ -259,6 +262,34 @@ export class AuthenticationService {
     });
   }
 
+  private async runSerializableTransaction<T>(
+    callback: (prisma: PrismaTransactionClient) => Promise<T>,
+  ): Promise<T> {
+    for (
+      let attempt = 1;
+      attempt <= serializableTransactionMaxAttempts;
+      attempt++
+    ) {
+      try {
+        return await this.prisma.$transaction(callback, {
+          isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+        });
+      } catch (error) {
+        // PostgreSQL can report a concurrent unique insert as P2002 even at
+        // serializable isolation. Retrying lets the lookup see the committed row.
+        const shouldRetry =
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          (error.code === "P2002" || error.code === "P2034");
+
+        if (!shouldRetry || attempt === serializableTransactionMaxAttempts) {
+          throw error;
+        }
+      }
+    }
+
+    throw new Error("Serializable transaction exhausted its retry attempts");
+  }
+
   /**
    * Tries to sign in a user with the given JWT token.
    * @param jwt The JWT token to sign in with.
@@ -384,11 +415,12 @@ export class AuthenticationService {
   }
 
   private async findAuthenticatedStudent(
+    prisma: PrismaTransactionClient,
     classId: number,
     rawPseudonym: Buffer,
     rawIdentifier: Buffer,
   ): Promise<AuthenticatedStudent | null> {
-    const byIdentifier = await this.prisma.authenticatedStudent.findUnique({
+    const byIdentifier = await prisma.authenticatedStudent.findUnique({
       where: {
         studentIdentifierUniquePerClass: {
           classId,
@@ -402,7 +434,7 @@ export class AuthenticationService {
       return byIdentifier;
     }
 
-    const byPseudonym = await this.prisma.authenticatedStudent.findUnique({
+    const byPseudonym = await prisma.authenticatedStudent.findUnique({
       where: {
         pseudonymUniquePerClass: { classId, pseudonym: rawPseudonym },
         deletedAt: null,
@@ -410,28 +442,10 @@ export class AuthenticationService {
     });
 
     if (byPseudonym && byPseudonym.studentIdentifier === null) {
-      try {
-        return await this.prisma.authenticatedStudent.update({
-          where: { studentId: byPseudonym.studentId },
-          data: { studentIdentifier: rawIdentifier },
-        });
-      } catch (error) {
-        if (
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        ) {
-          return this.prisma.authenticatedStudent.findUnique({
-            where: {
-              studentIdentifierUniquePerClass: {
-                classId,
-                studentIdentifier: rawIdentifier,
-              },
-              deletedAt: null,
-            },
-          });
-        }
-        throw error;
-      }
+      return prisma.authenticatedStudent.update({
+        where: { studentId: byPseudonym.studentId },
+        data: { studentIdentifier: rawIdentifier },
+      });
     }
 
     return byPseudonym;
@@ -456,85 +470,61 @@ export class AuthenticationService {
     const rawPseudonym = Buffer.from(pseudonym, "base64");
     const rawIdentifier = Buffer.from(studentIdentifier, "base64url");
 
-    let authenticatedStudent = await this.findAuthenticatedStudent(
-      classId,
-      rawPseudonym,
-      rawIdentifier,
-    );
-
-    let student: PrismaStudent;
-
-    if (authenticatedStudent === null) {
-      try {
-        student = await this.prisma.student.create({
-          data: {
-            authenticatedStudent: {
-              create: {
-                pseudonym: rawPseudonym,
-                studentIdentifier: rawIdentifier,
-                classId,
-                keyPairId,
-              },
-            },
-          },
-        });
-      } catch (error) {
-        // re-resolve the now-existing student here instead of failing for concurrent join attempts
-        if (
-          error instanceof Prisma.PrismaClientKnownRequestError &&
-          error.code === "P2002"
-        ) {
-          authenticatedStudent = await this.findAuthenticatedStudent(
-            classId,
-            rawPseudonym,
-            rawIdentifier,
-          );
-
-          if (authenticatedStudent === null) {
-            // this should never happen in theory, but if it does, throw
-            throw error;
-          }
-
-          student = await this.prisma.student.findUniqueOrThrow({
-            where: { id: authenticatedStudent.studentId, deletedAt: null },
-          });
-        } else {
-          throw error;
-        }
-      }
-    } else {
-      student = await this.prisma.student.findUniqueOrThrow({
-        where: {
-          id: authenticatedStudent.studentId,
-          deletedAt: null,
-        },
-      });
-    }
-
-    const randomToken = generateToken();
-
     // before signing in, delete all expired tokens
     await this.deleteExpiredTokens();
 
-    const authToken = await this.prisma.authenticationToken.create({
-      data: {
-        token: randomToken,
+    const result = await this.runSerializableTransaction(async (tx) => {
+      const authenticatedStudent = await this.findAuthenticatedStudent(
+        tx,
+        classId,
+        rawPseudonym,
+        rawIdentifier,
+      );
+
+      const student = authenticatedStudent
+        ? await tx.student.findUniqueOrThrow({
+            where: {
+              id: authenticatedStudent.studentId,
+              deletedAt: null,
+            },
+          })
+        : await tx.student.create({
+            data: {
+              authenticatedStudent: {
+                create: {
+                  pseudonym: rawPseudonym,
+                  studentIdentifier: rawIdentifier,
+                  classId,
+                  keyPairId,
+                },
+              },
+            },
+          });
+
+      const authToken = await tx.authenticationToken.create({
+        data: {
+          token: generateToken(),
+          studentId: student.id,
+          lastUsedAt: new Date(),
+        },
+      });
+
+      const resolvedIdentifier =
+        authenticatedStudent?.studentIdentifier ?? rawIdentifier;
+
+      return {
+        token: authToken.token,
         studentId: student.id,
-        lastUsedAt: new Date(),
-      },
+        studentIdentifier:
+          Buffer.from(resolvedIdentifier).toString("base64url"),
+      };
     });
 
-    this.logger.log(`Student sign-in successful (student id: ${student.id})`);
+    this.logger.log(
+      `Student sign-in successful (student id: ${result.studentId})`,
+    );
 
-    // prefer the authoritative stored identifier, falling back to the one just provided
-    const resolvedIdentifier =
-      authenticatedStudent?.studentIdentifier ?? rawIdentifier;
-
-    return {
-      token: authToken.token,
-      studentId: student.id,
-      studentIdentifier: Buffer.from(resolvedIdentifier).toString("base64url"),
-    };
+    return result;
   }
 
   /**

--- a/backend/src/prisma/transactions.spec.ts
+++ b/backend/src/prisma/transactions.spec.ts
@@ -1,0 +1,71 @@
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "./prisma.service";
+import { runSerializableTransaction } from "./transactions";
+
+const prismaError = (code: string): Prisma.PrismaClientKnownRequestError =>
+  new Prisma.PrismaClientKnownRequestError("Transaction failed", {
+    code,
+    clientVersion: "test",
+  });
+
+describe("runSerializableTransaction", () => {
+  const callback = jest.fn();
+  const transaction = jest.fn();
+  const prisma = { $transaction: transaction } as unknown as PrismaService;
+
+  beforeEach(() => {
+    callback.mockReset();
+    transaction.mockReset();
+  });
+
+  it("runs the callback in a serializable transaction", async () => {
+    transaction.mockResolvedValue("result");
+
+    await expect(runSerializableTransaction(prisma, callback)).resolves.toBe(
+      "result",
+    );
+    expect(transaction).toHaveBeenCalledWith(callback, {
+      isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+    });
+  });
+
+  it.each(["P2002", "P2034"])("retries %s errors", async (code) => {
+    const error = prismaError(code);
+    transaction.mockRejectedValueOnce(error).mockResolvedValue("result");
+
+    await expect(runSerializableTransaction(prisma, callback)).resolves.toBe(
+      "result",
+    );
+    expect(transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("uses three attempts by default", async () => {
+    const error = prismaError("P2034");
+    transaction.mockRejectedValue(error);
+
+    await expect(runSerializableTransaction(prisma, callback)).rejects.toBe(
+      error,
+    );
+    expect(transaction).toHaveBeenCalledTimes(3);
+  });
+
+  it("honors a custom maximum number of attempts", async () => {
+    const error = prismaError("P2034");
+    transaction.mockRejectedValue(error);
+
+    await expect(runSerializableTransaction(prisma, callback, 2)).rejects.toBe(
+      error,
+    );
+    expect(transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry other errors", async () => {
+    const error = new Error("Transaction failed");
+    transaction.mockRejectedValue(error);
+
+    await expect(runSerializableTransaction(prisma, callback)).rejects.toBe(
+      error,
+    );
+    expect(transaction).toHaveBeenCalledTimes(1);
+  });
+});

--- a/backend/src/prisma/transactions.ts
+++ b/backend/src/prisma/transactions.ts
@@ -2,11 +2,22 @@ import { Prisma } from "@prisma/client";
 import { PrismaService } from "./prisma.service";
 import { PrismaTransactionClient } from "./types";
 
+class TransactionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TransactionError";
+  }
+}
+
 export const runSerializableTransaction = async <T>(
   prisma: PrismaService,
   callback: (txClient: PrismaTransactionClient) => Promise<T>,
   maxAttempts = 3,
 ): Promise<T> => {
+  if (maxAttempts < 1) {
+    throw new TransactionError("maxAttempts must be at least 1");
+  }
+
   for (let attempt = 1; ; attempt++) {
     try {
       return await prisma.$transaction(callback, {

--- a/backend/src/prisma/transactions.ts
+++ b/backend/src/prisma/transactions.ts
@@ -1,0 +1,27 @@
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "./prisma.service";
+import { PrismaTransactionClient } from "./types";
+
+export const runSerializableTransaction = async <T>(
+  prisma: PrismaService,
+  callback: (txClient: PrismaTransactionClient) => Promise<T>,
+  maxAttempts = 3,
+): Promise<T> => {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await prisma.$transaction(callback, {
+        isolationLevel: Prisma.TransactionIsolationLevel.Serializable,
+      });
+    } catch (error) {
+      // PostgreSQL can report a concurrent unique insert as P2002 even at
+      // serializable isolation. Retrying lets the lookup see the committed row.
+      const shouldRetry =
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        (error.code === "P2002" || error.code === "P2034");
+
+      if (!shouldRetry || attempt >= maxAttempts) {
+        throw error;
+      }
+    }
+  }
+};


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use serializable transactions in the auth service to make student sign-in atomic and prevent TOCTOU races. Retries cover unique and serialization conflicts, addressing CRT-440.

- **Bug Fixes**
  - Added `runSerializableTransaction` with serializable isolation, up to 3 retries on `P2002`/`P2034` from `@prisma/client`, and validation that `maxAttempts >= 1`; tests included.
  - Student lookup/create and token issuance now run in one transaction; `findAuthenticatedStudent` accepts `PrismaTransactionClient`.
  - Removed manual conflict handling and inline retries; delete expired tokens before starting the transaction.

<sup>Written for commit 17fa11ca18dcb3f1135bda6f3c23af1acd0a7482. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

