### PR TITLE
Fix failed analyses crashing backend

### DIFF
--- a/backend/src/api/student-activity/student-activity.service.spec.ts
+++ b/backend/src/api/student-activity/student-activity.service.spec.ts
@@ -5,6 +5,7 @@ import {
   Student,
   StudentActivityType,
 } from "@prisma/client";
+import { Logger } from "@nestjs/common";
 import { PrismaService } from "src/prisma/prisma.service";
 import { TasksService } from "../tasks/tasks.service";
 import { SolutionAnalysisService } from "../solutions/solution-analysis.service";
@@ -70,7 +71,7 @@ describe("StudentActivityService", () => {
   beforeEach(() => {
     createActivity = jest.fn();
     findActivity = jest.fn();
-    performAnalysis = jest.fn();
+    performAnalysis = jest.fn().mockResolvedValue(null);
 
     const prisma = {
       studentActivity: {
@@ -89,6 +90,8 @@ describe("StudentActivityService", () => {
 
     service = new StudentActivityService(prisma, tasksService, analysisService);
   });
+
+  afterEach(() => jest.restoreAllMocks());
 
   it("returns an existing replay without triggering analysis again", async () => {
     createActivity.mockRejectedValue(uniqueConstraintError());
@@ -129,6 +132,22 @@ describe("StudentActivityService", () => {
     expect(createActivity).toHaveBeenCalledTimes(2);
     expect(findActivity).toHaveBeenCalledTimes(1);
     expect(performAnalysis).toHaveBeenCalledWith(storedSolution, AstVersion.v1);
+  });
+
+  it("logs and consumes a background analysis rejection", async () => {
+    const analysisError = new Error("conversion failed");
+    const logError = jest.spyOn(Logger.prototype, "error").mockImplementation();
+    createActivity.mockResolvedValue(storedActivity);
+    performAnalysis.mockRejectedValue(analysisError);
+
+    await expect(
+      service.create(student, activity, solutionInput),
+    ).resolves.toBe(storedActivity);
+
+    expect(logError).toHaveBeenCalledWith(
+      expect.stringContaining(`activity id: ${storedActivity.id}`),
+      analysisError.stack,
+    );
   });
 
   it("rethrows a persistent unrelated unique conflict after one retry", async () => {

--- a/backend/src/api/student-activity/student-activity.service.ts
+++ b/backend/src/api/student-activity/student-activity.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { Injectable, Logger } from "@nestjs/common";
 import { AstVersion, Prisma, Student, StudentActivity } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 import { TasksService } from "../tasks/tasks.service";
@@ -33,6 +33,8 @@ export type StudentActivityInput = Omit<
 
 @Injectable()
 export class StudentActivityService {
+  private readonly logger = new Logger(StudentActivityService.name);
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly tasksService: TasksService,
@@ -69,9 +71,15 @@ export class StudentActivityService {
           include: { solution: true },
         });
 
-        // do not wait for the promise to resolve
-        // this will happen in the background
-        this.analysisService.performAnalysis(result.solution, latestAstVersion);
+        // analysis runs in the background, but its rejection must be consumed
+        void this.analysisService
+          .performAnalysis(result.solution, latestAstVersion)
+          .catch((error: unknown) => {
+            this.logger.error(
+              `Failed to analyze solution for student activity (activity id: ${result.id})`,
+              error instanceof Error ? error.stack : String(error),
+            );
+          });
 
         return result;
       } catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevented backend crashes caused by failed background solution analyses by catching and logging rejections in the student activity flow. Analysis still runs asynchronously; failures no longer propagate.

- **Bug Fixes**
  - Consume `performAnalysis` rejection with `void ... .catch(...)` and log via `Logger` from `@nestjs/common`, including activity id and stack.
  - Updated tests to default `performAnalysis` to resolve, added a rejection logging test, and restored mocks between tests.

<sup>Written for commit 30fcb045726be421232daacc0b2450064d3548e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

