### PR TITLE
ci: pass a Sonar token to the scan on pull_request runs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,6 +229,9 @@ jobs:
           name: coverage-e2e
 
       - name: SonarCloud Scan
+        # A pull_request from a fork cannot read repository secrets, so there is
+        # no token to scan with; skip rather than fail with an empty token.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: SonarSource/sonarqube-scan-action@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,4 +232,5 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@v5.3.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          # SONAR_TOKEN may not be set if called in a pull_request or merge_group run
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN || secrets.DEV_SONAR_TOKEN }}


### PR DESCRIPTION
## Problem

The SonarCloud scan fails on **same-repo PRs** — the `sonar` job runs with an empty `SONAR_TOKEN` (job log: `SONAR_TOKEN:` blank, plus `##[warning]Running this GitHub Action without SONAR_TOKEN is not recommended`), while all the actual test jobs (unit/app/e2e) pass.

## Root cause

`tests.yml` is triggered two ways:
- **`workflow_call`** (from `development.yml` / `production.yml` on push to main) — the caller passes `SONAR_TOKEN: ${{ secrets.DEV_SONAR_TOKEN }}` (or `PROD_`), so it's populated.
- **`pull_request` / `merge_group`** — no caller, and there is **no repo secret literally named `SONAR_TOKEN`** (only `DEV_SONAR_TOKEN` / `PROD_SONAR_TOKEN`). So `secrets.SONAR_TOKEN` resolves to empty.

So the tokens *are* set correctly in the repo (`DEV_/PROD_SONAR_TOKEN`) — the scan step just never reads them on PR runs.

## Fix

Two changes to the `sonar` job's scan step:

1. **Fall back to `DEV_SONAR_TOKEN`** when the workflow_call input isn't present:
   ```yaml
   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN || secrets.DEV_SONAR_TOKEN }}
   ```
2. **Skip the scan on fork PRs**, which cannot read repository secrets at all (so no fallback can help) — gating with the same fork-check `licenses.yml` already uses:
   ```yaml
   if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
   ```

### Behaviour per trigger

| Trigger | Scan runs? | Token source |
|---|---|---|
| `workflow_call` (dev/prod push) | yes | caller-supplied `SONAR_TOKEN` |
| same-repo `pull_request` | yes | `DEV_SONAR_TOKEN` fallback |
| `merge_group` | yes | `DEV_SONAR_TOKEN` fallback |
| **fork `pull_request`** | **skipped** | none available — job still succeeds, so it isn't a stuck required check |

## Note for the other open PRs

`pull_request` runs use the workflow file from the PR's own branch, so this fix takes effect for a PR only after it picks up this change (merge to main, then rebase/merge main into the other branches). This PR's own `sonar` job is the live proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)