### PR TITLE
[CRT-467] Post one solution per save, not one per scheduled cell

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/src/__tests__/task-auto-saver.spec.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/__tests__/task-auto-saver.spec.ts
@@ -346,6 +346,15 @@ describe("TaskAutoSaver", () => {
       }
     ).forEach = (callback): void => callback(mockPanel);
 
+    // Capture the beforeunload handler this saver registers rather than
+    // dispatching a global event: earlier trackNotebook calls in this file
+    // leave their own beforeunload listeners on the shared jsdom window, and
+    // dispatching would fire those too - their stale mock trackers have no
+    // forEach, throwing unhandled rejections behind these assertions.
+    const addEventListenerSpy = jest
+      .spyOn(window, "addEventListener")
+      .mockImplementation(() => undefined);
+
     TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
     mockPanel.context.model.dirty = true;
     makeSaveClearDirty(mockPanel);
@@ -355,7 +364,12 @@ describe("TaskAutoSaver", () => {
       mockTracker.widgetAdded.connect as jest.Mock
     ).mock.calls.length;
 
-    dispatchEvent(new Event("beforeunload"));
+    const beforeUnloadHandler = addEventListenerSpy.mock.calls
+      .filter(([type]) => type === "beforeunload")
+      .map(([, handler]) => handler)
+      .pop() as EventListener;
+
+    beforeUnloadHandler(new Event("beforeunload"));
     await flushMicrotasks();
 
     expect(mockSave).toHaveBeenCalledTimes(1);
@@ -396,5 +410,20 @@ describe("TaskAutoSaver", () => {
     expect(
       jest.mocked(NotebookActions.executionScheduled.disconnect),
     ).toHaveBeenCalledWith(visiblePanelListener);
+  });
+
+  it("disconnects the disposed panel's own content-changed listener", () => {
+    TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
+    addNotebookToTracker(mockPanel);
+
+    const contentChangedDisconnect = mockPanel.context.model.contentChanged
+      .disconnect as jest.Mock;
+    const connectedListener = (
+      mockPanel.context.model.contentChanged.connect as jest.Mock
+    ).mock.calls[0][0];
+
+    simulateDisposal(mockPanel);
+
+    expect(contentChangedDisconnect).toHaveBeenCalledWith(connectedListener);
   });
 });

--- a/apps/jupyter/extensions/notebook-runner/src/__tests__/task-auto-saver.spec.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/__tests__/task-auto-saver.spec.ts
@@ -426,4 +426,29 @@ describe("TaskAutoSaver", () => {
 
     expect(contentChangedDisconnect).toHaveBeenCalledWith(connectedListener);
   });
+
+  it("keeps a shared model's pending save when one panel is disposed", async () => {
+    TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
+    addNotebookToTracker(mockPanel);
+
+    const hiddenPanel = {
+      context: mockPanel.context,
+      content: {
+        id: "/test/notebook.ipynb-hidden",
+        activeCell: mockCell,
+      } as NotebookPanel["content"],
+      disposed: {
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+      },
+    } as Partial<NotebookPanel> as NotebookPanel;
+    addNotebookToTracker(hiddenPanel);
+
+    simulateContentChange(mockPanel);
+    simulateDisposal(hiddenPanel);
+    await jest.advanceTimersByTimeAsync(TaskAutoSaver.debounceInterval);
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSendTaskSolution).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/jupyter/extensions/notebook-runner/src/__tests__/task-auto-saver.spec.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/__tests__/task-auto-saver.spec.ts
@@ -286,4 +286,115 @@ describe("TaskAutoSaver", () => {
 
     expect(mockToJSON).toHaveBeenCalledTimes(1);
   });
+
+  const flushMicrotasks = async (): Promise<void> => {
+    for (let i = 0; i < 10; i++) {
+      await Promise.resolve();
+    }
+  };
+
+  // the dirty flag only clears once the save resolves - like the real
+  // panel.context.save(), it stays set for the whole synchronous tick
+  const makeSaveClearDirty = (panel: NotebookPanel): void => {
+    (panel.context.save as jest.Mock).mockImplementation(() =>
+      Promise.resolve().then(() => {
+        panel.context.model.dirty = false;
+      }),
+    );
+  };
+
+  it("coalesces a run-all burst into a single save and post", async () => {
+    TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
+    mockPanel.context.model.dirty = true;
+    makeSaveClearDirty(mockPanel);
+    addNotebookToTracker(mockPanel);
+
+    // NotebookActions.runAll schedules every code cell in the same
+    // synchronous tick - one executionScheduled emission per cell (CRT-467)
+    for (let cell = 0; cell < 8; cell++) {
+      simulateExecutionScheduled(mockPanel);
+    }
+
+    await flushMicrotasks();
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSendTaskSolution).toHaveBeenCalledTimes(1);
+  });
+
+  it("saves again for changes made after a coalesced save", async () => {
+    TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
+    mockPanel.context.model.dirty = true;
+    makeSaveClearDirty(mockPanel);
+    addNotebookToTracker(mockPanel);
+
+    simulateExecutionScheduled(mockPanel);
+    simulateExecutionScheduled(mockPanel);
+    await flushMicrotasks();
+
+    mockPanel.context.model.dirty = true;
+    simulateExecutionScheduled(mockPanel);
+    await flushMicrotasks();
+
+    expect(mockSave).toHaveBeenCalledTimes(2);
+    expect(mockSendTaskSolution).toHaveBeenCalledTimes(2);
+  });
+
+  it("saves through the existing saver on page unload", async () => {
+    (
+      mockTracker as unknown as {
+        forEach: (callback: (panel: NotebookPanel) => void) => void;
+      }
+    ).forEach = (callback): void => callback(mockPanel);
+
+    TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
+    mockPanel.context.model.dirty = true;
+    makeSaveClearDirty(mockPanel);
+    addNotebookToTracker(mockPanel);
+
+    const widgetAddedConnectCount = (
+      mockTracker.widgetAdded.connect as jest.Mock
+    ).mock.calls.length;
+
+    dispatchEvent(new Event("beforeunload"));
+    await flushMicrotasks();
+
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    expect(mockSendTaskSolution).toHaveBeenCalledTimes(1);
+    // the unload handler must not construct new savers: each would register
+    // another beforeunload listener, doubling every later save (1→2→4→8)
+    expect(
+      (mockTracker.widgetAdded.connect as jest.Mock).mock.calls.length,
+    ).toBe(widgetAddedConnectCount);
+  });
+
+  it("disconnects the disposed panel's own execution listener", () => {
+    TaskAutoSaver.trackNotebook(mockTracker, mockSendRequest);
+    addNotebookToTracker(mockPanel);
+
+    // a second panel over the same document shares the model, like the
+    // hidden grading panel over the student notebook
+    const hiddenPanel = {
+      context: mockPanel.context,
+      content: {
+        id: "/test/notebook.ipynb-hidden",
+        activeCell: mockCell,
+      } as NotebookPanel["content"],
+      disposed: {
+        connect: jest.fn(),
+        disconnect: jest.fn(),
+      },
+    } as Partial<NotebookPanel> as NotebookPanel;
+    addNotebookToTracker(hiddenPanel);
+
+    const connectedListeners = jest.mocked(
+      NotebookActions.executionScheduled.connect,
+    ).mock.calls;
+    const visiblePanelListener = connectedListeners[0][0];
+
+    simulateDisposal(mockPanel);
+
+    expect(
+      jest.mocked(NotebookActions.executionScheduled.disconnect),
+    ).toHaveBeenCalledWith(visiblePanelListener);
+  });
 });

--- a/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
@@ -19,10 +19,13 @@ export class TaskAutoSaver {
     INotebookModel,
     NodeJS.Timeout
   >();
+  // keyed by panel: two panels over the same document (e.g. the hidden
+  // grading panel) share one model, and each needs its own listener
   private readonly executionListeners = new Map<
-    INotebookModel,
+    NotebookPanel,
     ExecutionScheduledCallback
   >();
+  private readonly inFlightSaves = new Map<INotebookModel, Promise<void>>();
   public static readonly debounceInterval = 30000;
 
   constructor(
@@ -34,7 +37,7 @@ export class TaskAutoSaver {
     });
 
     addEventListener("beforeunload", async () => {
-      await this.handlePageUnload(notebookTracker);
+      await this.handlePageUnload();
     });
   }
 
@@ -66,12 +69,12 @@ export class TaskAutoSaver {
       }
     };
 
-    this.executionListeners.set(model, executionListener);
+    this.executionListeners.set(panel, executionListener);
 
     NotebookActions.executionScheduled.connect(executionListener);
 
     panel.disposed.connect(() => {
-      this.handleNotebookDisposed(model);
+      this.handleNotebookDisposed(panel);
     });
   }
 
@@ -89,37 +92,18 @@ export class TaskAutoSaver {
     this.contentChangeTimers.set(model, timer);
   }
 
-  private async handlePageUnload(
-    notebookTracker: INotebookTracker,
-  ): Promise<void> {
-    for (const [model, _] of this.contentChangeTimers.entries()) {
-      // The listener/timer cleanup is technically unnecessary since the page is unloading
-      // but we do it for good measure and to avoid any potential side effects
-      // if the unload gets canceled for some reason.
-      NotebookActions.executionScheduled.disconnect(
-        this.executionListeners.get(model)!,
-      );
-
-      this.contentChangeTimers.delete(model);
+  private async handlePageUnload(): Promise<void> {
+    // The timer cleanup is technically unnecessary since the page is
+    // unloading, but we do it for good measure and to avoid any potential
+    // side effects if the unload gets canceled for some reason.
+    for (const model of [...this.contentChangeTimers.keys()]) {
+      this.cancelContentChangeTimer(model);
     }
 
-    notebookTracker.forEach(async (panel) => {
-      const model = panel.context.model;
-
-      const saver = new TaskAutoSaver(
-        notebookTracker,
-        this.sendRequest.bind(this),
-      );
-
-      try {
-        await saver.saveNotebook(panel, model);
-      } catch (error) {
-        console.error(
-          `${logModule} Failed to save notebook ${model.toString()}:`,
-          error,
-        );
-      }
-    });
+    // save through this instance: constructing a fresh TaskAutoSaver here
+    // would register another beforeunload listener each time, doubling every
+    // later save (CRT-467)
+    await this.saveAllNotebooks();
   }
 
   private async handleExecutionScheduled(
@@ -134,25 +118,44 @@ export class TaskAutoSaver {
     await this.saveNotebook(panel, model);
   }
 
-  private handleNotebookDisposed(model: INotebookModel): void {
-    this.cancelContentChangeTimer(model);
+  private handleNotebookDisposed(panel: NotebookPanel): void {
+    this.cancelContentChangeTimer(panel.context.model);
 
-    const listener = this.executionListeners.get(model);
+    const listener = this.executionListeners.get(panel);
 
     if (listener) {
       NotebookActions.executionScheduled.disconnect(listener);
-      this.executionListeners.delete(model);
+      this.executionListeners.delete(panel);
     }
   }
 
-  private async saveNotebook(
+  private saveNotebook(
     panel: NotebookPanel,
     model: INotebookModel,
   ): Promise<void> {
-    if (!model.dirty) {
-      return;
+    // A run-all schedules every code cell in the same synchronous tick, one
+    // executionScheduled emission per cell, and the dirty flag only clears
+    // once the save resolves - so each emission would trigger its own save
+    // and solution post. Coalesce them onto the save already in flight
+    // (CRT-467).
+    const inFlight = this.inFlightSaves.get(model);
+    if (inFlight) {
+      return inFlight;
     }
 
+    if (!model.dirty) {
+      return Promise.resolve();
+    }
+
+    const save = this.performSave(panel).finally(() => {
+      this.inFlightSaves.delete(model);
+    });
+    this.inFlightSaves.set(model, save);
+
+    return save;
+  }
+
+  private async performSave(panel: NotebookPanel): Promise<void> {
     try {
       await panel.context.save();
       await this.postCurrentSolution(panel);

--- a/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
@@ -66,7 +66,7 @@ export class TaskAutoSaver {
 
   private registerNotebook(panel: NotebookPanel, model: INotebookModel): void {
     const contentChangeListener = (): void => {
-      this.handleContentChange(panel, model);
+      this.handleContentChange(model);
     };
 
     model.contentChanged.connect(contentChangeListener);
@@ -87,15 +87,24 @@ export class TaskAutoSaver {
     });
   }
 
-  private handleContentChange(
-    panel: NotebookPanel,
-    model: INotebookModel,
-  ): void {
+  private handleContentChange(model: INotebookModel): void {
     this.cancelContentChangeTimer(model);
 
     const timer = setTimeout(async () => {
-      await this.saveNotebook(panel, model);
-      this.contentChangeTimers.delete(model);
+      // a model can be shared by more than one panels
+      // resolve the panel when the timer fires so we never save through the panel that originally scheduled the timer after it closed
+      const livePanel = [...this.contentChangeListeners.keys()].find(
+        (panel) => panel.context.model === model,
+      );
+
+      if (livePanel) {
+        await this.saveNotebook(livePanel, model);
+      }
+
+      // a content change can replace this timer while the save is awaiting, so only remove the map entry if it still belongs to this callback
+      if (this.contentChangeTimers.get(model) === timer) {
+        this.contentChangeTimers.delete(model);
+      }
     }, TaskAutoSaver.debounceInterval);
 
     this.contentChangeTimers.set(model, timer);
@@ -128,7 +137,7 @@ export class TaskAutoSaver {
   }
 
   private handleNotebookDisposed(panel: NotebookPanel): void {
-    this.cancelContentChangeTimer(panel.context.model);
+    const model = panel.context.model;
 
     const executionListener = this.executionListeners.get(panel);
 
@@ -140,8 +149,19 @@ export class TaskAutoSaver {
     const contentChangeListener = this.contentChangeListeners.get(panel);
 
     if (contentChangeListener) {
-      panel.context.model.contentChanged.disconnect(contentChangeListener);
+      model.contentChanged.disconnect(contentChangeListener);
       this.contentChangeListeners.delete(panel);
+    }
+
+    // the debounce timer belongs to the shared model, not to one panel
+    // keep it while another panel can still save that model, and cancel it
+    // only when the model's final panel has been disposed
+    const modelStillHasPanel = [...this.contentChangeListeners.keys()].some(
+      (livePanel) => livePanel.context.model === model,
+    );
+
+    if (!modelStillHasPanel) {
+      this.cancelContentChangeTimer(model);
     }
   }
 

--- a/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/auto-save/task-auto-saver.ts
@@ -25,6 +25,12 @@ export class TaskAutoSaver {
     NotebookPanel,
     ExecutionScheduledCallback
   >();
+  // keyed by panel for the same reason: the contentChanged signal lives on the
+  // shared model, so each panel's slot must be disconnected individually
+  private readonly contentChangeListeners = new Map<
+    NotebookPanel,
+    () => void
+  >();
   private readonly inFlightSaves = new Map<INotebookModel, Promise<void>>();
   public static readonly debounceInterval = 30000;
 
@@ -59,9 +65,12 @@ export class TaskAutoSaver {
   }
 
   private registerNotebook(panel: NotebookPanel, model: INotebookModel): void {
-    panel.context.model.contentChanged.connect(() => {
+    const contentChangeListener = (): void => {
       this.handleContentChange(panel, model);
-    });
+    };
+
+    model.contentChanged.connect(contentChangeListener);
+    this.contentChangeListeners.set(panel, contentChangeListener);
 
     const executionListener: ExecutionScheduledCallback = (sender, args) => {
       if (args.notebook === panel.content) {
@@ -121,11 +130,18 @@ export class TaskAutoSaver {
   private handleNotebookDisposed(panel: NotebookPanel): void {
     this.cancelContentChangeTimer(panel.context.model);
 
-    const listener = this.executionListeners.get(panel);
+    const executionListener = this.executionListeners.get(panel);
 
-    if (listener) {
-      NotebookActions.executionScheduled.disconnect(listener);
+    if (executionListener) {
+      NotebookActions.executionScheduled.disconnect(executionListener);
       this.executionListeners.delete(panel);
+    }
+
+    const contentChangeListener = this.contentChangeListeners.get(panel);
+
+    if (contentChangeListener) {
+      panel.context.model.contentChanged.disconnect(contentChangeListener);
+      this.contentChangeListeners.delete(panel);
     }
   }
 
@@ -138,6 +154,13 @@ export class TaskAutoSaver {
     // once the save resolves - so each emission would trigger its own save
     // and solution post. Coalesce them onto the save already in flight
     // (CRT-467).
+    //
+    // We deliberately do not re-check dirtiness and re-save when the in-flight
+    // save settles: changes that land mid-save (e.g. the run-all's cell
+    // outputs) fire contentChanged, which re-arms the debounce timer in
+    // handleContentChange independently of this map, so they are still saved -
+    // just debounced rather than immediately. Re-saving on settle would
+    // reintroduce an extra immediate post per run-all.
     const inFlight = this.inFlightSaves.get(model);
     if (inFlight) {
       return inFlight;


### PR DESCRIPTION
## Summary

One student action ("Run All Cells") produced 8 identical solution POSTs — one per code cell (Jira: CRT-467, jam 222ab434).

## Root cause

`NotebookActions.runAll` schedules every code cell in one synchronous tick; Lumino signals are synchronous, so the auto-saver's `executionScheduled` handler runs once per cell **before any await resolves**. Its only guard, `model.dirty`, clears only when `context.save()` resolves — several microtasks later — so all N emissions passed the guard and each ran its own save + `postTaskSolution`. 8 = number of code cells in the student notebook.

## Fix (all in `TaskAutoSaver`)

1. **Coalesce saves per model**: an in-flight promise map — while a save is running, further save requests join it. One burst → one save → one POST.
2. **Unload handler no longer constructs new `TaskAutoSaver`s**: each construction registered another `beforeunload` listener, doubling every later save (1→2→4→8) whenever an unload didn't terminate the page. It now saves through the existing instance.
3. **Execution listeners keyed by panel, not by the shared model**: the hidden grading panel over the same document used to overwrite the visible panel's map entry, permanently orphaning its listener on the global signal.

## Verification

- 4 new regression tests, written red-first and confirmed failing (the burst test initially passed vacuously because the mocked `save` cleared `dirty` synchronously — the mock now clears it only on promise resolution, mirroring the real `context.save()`, and then fails with 8 saves against the unfixed code).
- Full notebook-runner suite: 61/61 green. eslint + prettier clean; the one tsc error (`./sentry-config`) is pre-existing on main (build-time-generated module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CRT-467 by posting one solution per auto-save when “Run All Cells” is used, instead of one per code cell. Also prevents unload-driven duplicates and correctly handles multiple panels sharing the same notebook model.

- **Bug Fixes**
  - Coalesce concurrent save requests per model via an in-flight promise map: one burst → one save → one POST; follow-up changes are saved by the debounce, not by re-saving when the first save settles.
  - Handle multi-panel notebooks: key `executionScheduled` and `contentChanged` listeners by panel; resolve the live panel at debounce fire; keep timers/in-flight saves while any panel remains; cancel timers only when the model’s last panel is disposed; disconnect disposed panels’ `contentChanged` listeners to prevent leaks and stray saves.
  - Reuse the existing saver on `beforeunload` and clean up timers through it; no new instances or extra unload listeners are registered.

<sup>Written for commit 88987f1b3c6af1ab294704a00e1f0783b6e3ebd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

