### PR TITLE
[CRT-462] Record the Scratch stop button as a student activity

### DIFF
--- a/apps/scratch/src/__tests__/Show.spec.tsx
+++ b/apps/scratch/src/__tests__/Show.spec.tsx
@@ -57,6 +57,24 @@ test.describe("/show", () => {
     expect(page.unFullscreenButton).toHaveCount(0);
   });
 
+  test("does not record student activities from stage controls", async ({
+    page: pwPage,
+  }) => {
+    const page = await SolveTaskPage.load(pwPage);
+
+    await page.pressGreenFlag();
+    await page.pressStopButton();
+
+    const studentActivityMessages = await pwPage.evaluate(() =>
+      window.postedMessages.filter(
+        ({ message }) =>
+          (message as { method?: string }).method === "postStudentAppActivity",
+      ),
+    );
+
+    expect(studentActivityMessages).toHaveLength(0);
+  });
+
   test("can get height via window.postMessage", async ({ page }) => {
     await page.evaluate(() => {
       const event = new window.MockMessageEvent(window.parent, {

--- a/apps/scratch/src/__tests__/Solve.spec.tsx
+++ b/apps/scratch/src/__tests__/Solve.spec.tsx
@@ -481,6 +481,31 @@ test.describe("/solve", () => {
     });
   });
 
+  test("records a stop-all student activity when the stop button is pressed", async ({
+    page: pwPage,
+  }) => {
+    const { page } = await AssertionTaskPage.load(pwPage);
+
+    // run the project, then stop the ongoing execution
+    await page.pressGreenFlag();
+    await page.pressStopButton();
+
+    // the stop is reported as a student app activity, carrying only the action
+    await pwPage.waitForFunction(() =>
+      window.postedMessages.some((m) => {
+        const message = m.message as {
+          method?: string;
+          params?: { action?: string };
+        };
+
+        return (
+          message.method === "postStudentAppActivity" &&
+          message.params?.action === "stopAll"
+        );
+      }),
+    );
+  });
+
   test("reports the correct numbers of assertions when passing", async ({
     page: pwPage,
   }) => {

--- a/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
+++ b/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
@@ -114,12 +114,7 @@ export class ScratchEditorPage {
   }
 
   async pressStopButton() {
-    // the stage controls render the green flag first and the stop-all button
-    // last (mirrors pressGreenFlag, which clicks the first control)
-    return this.page
-      .getByTestId("stage-controls")
-      .locator("img:last-child")
-      .click();
+    return this.page.getByTestId("stage-controls").getByTitle("Stop").click();
   }
 
   async removeAllNonFrozenBlocks() {

--- a/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
+++ b/apps/scratch/src/__tests__/page-objects/scratch-editor.ts
@@ -113,6 +113,15 @@ export class ScratchEditorPage {
       .click();
   }
 
+  async pressStopButton() {
+    // the stage controls render the green flag first and the stop-all button
+    // last (mirrors pressGreenFlag, which clicks the first control)
+    return this.page
+      .getByTestId("stage-controls")
+      .locator("img:last-child")
+      .click();
+  }
+
   async removeAllNonFrozenBlocks() {
     while ((await this.blocksOfCurrentTargetNonFrozen.count()) > 0) {
       await this.blocksOfCurrentTargetNonFrozen.first().dragTo(this.toolbox, {

--- a/apps/scratch/src/components/customized-scratch-components/gui/Gui.tsx
+++ b/apps/scratch/src/components/customized-scratch-components/gui/Gui.tsx
@@ -98,6 +98,7 @@ const GUIComponent = (props: {
   blocksId?: string;
   cannotInteractWithBlocks?: boolean;
   canEditTask?: boolean;
+  isStudentSolving?: boolean;
   isStandaloneCodeEnabled?: boolean;
   isCodeTabEnabled?: boolean;
   isStageEnabled?: boolean;
@@ -139,6 +140,7 @@ const GUIComponent = (props: {
     cardsVisible,
     cannotInteractWithBlocks,
     canEditTask,
+    isStudentSolving,
     isStandaloneCodeEnabled,
     isCodeTabEnabled,
     isStageEnabled,
@@ -245,6 +247,7 @@ const GUIComponent = (props: {
               stageSize={STAGE_SIZE_MODES.large}
               vm={vm}
               canEditTask={canEditTask}
+              isStudentSolving={isStudentSolving}
             />
           ) : (
             <Box
@@ -457,6 +460,7 @@ const GUIComponent = (props: {
                         stageSize={stageSize}
                         vm={vm}
                         canEditTask={canEditTask}
+                        isStudentSolving={isStudentSolving}
                         isStageInteractive={
                           canEditTask || crtConfig.enableStageInteractions
                         }

--- a/apps/scratch/src/components/customized-scratch-components/stage-wrapper/StageWrapper.tsx
+++ b/apps/scratch/src/components/customized-scratch-components/stage-wrapper/StageWrapper.tsx
@@ -68,6 +68,7 @@ interface Props {
 
   isStageInteractive?: boolean;
   canEditTask?: boolean;
+  isStudentSolving?: boolean;
 }
 
 const StageWrapper = function (props: Props) {
@@ -81,6 +82,7 @@ const StageWrapper = function (props: Props) {
     stageSize,
     vm,
     canEditTask,
+    isStudentSolving,
   } = props;
 
   const dispatch = useDispatch();
@@ -110,7 +112,7 @@ const StageWrapper = function (props: Props) {
             style={{ width: getStageDimensions(null, true).width }}
           >
             <div className="d-contents" data-testid="stage-controls">
-              <Controls vm={vm} canEditTask={canEditTask} />
+              <Controls vm={vm} isStudentSolving={isStudentSolving} />
             </div>
             <div className={headerStyles.unselectWrapper}>
               <Button
@@ -136,7 +138,7 @@ const StageWrapper = function (props: Props) {
         <Box className={headerStyles.stageHeaderWrapper}>
           <Box className={headerStyles.stageMenuWrapper}>
             <div className="d-contents" data-testid="stage-controls">
-              <Controls vm={vm} canEditTask={canEditTask} />
+              <Controls vm={vm} isStudentSolving={isStudentSolving} />
             </div>
             <div>
               <div className={crtStyles.buttons}>

--- a/apps/scratch/src/containers/customized-scratch-containers/Controls.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Controls.tsx
@@ -14,7 +14,7 @@ interface Props {
   projectRunning: boolean;
   turbo: boolean;
   vm: VM;
-  canEditTask?: boolean;
+  isStudentSolving?: boolean;
 }
 
 const Controls = ({
@@ -22,7 +22,7 @@ const Controls = ({
   isStarted,
   projectRunning,
   turbo,
-  canEditTask,
+  isStudentSolving,
   ...props
 }: Props) => {
   const { sendRequest } = useContext(CrtContext);
@@ -37,7 +37,7 @@ const Controls = ({
           vm.start();
         }
 
-        if (!canEditTask) {
+        if (isStudentSolving) {
           const solution = new Blob([vm.toJSON()], {
             type: "application/json",
           });
@@ -50,14 +50,14 @@ const Controls = ({
         vm.greenFlag();
       }
     },
-    [vm, isStarted, turbo, sendRequest, canEditTask],
+    [vm, isStarted, turbo, sendRequest, isStudentSolving],
   );
 
   const handleStopAllClick = useCallback(
     (e: Event) => {
       e.preventDefault();
 
-      if (!canEditTask) {
+      if (isStudentSolving) {
         const solution = new Blob([vm.toJSON()], {
           type: "application/json",
         });
@@ -68,7 +68,7 @@ const Controls = ({
 
       vm.stopAll();
     },
-    [vm, canEditTask, sendRequest],
+    [vm, isStudentSolving, sendRequest],
   );
 
   return (

--- a/apps/scratch/src/containers/customized-scratch-containers/Controls.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Controls.tsx
@@ -4,7 +4,10 @@ import { connect } from "react-redux";
 
 import ControlsComponent from "@scratch-submodule/packages/scratch-gui/src/components/controls/controls.jsx";
 import { CrtContext } from "../../contexts/CrtContext";
-import { sendGreenFlagActivity } from "../../utilities/scratch-student-activities/senders";
+import {
+  sendGreenFlagActivity,
+  sendStopAllActivity,
+} from "../../utilities/scratch-student-activities/senders";
 
 interface Props {
   isStarted: boolean;
@@ -53,9 +56,19 @@ const Controls = ({
   const handleStopAllClick = useCallback(
     (e: Event) => {
       e.preventDefault();
+
+      if (!canEditTask) {
+        const solution = new Blob([vm.toJSON()], {
+          type: "application/json",
+        });
+
+        // do not wait for this request to succeed
+        sendStopAllActivity(sendRequest, solution);
+      }
+
       vm.stopAll();
     },
-    [vm],
+    [vm, canEditTask, sendRequest],
   );
 
   return (

--- a/apps/scratch/src/containers/customized-scratch-containers/Gui.tsx
+++ b/apps/scratch/src/containers/customized-scratch-containers/Gui.tsx
@@ -93,6 +93,7 @@ type Props = {
 
   cannotInteractWithBlocks?: boolean;
   canEditTask?: boolean;
+  isStudentSolving?: boolean;
   isStandaloneCodeEnabled?: boolean;
   isCodeTabEnabled?: boolean;
   isStageEnabled?: boolean;
@@ -115,6 +116,7 @@ type ExternalProps = Pick<
   Props,
   | "cannotInteractWithBlocks"
   | "canEditTask"
+  | "isStudentSolving"
   | "isStandaloneCodeEnabled"
   | "isCodeTabEnabled"
   | "isStageEnabled"

--- a/apps/scratch/src/pages/solve.tsx
+++ b/apps/scratch/src/pages/solve.tsx
@@ -10,6 +10,7 @@ const Solve = () => {
   return (
     <Gui
       canEditTask={false}
+      isStudentSolving={true}
       isCodeTabEnabled={true}
       isStageEnabled={true}
       isCostumesTabEnabled={false}

--- a/apps/scratch/src/types/scratch-student-activities/common.ts
+++ b/apps/scratch/src/types/scratch-student-activities/common.ts
@@ -26,6 +26,7 @@ export enum StudentActionType {
   Move = "move",
   Delete = "delete",
   GreenFlag = "greenFlag",
+  StopAll = "stopAll",
   BlockChange = "blockChange",
   IntermediateFieldChange = "intermediateFieldChange",
 }

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/index.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/index.ts
@@ -2,5 +2,6 @@ export { sendCreateActivity } from "./send-create-activity";
 export { sendMoveActivity } from "./send-move-activity";
 export { sendDeleteActivity } from "./send-delete-activity";
 export { sendGreenFlagActivity } from "./send-green-flag-activity";
+export { sendStopAllActivity } from "./send-stop-all-activity";
 export { sendChangeActivity } from "./send-change-activity";
 export { sendIntermediateChangeActivity } from "./send-intermediate-change-activity";

--- a/apps/scratch/src/utilities/scratch-student-activities/senders/send-stop-all-activity.ts
+++ b/apps/scratch/src/utilities/scratch-student-activities/senders/send-stop-all-activity.ts
@@ -1,0 +1,20 @@
+import { StudentActionType } from "../../../types/scratch-student-activities";
+import { CrtContextValue } from "../../../contexts/CrtContext";
+import { logBaseModule } from "../log-module";
+
+const logModule = `${logBaseModule}[senders/send-stop-all-activity]`;
+
+export async function sendStopAllActivity(
+  sendRequest: CrtContextValue["sendRequest"],
+  solution: Blob,
+): Promise<void> {
+  try {
+    await sendRequest("postStudentAppActivity", {
+      action: StudentActionType.StopAll,
+      data: {},
+      solution,
+    });
+  } catch (error) {
+    console.error(`${logModule} Error sending stop all activity:`, error);
+  }
+}


### PR DESCRIPTION
**WIP — opened primarily to observe CI.** The implementation is complete and locally typecheck/lint-clean, but I could not run the Scratch app's playwright e2e suite in my environment (no jest binary; playwright needs a full build + browsers). This PR lets CI exercise the e2e I added.

## Summary

The green flag already records a student activity when a solving student runs their project; the red **stop** button (which halts the ongoing execution) did not. Record it the same way, carrying only the action (a timestamp is added when the activity is stored).

- New `StopAll` action type + `sendStopAllActivity` sender, mirroring the green-flag ones.
- Posted from the stop-all handler in [Controls.tsx](apps/scratch/src/containers/customized-scratch-containers/Controls.tsx), guarded by `!canEditTask` so it fires only while a student is solving, not while a teacher edits.
- Flows through the generic `postStudentAppActivity` path (`action` is an arbitrary string stored as the app activity's `type`), so **no backend, rpc or schema change** is needed.

## Two things to verify (why this is WIP)

1. **The e2e is unverified locally.** New test in `Solve.spec.tsx` presses stop after the green flag and asserts a `postStudentAppActivity` with `action: "stopAll"` is posted. Its intent/assertion are correct, but it has never run.
2. **One selector is a best-effort guess.** `pressStopButton()` uses `img:last-child` in `stage-controls` (mirroring `pressGreenFlag()`'s `img:first-child`), because the scratch-gui controls DOM lives in an unreadable git submodule. If CI's `app-tests` fails on the stop click, this one line is the likely culprit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Record presses of the red stop button as a student activity when a student is solving, mirroring the green flag. Addresses CRT-462 by logging when execution is stopped and never logging in show mode.

- New Features
  - Add `StudentActionType.StopAll` and `sendStopAllActivity`; fire on stop only when `isStudentSolving`; attach serialized solution; non-blocking via existing `postStudentAppActivity` (no backend/RPC/schema changes).
  - Plumb `isStudentSolving` through `Gui` → `StageWrapper` → `Controls`; set on `/solve`; gate green-flag activity with it.
  - Tests: e2e asserts `"stopAll"` activity; updated stop selector to `getByTitle("Stop")` within `data-testid="stage-controls"`; added `/show` regression to confirm zero activities.

<sup>Written for commit 2d2d710876b26e1a77616a152102b72ae4543e65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

