### PR TITLE
[CRT-465] Analysis dashboard displays incorrect task details

### DIFF
--- a/frontend/src/api/collimator/hooks/solutions/__tests__/jest/usePatchStudentReferenceSolutions.spec.ts
+++ b/frontend/src/api/collimator/hooks/solutions/__tests__/jest/usePatchStudentReferenceSolutions.spec.ts
@@ -91,6 +91,9 @@ describe("usePatchStudentReferenceSolutions", () => {
       expect.any(Array),
       { revalidate: false },
     );
+    expect(mutate.mock.invocationCallOrder[0]).toBeLessThan(
+      revalidate.mock.invocationCallOrder[0],
+    );
 
     const updatedData = mutate.mock.calls[0][1] as CurrentStudentAnalysis[];
     expect(

--- a/frontend/src/api/collimator/hooks/solutions/usePatchStudentReferenceSolutions.ts
+++ b/frontend/src/api/collimator/hooks/solutions/usePatchStudentReferenceSolutions.ts
@@ -35,8 +35,6 @@ export const usePatchStudentReferenceSolutions =
           undefined,
           authOptions,
         ).then(() => {
-          revalidateSolutionList(classId, sessionId, taskId);
-
           const key = getSolutionsControllerFindCurrentAnalysesV0Url(
             classId,
             sessionId,
@@ -60,6 +58,8 @@ export const usePatchStudentReferenceSolutions =
               { revalidate: false },
             );
           }
+
+          revalidateSolutionList(classId, sessionId, taskId);
         }),
       [authOptions, cache, mutate, revalidateSolutionList],
     );

--- a/frontend/src/components/dashboard/Analyzer.state.ts
+++ b/frontend/src/components/dashboard/Analyzer.state.ts
@@ -4,7 +4,6 @@ import { FilterCriterion } from "./filter";
 import { ChartSplit, SplitType } from "./chartjs-plugins";
 
 export enum AnalyzerStateActionType {
-  setSelectedTask,
   setSelectedSubTask,
   setFilters,
   addSplit,
@@ -14,11 +13,6 @@ export enum AnalyzerStateActionType {
   setAutomaticGrouping,
   setAnalysesSelectedForComparison,
   setSelectedAnalyses,
-}
-
-export interface SetSelectedTaskAction {
-  type: AnalyzerStateActionType.setSelectedTask;
-  selectedTaskId: number;
 }
 
 export interface SetSelectedSubTaskAction {
@@ -64,7 +58,6 @@ export interface SetSelectedAnalysesAction {
 }
 
 export type AnalyzerStateAction =
-  | SetSelectedTaskAction
   | SetSelectedSubTaskAction
   | SetFiltersAction
   | AddSplitAction
@@ -75,7 +68,6 @@ export type AnalyzerStateAction =
   | SetSelectedAnalysesAction;
 
 export interface AnalyzerState {
-  selectedTask: number | undefined;
   selectedSubTaskId: string | undefined;
   isAutomaticGrouping: boolean;
   xAxis: AxesCriterionType;
@@ -137,8 +129,6 @@ export const analyzerStateReducer = (
   action: AnalyzerStateAction,
 ): AnalyzerState => {
   switch (action.type) {
-    case AnalyzerStateActionType.setSelectedTask:
-      return { ...state, selectedTask: action.selectedTaskId };
     case AnalyzerStateActionType.setSelectedSubTask:
       return { ...state, selectedSubTaskId: action.selectedSubTaskId };
     case AnalyzerStateActionType.setFilters:

--- a/frontend/src/components/dashboard/Analyzer.tsx
+++ b/frontend/src/components/dashboard/Analyzer.tsx
@@ -56,7 +56,6 @@ const Analyzer = ({
   task: ExistingTask;
 }) => {
   const [state, dispatch] = useReducer(analyzerStateReducer, {
-    selectedTask: session.tasks[0]?.id,
     selectedSubTaskId: undefined,
     isAutomaticGrouping: false,
     xAxis: AstCriterionType.statement,
@@ -71,11 +70,7 @@ const Analyzer = ({
     data: analyses,
     isLoading: isLoadingAnalyses,
     error: analysesErrors,
-  } = useCurrentSessionTaskSolutions(
-    session.klass.id,
-    session.id,
-    state.selectedTask,
-  );
+  } = useCurrentSessionTaskSolutions(session.klass.id, session.id, task.id);
 
   const subtasks = useSubtasks(analyses);
   const subTaskAnalyses = useSubtaskAnalyses(analyses, state.selectedSubTaskId);
@@ -140,15 +135,6 @@ const Analyzer = ({
     },
     [],
   );
-
-  if (!state.selectedTask) {
-    return (
-      <FormattedMessage
-        id="Analyzer.noTasksInSession"
-        defaultMessage="There are no tasks in this lesson."
-      />
-    );
-  }
 
   return (
     <>

--- a/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/analysis.tsx
+++ b/frontend/src/pages/class/[classId]/session/[sessionId]/task/[taskId]/analysis.tsx
@@ -83,7 +83,7 @@ const TaskInstanceAnalysis = () => {
                 sessionId={session.id}
                 taskId={task.id}
               />
-              <Analyzer session={session} task={task} />
+              <Analyzer key={task.id} session={session} task={task} />
             </>
           )}
         </MultiSwrContent>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes CRT-465 by loading analyses for the current task and correctly refreshing student solutions after edits. This resolves stale or wrong task details in the analysis dashboard.

- **Bug Fixes**
  - Analyzer now loads analyses using the current `task.id`; removed the `selectedTask` state and the no-task early return.
  - Added `key={task.id}` to `Analyzer` to reset component state when switching tasks.
  - In `usePatchStudentReferenceSolutions`, call `mutate` before `revalidateSolutionList`, then revalidate to fetch fresh data; added a test to assert call order.

<sup>Written for commit 0e0ede57f7864a55cbd3971a124a2096f6007091. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

