### PR TITLE
[CRT-380] Do not crash on a repeat-until with an empty condition

### DIFF
--- a/backend/src/ast/converters/scratch/__tests__/scratch-ast-converter.service.spec.ts
+++ b/backend/src/ast/converters/scratch/__tests__/scratch-ast-converter.service.spec.ts
@@ -4218,6 +4218,41 @@ describe("Scratch AST converter", () => {
       );
     });
 
+    it("converts a 'control_repeat_until' block with an empty condition (CRT-380)", () => {
+      // A student can drag a `repeat until` block and run/submit it without
+      // plugging anything into the hexagonal condition slot. In sb3 the
+      // CONDITION input is then simply absent, which used to throw
+      // "Reference was undefined" and crash the whole conversion. An empty
+      // condition has no expression to negate, so the loop simply has no
+      // condition, exactly as an empty `if`/`if else` condition does.
+      const ast = convertScratchToGeneralAst(
+        createScratchCodeInput([
+          {
+            opcode: "control_repeat_until",
+            inputs: {},
+            fields: {},
+            shadow: false,
+            topLevel: false,
+          },
+        ]),
+      );
+
+      expect(ast).toEqual(
+        createScratchCodeOutput([
+          {
+            nodeType: AstNodeType.statement,
+            statementType: StatementNodeType.loop,
+            condition: null,
+            body: {
+              nodeType: AstNodeType.statement,
+              statementType: StatementNodeType.sequence,
+              statements: [],
+            },
+          },
+        ]),
+      );
+    });
+
     it("can convert 'control_if' blocks to general AST nodes", () => {
       const ast = convertScratchToGeneralAst(
         createScratchCodeInput(

--- a/backend/src/ast/converters/scratch/scratch-control-block-converter.ts
+++ b/backend/src/ast/converters/scratch/scratch-control-block-converter.ts
@@ -171,16 +171,11 @@ export const convertControlBlockTreeToStatement = (
     .with(
       P.when(isRepeatUntilBlock),
       (block: RepeatUntilBlock & ControlCodeTreeNode) => {
-        // An empty hexagonal condition slot is a valid state a student can
-        // submit; the CONDITION input is then absent. Fall back to null
-        // instead of throwing "Reference was undefined". With no expression to
-        // negate, the loop simply has no condition - the same representation an
-        // empty `if` condition already produces.
         const condition = convertChildWithReferenceId(
           block,
           (block) => block.inputs.CONDITION,
           convertBlockTreeToExpression,
-          null,
+          null, // fallback value if condition input is absent
         );
 
         // a repeat until block is a  negated while loop, *not* a negated do-while loop as the name may suggest

--- a/backend/src/ast/converters/scratch/scratch-control-block-converter.ts
+++ b/backend/src/ast/converters/scratch/scratch-control-block-converter.ts
@@ -170,35 +170,46 @@ export const convertControlBlockTreeToStatement = (
     ])
     .with(
       P.when(isRepeatUntilBlock),
-      (block: RepeatUntilBlock & ControlCodeTreeNode) => [
+      (block: RepeatUntilBlock & ControlCodeTreeNode) => {
+        // An empty hexagonal condition slot is a valid state a student can
+        // submit; the CONDITION input is then absent. Fall back to null
+        // instead of throwing "Reference was undefined". With no expression to
+        // negate, the loop simply has no condition - the same representation an
+        // empty `if` condition already produces.
+        const condition = convertChildWithReferenceId(
+          block,
+          (block) => block.inputs.CONDITION,
+          convertBlockTreeToExpression,
+          null,
+        );
+
         // a repeat until block is a  negated while loop, *not* a negated do-while loop as the name may suggest
-        {
-          nodeType: AstNodeType.statement,
-          statementType: StatementNodeType.loop,
-          condition: {
-            nodeType: AstNodeType.expression,
-            expressionType: ExpressionNodeType.operator,
-            operator: "operator_not",
-            operands: [
-              convertChildWithReferenceId(
-                block,
-                (block) => block.inputs.CONDITION,
-                convertBlockTreeToExpression,
-              ),
-            ],
-          },
-          body: {
+        return [
+          {
             nodeType: AstNodeType.statement,
-            statementType: StatementNodeType.sequence,
-            statements: convertChildWithReferenceId(
-              block,
-              (block) => block.inputs.SUBSTACK,
-              convertBlockTreeToStatement,
-              [],
-            ),
+            statementType: StatementNodeType.loop,
+            condition:
+              condition === null
+                ? null
+                : {
+                    nodeType: AstNodeType.expression,
+                    expressionType: ExpressionNodeType.operator,
+                    operator: "operator_not",
+                    operands: [condition],
+                  },
+            body: {
+              nodeType: AstNodeType.statement,
+              statementType: StatementNodeType.sequence,
+              statements: convertChildWithReferenceId(
+                block,
+                (block) => block.inputs.SUBSTACK,
+                convertBlockTreeToStatement,
+                [],
+              ),
+            },
           },
-        },
-      ],
+        ];
+      },
     )
     .with(P.when(isRepeatBlock), (block: RepeatBlock & ControlCodeTreeNode) => [
       // a repeat until block is a  negated while loop, *not* a negated do-while loop as the name may suggest


### PR DESCRIPTION
## Summary

Fixes the Sentry crash **CRT-BACKEND-3C** (`throw new Error("Reference was undefined")`) that aborts conversion of a whole Scratch submission.

A student can drag a `repeat until` block and run/submit the project without plugging anything into its hexagonal condition slot. In sb3 the `CONDITION` input is then simply absent, and `convertChildWithReferenceId` threw, crashing the conversion of the entire submission.

## Root cause

Every other control block already tolerates an empty slot — `forever`/`if`/`repeat` substacks fall back to `[]`, and `if`/`if-else` conditions fall back to `null`. The `repeat until` **condition** was the one call site that omitted the fallback ([scratch-control-block-converter.ts](backend/src/ast/converters/scratch/scratch-control-block-converter.ts), the `isRepeatUntilBlock` arm).

## Fix

Fall back to `null`, and — since there is then no expression to negate — give the loop no condition at all, matching how an empty `if` condition is already represented (`LoopNode.condition` and `ConditionNode.condition` are both `ExpressionNode | null`). The `operator_not` negation wrapper is kept only when a real condition is present.

Note: the simpler "just pass `null` into the existing `operator_not` operands" does **not** work — `OperatorNode.operands` is `ExpressionNode[]` and rejects `null` — which is why the loop condition itself becomes `null` instead.

## Verification

- New regression test converts a `repeat until` with an empty `inputs` object; it throws against the previous code and passes now (verified red→green locally).
- Full Scratch converter suite: 122 tests, all green. eslint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CRT-380: prevent crashes when a Scratch `control_repeat_until` has no condition. The loop condition is now null, and `operator_not` is added only when a real condition exists.

- **Bug Fixes**
  - Handle missing `CONDITION` in `control_repeat_until` without throwing "Reference was undefined".
  - Set loop condition to null and omit the negation wrapper when null.
  - Add a regression test for an empty `repeat until`.

- **Refactors**
  - Shortened the inline comment around repeat-until condition handling.

<sup>Written for commit 8275682d6ac2c54b26be12abf4cd105620e84709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

