### PR TITLE
Fix conflicting student activity replays

### DIFF
--- a/backend/src/api/student-activity/student-activity.service.spec.ts
+++ b/backend/src/api/student-activity/student-activity.service.spec.ts
@@ -5,6 +5,7 @@ import {
   Student,
   StudentActivityType,
 } from "@prisma/client";
+import { ConflictException } from "@nestjs/common";
 import { PrismaService } from "src/prisma/prisma.service";
 import { TasksService } from "../tasks/tasks.service";
 import { SolutionAnalysisService } from "../solutions/solution-analysis.service";
@@ -54,6 +55,7 @@ describe("StudentActivityService", () => {
     taskId: activity.taskId,
     solutionHash,
     solution: storedSolution,
+    appActivity: null,
   };
 
   const uniqueConstraintError = (): Prisma.PrismaClientKnownRequestError =>
@@ -65,12 +67,14 @@ describe("StudentActivityService", () => {
   let createActivity: jest.Mock;
   let findActivity: jest.Mock;
   let performAnalysis: jest.Mock;
+  let computeSolutionHash: jest.Mock;
   let service: StudentActivityService;
 
   beforeEach(() => {
     createActivity = jest.fn();
     findActivity = jest.fn();
     performAnalysis = jest.fn();
+    computeSolutionHash = jest.fn().mockReturnValue(solutionHash);
 
     const prisma = {
       studentActivity: {
@@ -80,7 +84,7 @@ describe("StudentActivityService", () => {
     } as unknown as PrismaService;
 
     const tasksService = {
-      computeSolutionHash: jest.fn().mockReturnValue(solutionHash),
+      computeSolutionHash,
     } as unknown as TasksService;
 
     const analysisService = {
@@ -109,9 +113,66 @@ describe("StudentActivityService", () => {
           happenedAtCounter: activity.happenedAtCounter,
         },
       },
-      include: { solution: true },
+      include: { appActivity: true, solution: true },
     });
 
+    expect(performAnalysis).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    {
+      name: "session",
+      replayActivity: { ...activity, sessionId: activity.sessionId + 1 },
+      replaySolution: solutionInput,
+      replayHash: solutionHash,
+      existingActivity: storedActivity,
+    },
+    {
+      name: "task",
+      replayActivity: { ...activity, taskId: activity.taskId + 1 },
+      replaySolution: solutionInput,
+      replayHash: solutionHash,
+      existingActivity: storedActivity,
+    },
+    {
+      name: "solution",
+      replayActivity: activity,
+      replaySolution: {
+        ...solutionInput,
+        data: Buffer.from("different solution"),
+      },
+      replayHash: Buffer.from("different-solution-hash"),
+      existingActivity: storedActivity,
+    },
+    {
+      name: "app activity payload",
+      replayActivity: {
+        ...activity,
+        type: StudentActivityType.TASK_APP_ACTIVITY,
+        appActivity: { type: "stopAll", data: { source: "button" } },
+      },
+      replaySolution: solutionInput,
+      replayHash: solutionHash,
+      existingActivity: {
+        ...storedActivity,
+        type: StudentActivityType.TASK_APP_ACTIVITY,
+        appActivity: {
+          id: storedActivity.id,
+          type: "greenFlag",
+          data: { source: "button" },
+        },
+      },
+    },
+  ])("rejects a replay whose $name differs", async (testCase) => {
+    createActivity.mockRejectedValue(uniqueConstraintError());
+    findActivity.mockResolvedValue(testCase.existingActivity);
+    computeSolutionHash.mockReturnValue(testCase.replayHash);
+
+    await expect(
+      service.create(student, testCase.replayActivity, testCase.replaySolution),
+    ).rejects.toBeInstanceOf(ConflictException);
+
+    expect(createActivity).toHaveBeenCalledTimes(1);
     expect(performAnalysis).not.toHaveBeenCalled();
   });
 

--- a/backend/src/api/student-activity/student-activity.service.spec.ts
+++ b/backend/src/api/student-activity/student-activity.service.spec.ts
@@ -73,7 +73,7 @@ describe("StudentActivityService", () => {
   beforeEach(() => {
     createActivity = jest.fn();
     findActivity = jest.fn();
-    performAnalysis = jest.fn();
+    performAnalysis = jest.fn().mockResolvedValue(undefined);
     computeSolutionHash = jest.fn().mockReturnValue(solutionHash);
 
     const prisma = {

--- a/backend/src/api/student-activity/student-activity.service.ts
+++ b/backend/src/api/student-activity/student-activity.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from "@nestjs/common";
+import { isDeepStrictEqual } from "node:util";
+import { ConflictException, Injectable } from "@nestjs/common";
 import { AstVersion, Prisma, Student, StudentActivity } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
 import { TasksService } from "../tasks/tasks.service";
@@ -8,7 +9,7 @@ const latestAstVersion = AstVersion.v1;
 const activityCreateAttempts = 2;
 
 export type StudentActivityWithSolution = Prisma.StudentActivityGetPayload<{
-  include: { solution: true };
+  include: { appActivity: true; solution: true };
 }>;
 
 export type SolutionInput = Pick<
@@ -60,7 +61,13 @@ export class StudentActivityService {
     activity: StudentActivityInput,
     solution: SolutionInput,
   ): Promise<StudentActivity> {
-    const data = this.buildActivityInput(student, activity, solution);
+    const solutionHash = this.tasksService.computeSolutionHash(solution.data);
+    const data = this.buildActivityInput(
+      student,
+      activity,
+      solution,
+      solutionHash,
+    );
 
     for (let attempt = 1; ; attempt++) {
       try {
@@ -96,12 +103,23 @@ export class StudentActivityService {
               happenedAtCounter: activity.happenedAtCounter,
             },
           },
-          include: { solution: true },
+          include: { appActivity: true, solution: true },
         });
 
         if (existingActivity) {
-          // A replay may contain different solution data, but comparing or replacing it would complicate replay
-          // handling and could trigger analysis more than once
+          if (
+            !this.isExactReplay(
+              existingActivity,
+              activity,
+              solution,
+              solutionHash,
+            )
+          ) {
+            throw new ConflictException(
+              "The activity idempotency key is already used by a different activity",
+            );
+          }
+
           return existingActivity;
         }
 
@@ -118,6 +136,7 @@ export class StudentActivityService {
     student: Student,
     activity: StudentActivityInput,
     solution: SolutionInput,
+    solutionHash: Uint8Array,
   ): Prisma.StudentActivityCreateInput {
     const appActivityInput:
       | Prisma.StudentActivityAppCreateNestedOneWithoutStudentActivityInput
@@ -129,8 +148,6 @@ export class StudentActivityService {
           },
         }
       : undefined;
-
-    const solutionHash = this.tasksService.computeSolutionHash(solution.data);
 
     return {
       type: activity.type,
@@ -171,5 +188,31 @@ export class StudentActivityService {
         },
       },
     } satisfies Prisma.StudentActivityCreateInput;
+  }
+
+  private isExactReplay(
+    existing: StudentActivityWithSolution,
+    activity: StudentActivityInput,
+    solution: SolutionInput,
+    solutionHash: Uint8Array,
+  ): boolean {
+    const appActivityMatches =
+      existing.appActivity === null && activity.appActivity === null
+        ? true
+        : existing.appActivity !== null && activity.appActivity !== null
+          ? existing.appActivity.type === activity.appActivity.type &&
+            isDeepStrictEqual(
+              existing.appActivity.data,
+              activity.appActivity.data,
+            )
+          : false;
+
+    return (
+      existing.sessionId === activity.sessionId &&
+      existing.taskId === activity.taskId &&
+      Buffer.from(existing.solutionHash).equals(Buffer.from(solutionHash)) &&
+      existing.solution.mimeType === solution.mimeType &&
+      appActivityMatches
+    );
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rejects conflicting student activity replays by enforcing that an idempotency key maps to the exact same activity. This prevents inconsistent history and duplicate analysis.

- **Bug Fixes**
  - On unique constraint conflicts, fetch the existing activity (with `appActivity` and `solution`); return it if it’s an exact replay, otherwise throw a `ConflictException`.
  - Exact match checks: `sessionId`, `taskId`, precomputed solution hash and `mimeType`, and app activity `type` + deep-equal `data`.
  - Compute solution hash upfront; retry once for concurrent creation. Tests parameterize mismatches, ensure analysis doesn’t run on rejected replays, and fix the `performAnalysis` mock to resolve.

<sup>Written for commit 4e529e071833c490e2673c43d3107d2c4427e211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

