### PR TITLE
[CRT-470] Stop 'unknown source' console spam from setImmediate polyfill

### DIFF
--- a/apps/jupyter/iframe-message-buffering.js
+++ b/apps/jupyter/iframe-message-buffering.js
@@ -4,6 +4,15 @@
 const logModule = "[Iframe Message Buffer]";
 
 const bufferIncomingMessages = (e) => {
+  // Only buffer RPC messages (JSON-RPC objects). Non-object payloads are foreign
+  // traffic on the shared message channel - most notably the setImmediate
+  // polyfill's "setImmediate$<rand>$<handle>" strings, which fire in huge volume
+  // during JupyterLite/Pyodide boot. Buffering them would bloat the buffer and,
+  // on replay, spam the console with "unknown source".
+  if (typeof e.data !== "object" || e.data === null) {
+    return;
+  }
+
   console.debug(`${logModule} Buffering incoming message:`, e);
   window.bufferedMessages.push(e);
 };

--- a/apps/scratch/src/pages/_app.tsx
+++ b/apps/scratch/src/pages/_app.tsx
@@ -48,6 +48,15 @@ const App = ({ Component, pageProps }: AppProps) => {
         // so that we can buffer any incoming iframe messages until the main app is ready to handle them.
 
         const bufferIncomingMessages = (e) => {
+          // Only buffer RPC messages (JSON-RPC objects). Non-object payloads are
+          // foreign traffic on the shared message channel - most notably the
+          // setImmediate polyfill's "setImmediate$<rand>$<handle>" strings, which
+          // fire in huge volume during Scratch boot. Buffering them would bloat
+          // the buffer and, on replay, spam the console with "unknown source".
+          if (typeof e.data !== "object" || e.data === null) {
+            return;
+          }
+
           console.debug(\`\${logModule} Buffering incoming message:\`, e);
           window.bufferedMessages.push(e);
         };

--- a/frontend/src/__tests__/jest/iframe-rpc/handleWindowMessage.spec.ts
+++ b/frontend/src/__tests__/jest/iframe-rpc/handleWindowMessage.spec.ts
@@ -1,0 +1,114 @@
+import { AppCrtIframeApi, AppHandleRequestMap } from "iframe-rpc/src";
+
+/**
+ * Regression test for CRT-470.
+ *
+ * The RPC message listener is attached to `window`, so it receives *every*
+ * message dispatched at that window - not only RPC traffic. The most common
+ * foreign message is the `setimmediate` polyfill (bundled into JupyterLab and
+ * Scratch), which schedules macrotasks by posting a
+ * `"setImmediate$<rand>$<handle>"` string to its own window. These fire in huge
+ * volume during app boot and previously flooded the console with
+ * "Received message from unknown source" logs.
+ *
+ * `handleWindowMessage` must silently ignore non-object payloads while still
+ * routing genuine JSON-RPC objects.
+ */
+describe("IframeRpcApi.handleWindowMessage", () => {
+  // Fake peer windows. `postMessage` is stubbed because responding to a routed
+  // request posts back to `event.source`.
+  const targetWindow = {
+    name: "rpc-peer",
+    postMessage: jest.fn(),
+  } as unknown as Window;
+  const otherWindow = {
+    name: "self",
+    postMessage: jest.fn(),
+  } as unknown as Window;
+
+  let consoleDebug: jest.SpyInstance;
+
+  const createApi = (
+    handleRequest: AppHandleRequestMap | null = null,
+  ): AppCrtIframeApi => {
+    const api = new AppCrtIframeApi(handleRequest);
+    api.setTarget(targetWindow);
+    api.setOrigin("https://example.test");
+    return api;
+  };
+
+  const messageEvent = (data: unknown, source: Window | null): MessageEvent =>
+    new MessageEvent("message", {
+      data,
+      source,
+      origin: "https://example.test",
+    });
+
+  beforeEach(() => {
+    consoleDebug = jest.spyOn(console, "debug").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleDebug.mockRestore();
+  });
+
+  it("silently ignores the setImmediate polyfill payload", async () => {
+    const api = createApi();
+
+    // Same shape the setimmediate polyfill posts, from a mismatched source.
+    await api.handleWindowMessage(
+      messageEvent("setImmediate$0.34213620966509795$1", otherWindow),
+    );
+
+    expect(consoleDebug).not.toHaveBeenCalledWith(
+      "Received message from unknown source",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("ignores non-object payloads without logging (string, number, null)", async () => {
+    const api = createApi();
+
+    for (const payload of ["some string", 42, null]) {
+      await api.handleWindowMessage(messageEvent(payload, otherWindow));
+    }
+
+    expect(consoleDebug).not.toHaveBeenCalledWith(
+      "Received message from unknown source",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it("still logs object messages from an unexpected source", async () => {
+    const api = createApi();
+
+    await api.handleWindowMessage(
+      messageEvent({ jsonrpc: "2.0", id: 1, method: "getHeight" }, otherWindow),
+    );
+
+    expect(consoleDebug).toHaveBeenCalledWith(
+      "Received message from unknown source",
+      otherWindow,
+      "expected",
+      targetWindow,
+    );
+  });
+
+  it("routes a valid RPC request from the expected source to its handler", async () => {
+    const getHeight = jest.fn().mockResolvedValue(123);
+    const api = createApi({ getHeight } as unknown as AppHandleRequestMap);
+
+    await api.handleWindowMessage(
+      messageEvent(
+        { jsonrpc: "2.0", id: 1, method: "getHeight" },
+        targetWindow,
+      ),
+    );
+
+    expect(getHeight).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libraries/iframe-rpc/src/apis/iframe-rpc-api.ts
+++ b/libraries/iframe-rpc/src/apis/iframe-rpc-api.ts
@@ -201,6 +201,17 @@ export abstract class IframeRpcApi<
   }
 
   public async handleWindowMessage(event: MessageEvent): Promise<void> {
+    // Ignore non-RPC messages. RPC messages are always JSON-RPC objects; a
+    // non-object payload can only be foreign traffic on the shared `message`
+    // channel. The most common source is the `setimmediate` polyfill (bundled
+    // into JupyterLab and Scratch), which schedules macrotasks by posting a
+    // `"setImmediate$<rand>$<handle>"` string to its own window. These fire in
+    // huge volume during app boot; without this guard every one is logged as an
+    // "unknown source" message.
+    if (typeof event.data !== "object" || event.data === null) {
+      return;
+    }
+
     if (event.source !== this.requestTarget) {
       console.debug(
         "Received message from unknown source",


### PR DESCRIPTION
## Problem

When the embedded iframe loads a student solution — or a teacher hits **view task** — the console fills with hundreds of:

```
Received message from unknown source Window {...} expected Window {...}
```

### Root cause

The iframe-rpc message listener is attached to `window`, so it receives **every** message dispatched there, not just RPC traffic. The [`setimmediate`](https://www.npmjs.com/package/setimmediate) polyfill — bundled into both JupyterLab and Scratch — implements `setImmediate()` by posting a `"setImmediate$<rand>$<handle>"` string to its own window (fastest way to schedule a macrotask). Those fire in huge volume during app boot.

Each one reaches `handleWindowMessage`, fails the `event.source === requestTarget` check (the message came from the app window itself, not its RPC peer), and gets logged. Captured event:

- `event.data` = `"setImmediate$0.34213620966509795$1"`
- `event.source` = the Jupyter/Scratch window (self-post from the polyfill)
- `requestTarget` = the parent host

Scratch and Jupyter make it worse: their startup message buffers capture **all** messages and replay them once the app is ready, so the polyfill noise is buffered and then re-emitted as a burst of "unknown source" logs.

## Fix

RPC messages are always JSON-RPC **objects**, so bail out early on any non-object payload:

- `handleWindowMessage` returns before the source check when `event.data` isn't an object — killing the "unknown source" logs while genuine cross-frame mismatches (object payloads) are still logged.
- The Jupyter and Scratch startup buffers no longer buffer (and later replay) non-object messages, which also keeps the buffer small.

## Tests

New unit tests for the guard (`frontend/src/__tests__/jest/iframe-rpc/handleWindowMessage.spec.ts`):
- non-object payloads (the `setImmediate$…` string, other strings, numbers, `null`) are silently ignored
- object messages from an unexpected source **still** log "unknown source"
- a valid RPC request from the expected source **still** routes to its handler

Full frontend jest suite: 28 suites / 150 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the “Received message from unknown source” console spam by ignoring non-RPC window messages in `iframe-rpc` and by not buffering them in Jupyter and Scratch. Addresses CRT-470 while keeping valid RPC handling unchanged.

- **Bug Fixes**
  - In `IframeRpcApi.handleWindowMessage`, return early for non-object payloads; object payloads from the wrong source still log.
  - Jupyter and Scratch startup buffers now store only object payloads to avoid burst replays and keep buffers small.
  - Added regression tests to confirm non-object messages are ignored and valid RPC requests still route correctly.

<sup>Written for commit 31a06f292f696416bd7edfc7fb4764cb807ec716. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

