### PR TITLE
[CRT-399] Close the remaining kernel-dialog races in the teacher flow

### DIFF
--- a/apps/jupyter/extensions/notebook-runner/eslint.config.mjs
+++ b/apps/jupyter/extensions/notebook-runner/eslint.config.mjs
@@ -59,6 +59,12 @@ export default defineConfig([
           message:
             "Use openTaskNotebook() instead — it awaits kernelspecs.ready so JupyterLab auto-selects the Pyodide kernel instead of prompting the user.",
         },
+        {
+          selector:
+            "CallExpression > MemberExpression.callee[object.name='documentManager'][property.name='open']",
+          message:
+            "Await waitForKernelSpecs() before opening a notebook — opening without a registered kernelspec makes JupyterLab prompt the user to pick a kernel.",
+        },
       ],
 
       "@typescript-eslint/no-unused-vars": [

--- a/apps/jupyter/extensions/notebook-runner/src/__tests__/wait-for-kernel-specs.spec.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/__tests__/wait-for-kernel-specs.spec.ts
@@ -1,0 +1,147 @@
+import {
+  KernelSpecWaitTarget,
+  waitForKernelSpecs,
+} from "../kernel/wait-for-kernel-specs";
+
+type SpecsChangedCallback = (
+  sender: unknown,
+  specs: KernelSpecWaitTarget["specs"],
+) => void;
+
+const pyodideSpecs = {
+  default: "python",
+  kernelspecs: {
+    python: {
+      name: "python",
+      language: "python",
+      display_name: "Python (Pyodide)",
+      argv: [],
+      resources: {},
+    },
+  },
+} as unknown as Exclude<KernelSpecWaitTarget["specs"], null>;
+
+const createManager = (
+  initialSpecs: KernelSpecWaitTarget["specs"],
+): {
+  manager: KernelSpecWaitTarget;
+  emitSpecs: (specs: KernelSpecWaitTarget["specs"]) => void;
+  connected: () => number;
+} => {
+  const callbacks = new Set<SpecsChangedCallback>();
+
+  const manager = {
+    ready: Promise.resolve(),
+    specs: initialSpecs,
+    specsChanged: {
+      connect: (callback: SpecsChangedCallback): boolean => {
+        callbacks.add(callback);
+        return true;
+      },
+      disconnect: (callback: SpecsChangedCallback): boolean => {
+        callbacks.delete(callback);
+        return true;
+      },
+    },
+  };
+
+  return {
+    manager,
+    // like the real manager: the specs property updates, then the signal fires
+    emitSpecs: (emitted): void => {
+      manager.specs = emitted;
+      for (const callback of [...callbacks]) {
+        callback(manager, emitted);
+      }
+    },
+    connected: () => callbacks.size,
+  };
+};
+
+describe("waitForKernelSpecs", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  it("resolves immediately when a kernelspec is already registered", async () => {
+    const { manager, connected } = createManager(pyodideSpecs);
+
+    await waitForKernelSpecs(manager);
+
+    expect(connected()).toBe(0);
+  });
+
+  it("resolves once a kernelspec is registered later", async () => {
+    const { manager, emitSpecs, connected } = createManager(null);
+
+    const wait = waitForKernelSpecs(manager);
+
+    let resolved = false;
+    void wait.then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    emitSpecs(pyodideSpecs);
+    await wait;
+
+    expect(connected()).toBe(0);
+  });
+
+  it("ignores emissions that still contain no spec", async () => {
+    const { manager, emitSpecs } = createManager(null);
+
+    const wait = waitForKernelSpecs(manager);
+
+    emitSpecs({
+      default: "python",
+      kernelspecs: {},
+    } as unknown as KernelSpecWaitTarget["specs"]);
+
+    let resolved = false;
+    void wait.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(resolved).toBe(false);
+
+    emitSpecs(pyodideSpecs);
+    await wait;
+  });
+
+  it("gives up after the bounded wait so the notebook still opens", async () => {
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { manager, connected } = createManager(null);
+
+    const wait = waitForKernelSpecs(manager, 1_000);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    await wait;
+
+    expect(connected()).toBe(0);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("does not miss a spec registered before the wait could subscribe", async () => {
+    // the manager's mutable specs may be populated before the helper has a
+    // chance to connect to the signal; the specs re-checks cover it
+    const { manager, emitSpecs, connected } = createManager(null);
+
+    const wait = waitForKernelSpecs(manager);
+    emitSpecs(pyodideSpecs);
+
+    await wait;
+
+    expect(connected()).toBe(0);
+  });
+});

--- a/apps/jupyter/extensions/notebook-runner/src/__tests__/wait-for-kernel-specs.spec.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/__tests__/wait-for-kernel-specs.spec.ts
@@ -23,6 +23,7 @@ const pyodideSpecs = {
 
 const createManager = (
   initialSpecs: KernelSpecWaitTarget["specs"],
+  ready: Promise<void> = Promise.resolve(),
 ): {
   manager: KernelSpecWaitTarget;
   emitSpecs: (specs: KernelSpecWaitTarget["specs"]) => void;
@@ -31,7 +32,7 @@ const createManager = (
   const callbacks = new Set<SpecsChangedCallback>();
 
   const manager = {
-    ready: Promise.resolve(),
+    ready,
     specs: initialSpecs,
     specsChanged: {
       connect: (callback: SpecsChangedCallback): boolean => {
@@ -136,6 +137,53 @@ describe("waitForKernelSpecs", () => {
     // the manager's mutable specs may be populated before the helper has a
     // chance to connect to the signal; the specs re-checks cover it
     const { manager, emitSpecs, connected } = createManager(null);
+
+    const wait = waitForKernelSpecs(manager);
+    emitSpecs(pyodideSpecs);
+
+    await wait;
+
+    expect(connected()).toBe(0);
+  });
+
+  it("falls back through the timeout when readiness rejects", async () => {
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { manager, connected } = createManager(
+      null,
+      Promise.reject(new Error("kernelspec manager failed")),
+    );
+
+    const wait = waitForKernelSpecs(manager, 1_000);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    await wait;
+
+    expect(connected()).toBe(0);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("still gives up when the manager never becomes ready", async () => {
+    jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    // a readiness promise that never settles must not hang the caller
+    const { manager, connected } = createManager(
+      null,
+      new Promise<void>(() => {}),
+    );
+
+    const wait = waitForKernelSpecs(manager, 1_000);
+
+    await jest.advanceTimersByTimeAsync(1_000);
+    await wait;
+
+    expect(connected()).toBe(0);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("resolves on a late spec even after readiness rejected", async () => {
+    const { manager, emitSpecs, connected } = createManager(
+      null,
+      Promise.reject(new Error("kernelspec manager failed")),
+    );
 
     const wait = waitForKernelSpecs(manager);
     emitSpecs(pyodideSpecs);

--- a/apps/jupyter/extensions/notebook-runner/src/command.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/command.ts
@@ -3,6 +3,7 @@ import { IDocumentManager } from "@jupyterlab/docmanager";
 import { NotebookActions, NotebookPanel } from "@jupyterlab/notebook";
 import { Contents, ContentsManager } from "@jupyterlab/services";
 import { NotebookRunnerState } from "./notebook-runner-state";
+import { waitForKernelSpecs } from "./kernel/wait-for-kernel-specs";
 import { executePythonInKernel, writeJsonToVirtualFilesystem } from "./utils";
 
 const logModule = "[Jupyter][command]";
@@ -26,7 +27,12 @@ export const executeRunNotebookCommand = async (
 ): Promise<void> => {
   console.debug(`${logModule} Opening notebook at path:`, notebookPath);
 
+  // Opening before any kernelspec is registered would pop the kernel
+  // selection dialog over the hidden grading run (CRT-399)
+  await waitForKernelSpecs(app.serviceManager.kernelspecs);
+
   state.allowNextNotebookInParallel = true;
+  // eslint-disable-next-line no-restricted-syntax -- guarded by the kernelspec wait above
   const newNotebookPanel = documentManager.open(
     notebookPath,
     "Notebook",

--- a/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/iframe-api.ts
@@ -19,6 +19,7 @@ import {
 import { stopBufferingIframeMessages } from "./iframe-message-buffer";
 import { OtterGradingResults } from "./grading-results";
 import { runAssignCommand, runGradingCommand } from "./command";
+import { waitForKernelSpecs } from "./kernel/wait-for-kernel-specs";
 import { blockUserInterface } from "./ui-blocker";
 import { Mode } from "./mode";
 import {
@@ -103,10 +104,6 @@ export class EmbeddedPythonCallbacks {
   public static readonly gradingSrcLocation: string = "/grading_src";
   public static readonly pluginId = "@jupyterlab/translation-extension:plugin";
 
-  // kernelspec registration happens during startup (local JS, no downloads),
-  // so this is generous; it only matters when the kernel extension is broken
-  private static readonly kernelSpecWaitTimeoutMs = 15_000;
-
   private readonly beforeReloadCallbacks: Array<() => Promise<void>> = [];
 
   constructor(
@@ -131,66 +128,12 @@ export class EmbeddedPythonCallbacks {
       : EmbeddedPythonCallbacks.studentTaskLocation;
 
   /**
-   * Resolves once at least one kernelspec (the Pyodide kernel) is registered,
-   * or after a bounded wait. The wait is bounded so that a broken kernel
-   * extension degrades to the pre-existing behavior (the notebook opens and
-   * JupyterLab may prompt for a kernel) instead of hanging the task-opening
-   * RPC — and with it the embedded app — forever.
-   */
-  private async waitForKernelSpecs(): Promise<void> {
-    const kernelSpecs = this.app.serviceManager.kernelspecs;
-    await kernelSpecs.ready;
-
-    const hasSpec = (specs = kernelSpecs.specs): boolean =>
-      !!specs && Object.keys(specs.kernelspecs).length > 0;
-
-    if (hasSpec()) {
-      return;
-    }
-
-    await new Promise<void>((resolve) => {
-      // specsChanged emits the freshly fetched specs, so use the emitted
-      // payload instead of re-reading the manager's mutable specs property
-      function onChange(
-        _sender: unknown,
-        specs: typeof kernelSpecs.specs,
-      ): void {
-        if (hasSpec(specs)) {
-          clearTimeout(timeout);
-          kernelSpecs.specsChanged.disconnect(onChange);
-          resolve();
-        }
-      }
-
-      const timeout = setTimeout(() => {
-        kernelSpecs.specsChanged.disconnect(onChange);
-        console.warn(
-          `${logModule} No kernelspec registered after ${EmbeddedPythonCallbacks.kernelSpecWaitTimeoutMs}ms; opening the notebook anyway (the kernel selection dialog may appear)`,
-        );
-        resolve();
-      }, EmbeddedPythonCallbacks.kernelSpecWaitTimeoutMs);
-
-      kernelSpecs.specsChanged.connect(onChange);
-
-      // Re-check after connecting so that a spec registered between the check
-      // above and the connect cannot be missed. This makes the wait correct by
-      // inspection instead of relying on the surrounding block staying free of
-      // awaits between the check and the connect.
-      if (hasSpec()) {
-        clearTimeout(timeout);
-        kernelSpecs.specsChanged.disconnect(onChange);
-        resolve();
-      }
-    });
-  }
-
-  /**
    * Open the visible task notebook only after a kernel is available, so
    * JupyterLab auto-selects the Pyodide kernel instead of prompting the user to
    * pick one.
    */
   private async openTaskNotebook(path: string): Promise<void> {
-    await this.waitForKernelSpecs();
+    await waitForKernelSpecs(this.app.serviceManager.kernelspecs);
     // eslint-disable-next-line no-restricted-syntax -- this wrapper is the one sanctioned call site
     this.documentManager.openOrReveal(path);
   }

--- a/apps/jupyter/extensions/notebook-runner/src/kernel/wait-for-kernel-specs.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/kernel/wait-for-kernel-specs.ts
@@ -25,29 +25,36 @@ export interface KernelSpecWaitTarget {
 }
 
 /**
- * Resolves once at least one kernelspec (the Pyodide kernel) is registered,
- * or after a bounded wait. Opening a notebook before any spec is registered
- * makes JupyterLab prompt the user to pick a kernel (CRT-399): the session
- * initialization cannot resolve a default kernel without specs, no matter
- * what the notebook's metadata says. The wait is bounded so that a broken
- * kernel extension degrades to the pre-existing behavior (the notebook opens
- * and JupyterLab may prompt for a kernel) instead of hanging the caller -
- * and with it the embedded app - forever.
+ * Resolves once at least one kernelspec - in this app that is the Pyodide
+ * kernel - is registered, or after a bounded wait. Opening a notebook before
+ * any spec is registered makes JupyterLab prompt the user to pick a kernel
+ * (CRT-399): the session initialization cannot resolve a default kernel
+ * without specs, no matter what the notebook's metadata says. The wait is
+ * bounded - and covers waiting for the manager to become ready - so that a
+ * broken, slow or rejecting kernel extension degrades to the pre-existing
+ * behavior (the notebook opens and JupyterLab may prompt for a kernel)
+ * instead of hanging the caller, and with it the embedded app, forever.
  */
 export const waitForKernelSpecs = async (
   kernelSpecs: KernelSpecWaitTarget,
   timeoutMs: number = defaultTimeoutMs,
 ): Promise<void> => {
-  await kernelSpecs.ready;
-
   const hasSpec = (specs = kernelSpecs.specs): boolean =>
     !!specs && Object.keys(specs.kernelspecs).length > 0;
 
-  if (hasSpec()) {
-    return;
-  }
-
   await new Promise<void>((resolve) => {
+    let settled = false;
+
+    const finish = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeout);
+      kernelSpecs.specsChanged.disconnect(onChange);
+      resolve();
+    };
+
     // specsChanged emits the freshly fetched specs, so use the emitted
     // payload instead of re-reading the manager's mutable specs property
     function onChange(
@@ -55,30 +62,35 @@ export const waitForKernelSpecs = async (
       specs: KernelSpec.ISpecModels | null,
     ): void {
       if (hasSpec(specs)) {
-        clearTimeout(timeout);
-        kernelSpecs.specsChanged.disconnect(onChange);
-        resolve();
+        finish();
       }
     }
 
+    // Arm the deadline and the listener before awaiting readiness, so a
+    // manager that never becomes ready (or whose readiness rejects) still
+    // falls back through this same timeout rather than hanging the caller.
     const timeout = setTimeout(() => {
-      kernelSpecs.specsChanged.disconnect(onChange);
       console.warn(
         `${logModule} No kernelspec registered after ${timeoutMs}ms; opening the notebook anyway (the kernel selection dialog may appear)`,
       );
-      resolve();
+      finish();
     }, timeoutMs);
 
     kernelSpecs.specsChanged.connect(onChange);
 
-    // Re-check after connecting so that a spec registered between the check
-    // above and the connect cannot be missed. This makes the wait correct by
-    // inspection instead of relying on the surrounding block staying free of
-    // awaits between the check and the connect.
+    // a spec may already be present, or arrive once the manager is ready; a
+    // rejected readiness is treated the same as the timeout fallback
     if (hasSpec()) {
-      clearTimeout(timeout);
-      kernelSpecs.specsChanged.disconnect(onChange);
-      resolve();
+      finish();
     }
+    void kernelSpecs.ready
+      .then(() => {
+        if (hasSpec()) {
+          finish();
+        }
+      })
+      .catch(() => {
+        // fall through to the bounded wait / timeout above
+      });
   });
 };

--- a/apps/jupyter/extensions/notebook-runner/src/kernel/wait-for-kernel-specs.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/kernel/wait-for-kernel-specs.ts
@@ -1,0 +1,84 @@
+import { KernelSpec } from "@jupyterlab/services";
+
+const logModule = "[Jupyter][kernel/wait-for-kernel-specs]";
+
+// kernelspec registration happens during startup (local JS, no downloads),
+// so this is generous; it only matters when the kernel extension is broken
+const defaultTimeoutMs = 15_000;
+
+type SpecsChangedCallback = (
+  sender: unknown,
+  specs: KernelSpec.ISpecModels | null,
+) => void;
+
+/**
+ * The slice of KernelSpec.IManager the wait needs - kept structural so tests
+ * can provide a plain stub.
+ */
+export interface KernelSpecWaitTarget {
+  readonly ready: Promise<void>;
+  readonly specs: KernelSpec.ISpecModels | null;
+  readonly specsChanged: {
+    connect(callback: SpecsChangedCallback): unknown;
+    disconnect(callback: SpecsChangedCallback): unknown;
+  };
+}
+
+/**
+ * Resolves once at least one kernelspec (the Pyodide kernel) is registered,
+ * or after a bounded wait. Opening a notebook before any spec is registered
+ * makes JupyterLab prompt the user to pick a kernel (CRT-399): the session
+ * initialization cannot resolve a default kernel without specs, no matter
+ * what the notebook's metadata says. The wait is bounded so that a broken
+ * kernel extension degrades to the pre-existing behavior (the notebook opens
+ * and JupyterLab may prompt for a kernel) instead of hanging the caller -
+ * and with it the embedded app - forever.
+ */
+export const waitForKernelSpecs = async (
+  kernelSpecs: KernelSpecWaitTarget,
+  timeoutMs: number = defaultTimeoutMs,
+): Promise<void> => {
+  await kernelSpecs.ready;
+
+  const hasSpec = (specs = kernelSpecs.specs): boolean =>
+    !!specs && Object.keys(specs.kernelspecs).length > 0;
+
+  if (hasSpec()) {
+    return;
+  }
+
+  await new Promise<void>((resolve) => {
+    // specsChanged emits the freshly fetched specs, so use the emitted
+    // payload instead of re-reading the manager's mutable specs property
+    function onChange(
+      _sender: unknown,
+      specs: KernelSpec.ISpecModels | null,
+    ): void {
+      if (hasSpec(specs)) {
+        clearTimeout(timeout);
+        kernelSpecs.specsChanged.disconnect(onChange);
+        resolve();
+      }
+    }
+
+    const timeout = setTimeout(() => {
+      kernelSpecs.specsChanged.disconnect(onChange);
+      console.warn(
+        `${logModule} No kernelspec registered after ${timeoutMs}ms; opening the notebook anyway (the kernel selection dialog may appear)`,
+      );
+      resolve();
+    }, timeoutMs);
+
+    kernelSpecs.specsChanged.connect(onChange);
+
+    // Re-check after connecting so that a spec registered between the check
+    // above and the connect cannot be missed. This makes the wait correct by
+    // inspection instead of relying on the surrounding block staying free of
+    // awaits between the check and the connect.
+    if (hasSpec()) {
+      clearTimeout(timeout);
+      kernelSpecs.specsChanged.disconnect(onChange);
+      resolve();
+    }
+  });
+};

--- a/apps/jupyter/extensions/notebook-runner/src/packages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/packages.ts
@@ -112,29 +112,24 @@ const autoInstallPackages =
     }
   };
 
-const trackSession = (
+const trackSession = async (
   contentsManager: ContentsManager,
   panel: NotebookPanel,
 ): Promise<void> => {
   const notebookPath = panel.context.path;
   const sessionContext = panel.sessionContext;
 
-  // Start the kernel so the install runs in the background, instead of
-  // waiting for something else to trigger it - but only once the document
-  // context is fully populated. Initializing earlier races the context's
-  // own initialization (Context._populate): when this call wins, the session
-  // resolves its kernel before the notebook's kernelspec metadata is applied
-  // to the kernel preference, and JupyterLab asks the user to pick a kernel
-  // instead of auto-selecting Pyodide (CRT-399).
-  void panel.context.ready.then(() =>
-    sessionContext.initialize().catch((error) => {
-      console.error(
-        `${logModule} Failed to initialize session for`,
-        notebookPath,
-        error,
-      );
-    }),
-  );
+  // Start the kernel only after the context has applied the notebook's
+  // kernelspec, so Pyodide is auto-selected rather than prompted for (CRT-399).
+  await panel.context.ready;
+
+  sessionContext.initialize().catch((error) => {
+    console.error(
+      `${logModule} Failed to initialize session for`,
+      notebookPath,
+      error,
+    );
+  });
 
   return setupKernel(
     sessionContext,

--- a/apps/jupyter/extensions/notebook-runner/src/packages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/packages.ts
@@ -121,7 +121,13 @@ const trackSession = async (
 
   // Start the kernel only after the context has applied the notebook's
   // kernelspec, so Pyodide is auto-selected rather than prompted for (CRT-399).
-  await panel.context.ready;
+  await panel.context.ready.catch((error) =>
+    console.error(
+      `${logModule} Failed to load notebook context for`,
+      notebookPath,
+      error,
+    ),
+  );
 
   sessionContext.initialize().catch((error) => {
     console.error(

--- a/apps/jupyter/extensions/notebook-runner/src/packages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/packages.ts
@@ -1,6 +1,5 @@
 import { JupyterFrontEnd } from "@jupyterlab/application";
-import { ISessionContext } from "@jupyterlab/apputils";
-import { INotebookTracker } from "@jupyterlab/notebook";
+import { INotebookTracker, NotebookPanel } from "@jupyterlab/notebook";
 import { IKernelConnection } from "@jupyterlab/services/lib/kernel/kernel";
 import { Contents, ContentsManager, KernelMessage } from "@jupyterlab/services";
 import {
@@ -115,17 +114,27 @@ const autoInstallPackages =
 
 const trackSession = (
   contentsManager: ContentsManager,
-  sessionContext: ISessionContext,
-  notebookPath: string,
+  panel: NotebookPanel,
 ): Promise<void> => {
-  // start the kernel so the install runs in the background, instead of waiting for something else to trigger it.
-  sessionContext.initialize().catch((error) => {
-    console.error(
-      `${logModule} Failed to initialize session for`,
-      notebookPath,
-      error,
-    );
-  });
+  const notebookPath = panel.context.path;
+  const sessionContext = panel.sessionContext;
+
+  // Start the kernel so the install runs in the background, instead of
+  // waiting for something else to trigger it - but only once the document
+  // context is fully populated. Initializing earlier races the context's
+  // own initialization (Context._populate): when this call wins, the session
+  // resolves its kernel before the notebook's kernelspec metadata is applied
+  // to the kernel preference, and JupyterLab asks the user to pick a kernel
+  // instead of auto-selecting Pyodide (CRT-399).
+  void panel.context.ready.then(() =>
+    sessionContext.initialize().catch((error) => {
+      console.error(
+        `${logModule} Failed to initialize session for`,
+        notebookPath,
+        error,
+      );
+    }),
+  );
 
   return setupKernel(
     sessionContext,
@@ -138,15 +147,10 @@ export const preInstallPackages = async (
   contentsManager: ContentsManager,
   notebookTracker: INotebookTracker,
 ): Promise<void> => {
-  notebookTracker.forEach((panel) =>
-    trackSession(contentsManager, panel.sessionContext, panel.context.path),
-  );
+  notebookTracker.forEach((panel) => trackSession(contentsManager, panel));
 
   notebookTracker.widgetAdded.connect((_, panel) => {
-    // get path of notebook
-    const notebookPath = panel.context.path;
-
-    trackSession(contentsManager, panel.sessionContext, notebookPath);
+    trackSession(contentsManager, panel);
   });
 };
 

--- a/apps/jupyter/extensions/notebook-runner/src/packages.ts
+++ b/apps/jupyter/extensions/notebook-runner/src/packages.ts
@@ -121,13 +121,17 @@ const trackSession = async (
 
   // Start the kernel only after the context has applied the notebook's
   // kernelspec, so Pyodide is auto-selected rather than prompted for (CRT-399).
-  await panel.context.ready.catch((error) =>
+  try {
+    await panel.context.ready;
+  } catch (error) {
     console.error(
       `${logModule} Failed to load notebook context for`,
       notebookPath,
       error,
-    ),
-  );
+    );
+
+    return;
+  }
 
   sessionContext.initialize().catch((error) => {
     console.error(


### PR DESCRIPTION
## Summary

Teachers no longer get asked to select the Pyodide kernel when defining a task (Jira: CRT-399, jam e615a8d5 — "fixed for students, not for teachers").

## Background

The existing fix (`openTaskNotebook` awaiting kernelspecs) is mode-agnostic and already covers the common teacher path; the student flow was fixed by the same commit. The teacher-only repro came from two remaining openings that bypassed the guard — both exercised disproportionately by the teacher flow:

1. **Hidden grading panel** (`executeRunNotebookCommand`): a raw `documentManager.open` reached from the teacher's *save task* path (`getTask` → grading run). With specs not yet registered, JupyterLab's session init cannot resolve a default kernel and pops the dialog — over a hidden panel. Now awaits the same kernelspec wait; the extension's lint rule (which previously only banned `openOrReveal`) now also bans raw `documentManager.open`, verified to fire.
2. **Eager `sessionContext.initialize()`** (`preInstallPackages`): fired the moment a panel was added, racing `Context._populate`. When our call won, the session resolved its kernel *before* the notebook's `kernelspec` metadata reached the kernel preference → `getDefaultKernel` returns null → prompt, even with specs present. The background kernel start (for package pre-install) now waits for `context.ready`, after which it collapses into the context's own memoized `initialize` — the pre-install still runs in the background, just no longer ahead of the metadata.

## Refactor

`waitForKernelSpecs` moves out of the iframe API into `src/kernel/wait-for-kernel-specs.ts` (structural manager type) so both call sites share it — and it finally has unit coverage: specs already present, specs arriving late, empty emissions ignored, bounded give-up (still opens, warns), and a registration the subscription would have missed. Written red-first.

## Verification

Full notebook-runner suite 62/62; tsc + eslint + prettier clean. A teacher-flow e2e remains infeasible (saving a Jupyter task runs otter-grader in JupyterLite; the Pyodide kernel never finishes preparing in headless Chromium — same reason documented when the student e2e was written), so the races are covered by the unit tests + the lint gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the Pyodide kernel selection dialog for teachers by waiting for kernelspecs before any notebook opens and starting background kernels only after the notebook context is ready, with a bounded fallback and context-failure handling. Addresses CRT-399.

- **Bug Fixes**
  - Guard the hidden grading notebook open in `executeRunNotebookCommand` by awaiting `waitForKernelSpecs(app.serviceManager.kernelspecs)`; extend ESLint to also flag raw `documentManager.open`.
  - Start background kernels after `panel.context.ready` in `preInstallPackages`; handle failed context loads (log and skip) to avoid unhandled rejections.
  - Extract `waitForKernelSpecs` to `src/kernel/wait-for-kernel-specs.ts`: arm timeout/listener before readiness, resolve on any spec, and fall back on timeout or readiness reject/never-ready; add unit tests for late specs, empty emissions, reject/never-ready, and late spec after reject.

<sup>Written for commit a5743aeb2c57310ac5e4204fdd427cc160057979. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

