### PR TITLE
[CRT-461] Re-baseline the user form after a successful save

### DIFF
--- a/e2e/tests/users/user-form-page-model.ts
+++ b/e2e/tests/users/user-form-page-model.ts
@@ -17,13 +17,17 @@ export class UserFormPageModel extends FormPageModel {
     return {
       name: this.form.locator('[data-testid="name"]'),
       email: this.form.locator('[data-testid="email"]'),
-      type: this.form.locator('[data-testid="type"]'),
+      type: this.form.locator('select[name="type"]'),
       oidcSub: this.form.locator('[data-testid="oidcSub"]'),
     };
   }
 
+  get typeTrigger() {
+    return this.form.locator('[data-testid="type"]');
+  }
+
   async setUserType(type: string) {
-    await this.selectChakraOption(this.inputs.type, type);
+    await this.selectChakraOption(this.typeTrigger, type);
   }
 
   get submitButton() {

--- a/frontend/src/components/user/UserForm.tsx
+++ b/frontend/src/components/user/UserForm.tsx
@@ -60,7 +60,7 @@ const UserForm = ({
 }: {
   submitMessage: MessageDescriptor;
   initialValues?: PartialNullable<UserFormValues>;
-  onSubmit: (data: UserFormValues) => void | Promise<void>;
+  onSubmit: (data: UserFormValues) => boolean | Promise<boolean>;
 }) => {
   const intl = useIntl();
 
@@ -119,7 +119,12 @@ const UserForm = ({
     <FormContainer
       as="form"
       onSubmit={handleSubmit(async (values) => {
-        await onSubmit(values);
+        const succeeded = await onSubmit(values);
+
+        if (!succeeded) {
+          return;
+        }
+
         // re-baseline the form to the saved values so no field stays marked
         // as edited and the validation state resets after a successful save
         reset(values);
@@ -132,6 +137,7 @@ const UserForm = ({
             label={messages.name}
             {...register("name")}
             data-testid="name"
+            disabled={isSubmitting}
             invalid={!!errors.name}
             errorText={errors.name?.message}
             labelBadge={showEditedBadges && dirtyFields.name && <EditedBadge />}
@@ -148,7 +154,8 @@ const UserForm = ({
               value: userType,
               label: getUserTypeMessage(userType as UserType),
             }))}
-            data-testid="type"
+            testID="type"
+            disabled={isSubmitting}
           >
             <ValidationErrorMessage>
               {errors.type?.message}
@@ -161,6 +168,7 @@ const UserForm = ({
             label={messages.email}
             {...register("email")}
             data-testid="email"
+            disabled={isSubmitting}
             invalid={!!errors.email}
             errorText={errors.email?.message}
             labelBadge={

--- a/frontend/src/components/user/UserForm.tsx
+++ b/frontend/src/components/user/UserForm.tsx
@@ -60,7 +60,7 @@ const UserForm = ({
 }: {
   submitMessage: MessageDescriptor;
   initialValues?: PartialNullable<UserFormValues>;
-  onSubmit: (data: UserFormValues) => void;
+  onSubmit: (data: UserFormValues) => void | Promise<void>;
 }) => {
   const intl = useIntl();
 
@@ -102,6 +102,7 @@ const UserForm = ({
     register,
     handleSubmit,
     control,
+    reset,
     formState: { errors, dirtyFields, isDirty, isSubmitting },
   } = useForm<UserFormValues>({
     resolver,
@@ -117,7 +118,12 @@ const UserForm = ({
   return (
     <FormContainer
       as="form"
-      onSubmit={handleSubmit(onSubmit)}
+      onSubmit={handleSubmit(async (values) => {
+        await onSubmit(values);
+        // re-baseline the form to the saved values so no field stays marked
+        // as edited and the validation state resets after a successful save
+        reset(values);
+      })}
       data-testid="user-form"
     >
       <Grid templateColumns="repeat(12, 1fr)" gap={4}>

--- a/frontend/src/components/user/__tests__/jest/UserForm.PageObject.ts
+++ b/frontend/src/components/user/__tests__/jest/UserForm.PageObject.ts
@@ -1,0 +1,31 @@
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+export class UserFormPageObject {
+  readonly user: ReturnType<typeof userEvent.setup>;
+
+  constructor() {
+    this.user = userEvent.setup();
+  }
+
+  get nameInput(): HTMLInputElement {
+    return screen.getByTestId("name") as HTMLInputElement;
+  }
+
+  get submitButton(): HTMLInputElement {
+    return screen.getByTestId("submit") as HTMLInputElement;
+  }
+
+  queryEditedBadge(): HTMLElement | null {
+    return screen.queryByText("Edited");
+  }
+
+  async clearAndTypeName(value: string): Promise<void> {
+    await this.user.clear(this.nameInput);
+    await this.user.type(this.nameInput, value);
+  }
+
+  async clickSubmit(): Promise<void> {
+    await this.user.click(this.submitButton);
+  }
+}

--- a/frontend/src/components/user/__tests__/jest/UserForm.PageObject.ts
+++ b/frontend/src/components/user/__tests__/jest/UserForm.PageObject.ts
@@ -12,17 +12,34 @@ export class UserFormPageObject {
     return screen.getByTestId("name") as HTMLInputElement;
   }
 
+  get emailInput(): HTMLInputElement {
+    return screen.getByTestId("email") as HTMLInputElement;
+  }
+
+  get typeSelect(): HTMLButtonElement {
+    return screen.getByTestId("type") as HTMLButtonElement;
+  }
+
   get submitButton(): HTMLInputElement {
     return screen.getByTestId("submit") as HTMLInputElement;
   }
 
   queryEditedBadge(): HTMLElement | null {
-    return screen.queryByText("Edited");
+    return screen.queryAllByText("Edited")[0] ?? null;
+  }
+
+  queryEmailValidationError(): HTMLElement | null {
+    return screen.queryByText(/must be a valid email/i);
   }
 
   async clearAndTypeName(value: string): Promise<void> {
     await this.user.clear(this.nameInput);
     await this.user.type(this.nameInput, value);
+  }
+
+  async clearAndTypeEmail(value: string): Promise<void> {
+    await this.user.clear(this.emailInput);
+    await this.user.type(this.emailInput, value);
   }
 
   async clickSubmit(): Promise<void> {

--- a/frontend/src/components/user/__tests__/jest/UserForm.PageObject.ts
+++ b/frontend/src/components/user/__tests__/jest/UserForm.PageObject.ts
@@ -20,6 +20,10 @@ export class UserFormPageObject {
     return screen.getByTestId("type") as HTMLButtonElement;
   }
 
+  get typeInput(): HTMLSelectElement {
+    return document.querySelector<HTMLSelectElement>('select[name="type"]')!;
+  }
+
   get submitButton(): HTMLInputElement {
     return screen.getByTestId("submit") as HTMLInputElement;
   }

--- a/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
+++ b/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom";
+import { waitFor } from "@testing-library/react";
+import { UserType } from "@/api/collimator/generated/models";
+import UserForm from "@/components/user/UserForm";
+import { renderWithProviders } from "@/__tests__/helpers/render-with-providers";
+import { UserFormPageObject } from "./UserForm.PageObject";
+
+const submitMessage = { id: "submit", defaultMessage: "Save" };
+
+const initialValues = {
+  name: "Existing Name",
+  email: "existing@example.com",
+  type: UserType.TEACHER,
+};
+
+describe("UserForm UI Interactions", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows the edited badge for a modified field", async () => {
+    renderWithProviders(
+      <UserForm
+        submitMessage={submitMessage}
+        initialValues={initialValues}
+        onSubmit={jest.fn()}
+      />,
+    );
+
+    const form = new UserFormPageObject();
+    expect(form.queryEditedBadge()).toBeNull();
+
+    await form.clearAndTypeName("Updated Name");
+
+    await waitFor(() => expect(form.queryEditedBadge()).not.toBeNull());
+  });
+
+  it("clears the edited badge after a successful save (CRT-461)", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    renderWithProviders(
+      <UserForm
+        submitMessage={submitMessage}
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const form = new UserFormPageObject();
+
+    await form.clearAndTypeName("Updated Name");
+    await waitFor(() => expect(form.queryEditedBadge()).not.toBeNull());
+    await waitFor(() => expect(form.submitButton.disabled).toBe(false));
+
+    await form.clickSubmit();
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+
+    // after saving, the form is re-baselined: the field is no longer edited
+    await waitFor(() => expect(form.queryEditedBadge()).toBeNull());
+    await waitFor(() => expect(form.submitButton.disabled).toBe(true));
+  });
+});

--- a/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
+++ b/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
@@ -23,7 +23,7 @@ describe("UserForm UI Interactions", () => {
       <UserForm
         submitMessage={submitMessage}
         initialValues={initialValues}
-        onSubmit={jest.fn()}
+        onSubmit={jest.fn().mockResolvedValue(true)}
       />,
     );
 
@@ -36,7 +36,7 @@ describe("UserForm UI Interactions", () => {
   });
 
   it("clears the edited badge after a successful save (CRT-461)", async () => {
-    const onSubmit = jest.fn().mockResolvedValue(undefined);
+    const onSubmit = jest.fn().mockResolvedValue(true);
     renderWithProviders(
       <UserForm
         submitMessage={submitMessage}
@@ -47,6 +47,14 @@ describe("UserForm UI Interactions", () => {
 
     const form = new UserFormPageObject();
 
+    await form.clearAndTypeEmail("invalid-email");
+    await form.clickSubmit();
+    await waitFor(() =>
+      expect(form.queryEmailValidationError()).not.toBeNull(),
+    );
+    expect(onSubmit).not.toHaveBeenCalled();
+
+    await form.clearAndTypeEmail("updated@example.com");
     await form.clearAndTypeName("Updated Name");
     await waitFor(() => expect(form.queryEditedBadge()).not.toBeNull());
     await waitFor(() => expect(form.submitButton.disabled).toBe(false));
@@ -56,6 +64,53 @@ describe("UserForm UI Interactions", () => {
 
     // after saving, the form is re-baselined: the field is no longer edited
     await waitFor(() => expect(form.queryEditedBadge()).toBeNull());
+    expect(form.queryEmailValidationError()).toBeNull();
     await waitFor(() => expect(form.submitButton.disabled).toBe(true));
+  });
+
+  it("preserves unsaved state after a failed save", async () => {
+    const onSubmit = jest.fn().mockResolvedValue(false);
+    renderWithProviders(
+      <UserForm
+        submitMessage={submitMessage}
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const form = new UserFormPageObject();
+    await form.clearAndTypeName("Updated Name");
+    await form.clickSubmit();
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalled());
+    await waitFor(() => expect(form.submitButton.disabled).toBe(false));
+    expect(form.queryEditedBadge()).not.toBeNull();
+  });
+
+  it("locks editable controls while saving", async () => {
+    let resolveSubmit: (succeeded: boolean) => void = () => undefined;
+    const onSubmit = jest.fn().mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveSubmit = resolve;
+      }),
+    );
+    renderWithProviders(
+      <UserForm
+        submitMessage={submitMessage}
+        initialValues={initialValues}
+        onSubmit={onSubmit}
+      />,
+    );
+
+    const form = new UserFormPageObject();
+    await form.clearAndTypeName("Updated Name");
+    await form.clickSubmit();
+
+    await waitFor(() => expect(form.nameInput).toBeDisabled());
+    expect(form.emailInput).toBeDisabled();
+    expect(form.typeSelect).toBeDisabled();
+
+    resolveSubmit(true);
+    await waitFor(() => expect(form.queryEditedBadge()).toBeNull());
   });
 });

--- a/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
+++ b/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom";
 import { waitFor } from "@testing-library/react";
-import { UserFormPageObject } from "./UserForm.PageObject";
 import { UserType } from "@/api/collimator/generated/models";
 import UserForm from "@/components/user/UserForm";
 import { renderWithProviders } from "@/__tests__/helpers/render-with-providers";
+import { UserFormPageObject } from "./UserForm.PageObject";
 
 const submitMessage = { id: "submit", defaultMessage: "Save" };
 

--- a/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
+++ b/frontend/src/components/user/__tests__/jest/UserForm.ui.spec.tsx
@@ -1,9 +1,9 @@
 import "@testing-library/jest-dom";
 import { waitFor } from "@testing-library/react";
+import { UserFormPageObject } from "./UserForm.PageObject";
 import { UserType } from "@/api/collimator/generated/models";
 import UserForm from "@/components/user/UserForm";
 import { renderWithProviders } from "@/__tests__/helpers/render-with-providers";
-import { UserFormPageObject } from "./UserForm.PageObject";
 
 const submitMessage = { id: "submit", defaultMessage: "Save" };
 
@@ -28,6 +28,8 @@ describe("UserForm UI Interactions", () => {
     );
 
     const form = new UserFormPageObject();
+
+    expect(form.typeInput).toHaveValue(UserType.TEACHER);
     expect(form.queryEditedBadge()).toBeNull();
 
     await form.clearAndTypeName("Updated Name");

--- a/frontend/src/pages/user/[userId]/detail.tsx
+++ b/frontend/src/pages/user/[userId]/detail.tsx
@@ -51,7 +51,7 @@ const UserDetail = () => {
   const onSubmit = useCallback(
     async (formValues: UserFormValues) => {
       if (!user) {
-        return;
+        return false;
       }
 
       try {
@@ -66,12 +66,16 @@ const UserDetail = () => {
           id: `user-update-success-${user.id}`,
           title: intl.formatMessage(messages.successMessage),
         });
+
+        return true;
       } catch (e) {
         console.error("Failed to update user:", e);
         toaster.error({
           id: `user-update-error-${user.id}`,
           title: intl.formatMessage(messages.errorMessage),
         });
+
+        return false;
       }
     },
     [user, updateUser, intl],

--- a/frontend/src/pages/user/create.tsx
+++ b/frontend/src/pages/user/create.tsx
@@ -46,6 +46,8 @@ const CreateUser = () => {
         intl.formatMessage(messages.createUserError),
       );
       router.back();
+
+      return true;
     },
     [createUser, router, intl],
   );


### PR DESCRIPTION
## Summary

On the edit-user form, after editing a field and saving, the field stays marked **"Edited"** and the validation state is never refreshed ([jam.dev repro](https://jam.dev/c/758bff88-c851-447a-ba38-2c25c5565838)).

## Root cause

[UserForm.tsx](frontend/src/components/user/UserForm.tsx) wired `handleSubmit` straight to the parent's `onSubmit` and never called `reset`, so react-hook-form kept diffing current values against the original `defaultValues`. After a save the values still differed from that stale baseline, so `dirtyFields`/`isDirty` stayed set — keeping the `EditedBadge` on and the yup/error state stale.

`UserForm` was the **outlier**: `ClassForm`, `SessionForm` and `TaskForm` all already `reset(values)` after the mutation resolves.

## Fix

Adopt the same convention — `await onSubmit(values); reset(values);`. `reset(values)` re-baselines the form, clearing `dirtyFields` **and** `errors` in one call, which addresses both halves of the ticket (stuck badge + stale yup state). No `trigger()` is needed. Also widened the `onSubmit` prop type to allow the `async` handler the page already passes.

## Verification

New jest UI test (mirrors `TaskForm.ui.spec.tsx`): edits a field, submits, and asserts the "Edited" badge is gone and the save button disabled again. It fails against the previous code and passes now (verified red→green locally). eslint clean (the 3 remaining warnings are pre-existing, in unrelated `*.stories.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-baselines the user edit form after a successful save so the "Edited" badge clears and validation refreshes, and preserves unsaved state on failed saves. Addresses CRT-461.

- **Bug Fixes**
  - `onSubmit` now returns a success flag; the form awaits it and calls `reset(values)` only on success.
  - Disabled name, email, and type controls while submitting.
  - Updated `user/[userId]/detail` to return true/false and `user/create` to return true.
  - Added UI tests and a page object; fixed the e2e user type selector to `select[name="type"]`; minor linter fixes.

<sup>Written for commit 0d1f2e4b2d0f5c083286807b3e7c305737220ba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

