### PR TITLE
Update documentation

### DIFF
--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -40,4 +40,4 @@ This configuration generates an OpenAPI specification that is available at:
 
 Orval generates type-safe JavaScript and TypeScript clients from any valid OpenAPI v3 specification.
 
-The command `yarn update:api` in the `frontend` folder reads the OpenAPI JSON specification and generates a client in `frontend/api/collimator/generated`. Note that the backend must be running for this command to work (`cd backend && yarn dev`).
+The command `yarn update:api` in the `frontend` folder reads the OpenAPI JSON specification and generates a client in `frontend/src/api/collimator/generated`. The specification is read from the committed `backend/docs/api.json` file, so the backend does not need to be running. To regenerate that specification after changing the API, run `yarn api:generate` in the `backend` folder.

--- a/docs/architecture/api.md
+++ b/docs/architecture/api.md
@@ -40,4 +40,4 @@ This configuration generates an OpenAPI specification that is available at:
 
 Orval generates type-safe JavaScript and TypeScript clients from any valid OpenAPI v3 specification.
 
-The command `yarn update:api` in the `frontend` folder reads the OpenAPI JSON specification and generates a client in `frontend/src/api/collimator/generated`. The specification is read from the committed `backend/docs/api.json` file, so the backend does not need to be running. To regenerate that specification after changing the API, run `yarn api:generate` in the `backend` folder.
+The command `task frontend:api:generate` regenerates the type-safe client in `frontend/src/api/collimator/generated`. It builds the backend, regenerates the committed `backend/docs/api.json` specification, installs the frontend dependencies, and finally runs Orval to generate the client — so you do not need to start the backend yourself.

--- a/docs/architecture/iframe-rpc.md
+++ b/docs/architecture/iframe-rpc.md
@@ -34,12 +34,11 @@ It defines strict types for requests and responses, ensuring reliability and sec
 
 The library is installed with ClassMosaic.
 
-Only for development purposes, you can install it via yarn:
+Only for development purposes, you can set it up via `task`:
 
 ```sh
 # From: collimator/
-cd /libraries/iframe-rpc
-yarn install
+task libs:iframe-rpc:setup
 ```
 
 ### Public API
@@ -122,12 +121,11 @@ It encapsulates origin validation, lifecycle handling, and communication setup f
 
 The library is installed with ClassMosaic.
 
-Only for development purposes when working on the library, you can install it via yarn:
+Only for development purposes when working on the library, you can set it up via `task`:
 
 ```sh
 # From: collimator/
-cd /libraries/iframe-rpc-react
-yarn install
+task libs:iframe-rpc-react:setup
 ```
 
 ### Hooks

--- a/docs/architecture/iframe-rpc.md
+++ b/docs/architecture/iframe-rpc.md
@@ -73,9 +73,34 @@ Defined in `methods/index.ts`. Methods are organized by caller (who initiates th
 | `postSubmission`         | Sends a submission                                    |
 | `postSolutionRun`        | Sends a solution to execute                           |
 | `postTaskSolution`       | Sends a task solution                                 |
+| `postTaskStarted`        | Signals that a student has started (opened) a task    |
 | `postStudentAppActivity` | Reports student activity (action, data, and solution) |
+| `postMessage`            | Asks the frontend to show a toast notification        |
 
 Each method is strongly typed for parameters and return values.
+
+#### Task start (`postTaskStarted`)
+
+The embedded app emits `postTaskStarted` once it has loaded a task for a solving
+student. Its parameters are:
+
+- `solution`: a `Blob` carrying the solution the task was opened with, encoded in
+  the app's own format (not the platform's stored task/submission file).
+- `locale`: the `Language` the task was presented in.
+
+The platform records this as a `TASK_STARTED` student activity, which:
+
+- marks the starting point when replaying a student's interactions with the task, and
+- makes the student visible in the progress view before they submit anything.
+
+The app re-emits `postTaskStarted` when the task is re-presented in a different
+language, carrying the new locale so the platform stays in sync.
+
+#### Notifications (`postMessage`)
+
+The embedded app can ask the frontend to display a toast notification with
+`postMessage`. Its parameters are a `title`, a `message`, and a `type`
+(`ToastType.Success`, `ToastType.Error`, or `ToastType.Info`).
 
 ### Demo
 

--- a/docs/data-analyzer/ast-conversion.md
+++ b/docs/data-analyzer/ast-conversion.md
@@ -206,9 +206,9 @@ sequenceDiagram
     "Piscina Worker Pool"->>"SolutionConversionWorker": Execute with solution data
     "SolutionConversionWorker"->>converter: convert decoded JSON
     converter->>"SolutionConversionWorker": GeneralAst
-    "SolutionConversionWorker"->>"Piscina Worker Pool": return GeneralAst
-    "Piscina Worker Pool"->>"AstConversionService": Promise<GeneralAst>
-    "AstConversionService"->>"API Controller": GeneralAst
+    "SolutionConversionWorker"->>"Piscina Worker Pool": return SolutionConversionResult
+    "Piscina Worker Pool"->>"AstConversionService": Promise<SolutionConversionResult>
+    "AstConversionService"->>"API Controller": SolutionConversionResult
     "API Controller"->>Client: Response (e.g., analysis results)
 ```
 

--- a/docs/guides/add-new-analysis.md
+++ b/docs/guides/add-new-analysis.md
@@ -61,7 +61,7 @@ To add a new AST-based criterion, you must:
 
 If your criterion is not related to the AST, you must:
 
-1. Add your criterion to `MetaCriterionType` in `frontend/src/data-analyzer/meta-criterion-type.ts`.
+1. Add your criterion to `MetaCriterionType` in `frontend/src/components/dashboard/criteria/meta-criterion-type.ts`.
 2. Define an axis or a filter, as described below.
 
 ### Axis

--- a/docs/guides/add-new-app.md
+++ b/docs/guides/add-new-app.md
@@ -91,10 +91,10 @@ enum TaskType {
 }
 ```
 
-Then generate and apply a migration:
+Then generate and apply a migration (you will be prompted for a migration name):
 
 ```sh
-prisma migrate dev --name added_my_new_task_type
+task db:migrate:dev
 ```
 
 ### AST converter

--- a/docs/guides/add-new-app.md
+++ b/docs/guides/add-new-app.md
@@ -30,6 +30,14 @@ This includes declaring the events exchanged between the app and the frontend (e
 
 As an example, to retrieve the height of the embedded iframe, you must implement the `GetHeight` event.
 
+Beyond responding to frontend requests, an app used by solving students is also
+expected to emit app-initiated events the platform relies on. In particular, it
+must send `postTaskStarted` once it has loaded a task for a student — this marks
+the replay starting point and makes the student visible in the progress view
+before their first submission. See the [method list](../architecture/iframe-rpc.md#available-methods)
+for the full set of events an app can send (e.g. `postSubmission`,
+`postStudentAppActivity`, `postMessage`).
+
 In a non-React environment, this can be implemented in a file named `iframe-api.ts`, for example:
 
 ```typescript

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -10,19 +10,21 @@ The root OpenTofu configuration in `collimator-infrastructure` orchestrates the 
 
 ## Configuration and secrets management
 
-Variables and secrets for the `deployment.yml` and `test.yml` are stored in the GitHub repository settings.
+The deployment is driven by the `development.yml` and `production.yml` workflows, which both call the reusable `deploy_collimator.yml` workflow. Tests run through the `tests.yml` workflow. Their variables and secrets are stored in the GitHub repository settings.
 
-| Key | Type |
+Each key exists once per environment, prefixed with `DEV_` (used by `development.yml`) or `PROD_` (used by `production.yml`) — for example `DEV_AWS_REGION` and `PROD_AWS_REGION`. The base names are:
+
+| Key (prefixed with `DEV_` / `PROD_`) | Type |
 | ----------- | ---------- |
-| APP_SCRATCH_SENTRY_AUTH_TOKEN | Repository Secret |
-| APP_SCRATCH_SENTRY_DNS | Repository Variable |
+| ROLE_TO_ASSUME | Repository Variable |
 | AWS_REGION | Repository Variable |
-| BACKEND_SENTRY_AUTH_TOKEN | Repository Secret |
+| BACKEND_ECR_REGISTRY_URI | Repository Variable |
 | DEPLOY_URL | Repository Variable |
-| DEV_ROLE_TO_ASSUME | Repository Variable |
-| ECR_REGISTRY_URI | Repository Variable |
 | ENTRA_ID_CLIENT_ID | Repository Variable |
-| FRONTEND_SENTRY_AUTH_TOKEN | Repository Secret |
 | FRONTEND_SENTRY_DSN | Repository Variable |
+| APP_SCRATCH_SENTRY_DSN | Repository Variable |
+| APP_JUPYTER_SENTRY_DSN | Repository Variable |
+| SENTRY_AUTH_TOKEN | Repository Secret |
 | SONAR_TOKEN | Repository Secret |
-| SONAR_TOKEN | Dependabot Secret |
+
+A single `SENTRY_AUTH_TOKEN` is shared by the backend and both apps (there are no per-app auth tokens). `SONAR_TOKEN` is also available as a Dependabot secret.

--- a/docs/infrastructure/deployment.md
+++ b/docs/infrastructure/deployment.md
@@ -18,9 +18,16 @@ Each key exists once per environment, prefixed with `DEV_` (used by `development
 | ----------- | ---------- |
 | ROLE_TO_ASSUME | Repository Variable |
 | AWS_REGION | Repository Variable |
-| BACKEND_ECR_REGISTRY_URI | Repository Variable |
 | DEPLOY_URL | Repository Variable |
 | ENTRA_ID_CLIENT_ID | Repository Variable |
+| BACKEND_ECR_REGISTRY_URI | Repository Variable |
+| BACKEND_IMAGE_NAME | Repository Variable |
+| BACKEND_CLUSTER_NAME | Repository Variable |
+| BACKEND_SERVICE_NAME | Repository Variable |
+| FRONTEND_BUCKET_ID | Repository Variable |
+| SCRATCH_APP_BUCKET_ID | Repository Variable |
+| JUPYTER_APP_BUCKET_ID | Repository Variable |
+| CLOUDFRONT_DISTRIBUTION_ID | Repository Variable |
 | FRONTEND_SENTRY_DSN | Repository Variable |
 | APP_SCRATCH_SENTRY_DSN | Repository Variable |
 | APP_JUPYTER_SENTRY_DSN | Repository Variable |

--- a/docs/overview/developer-setup-guide.md
+++ b/docs/overview/developer-setup-guide.md
@@ -126,6 +126,8 @@ See [apps/jupyter/README.md](../../apps/jupyter/README.md) for more information.
 
 #### Postgres Docker
 
+?> The recommended way to run PostgreSQL locally is `task db:run` (also invoked by `task setup:dev`), which starts the container for you. The manual Docker setup below is only needed if you prefer to manage the containers yourself.
+
 This process creates two Docker containers:  
 
 - one for the PostgreSQL server
@@ -164,7 +166,7 @@ This process creates two Docker containers:
     - Port: 5432 (default postgres port)
     - Username: postgres
     - Password: password (value from step 1)
-9. Save. Update the `backend/.env` file by setting `DATABASE_URL` to `postgresql://postgres:password@localhost:5432/database?schema=public`.
+9. Save. Update the `backend/.env.local` file by setting `DATABASE_URL` to `postgresql://postgres:password@localhost:5432/database?schema=public`.
 
 ## Infrastructure and deployment
 

--- a/docs/overview/developer-setup-guide.md
+++ b/docs/overview/developer-setup-guide.md
@@ -53,10 +53,10 @@ By default, when you run `task setup:dev` the PostgreSQL container will be runni
 
 ### Backend setup
 
-1. By running the commands above, a `.env` file will have been created in your `backend` folder,
+1. By running the commands above, a `.env.local` file will have been created in your `backend` folder,
    with a `DATABASE_URL` matching the PostgreSQL container configuration. 
 
-2. Configure the admin account by setting environment variables in your `backend/.env` file:
+2. Configure the admin account by setting environment variables in your `backend/.env.local` file:
 
     ```sh
     SEED_ADMIN_EMAIL=yourMicrosoftAccountEmail
@@ -91,7 +91,7 @@ By default, when you run `task setup:dev` the PostgreSQL container will be runni
 
 ### Frontend setup
 
-1. If you changed the backend URI, you will need to update it in `frontend/.env`.
+1. If you changed the backend URI, you will need to update it in `frontend/.env.development`.
 
 2. Start the frontend in development mode:
 
@@ -108,8 +108,8 @@ By default, when you run `task setup:dev` the PostgreSQL container will be runni
     ```
 
 ### Jupyter setup
-1. 
-2. Start the app in development mode:
+
+1. Start the app in development mode:
 
     ```sh
     $ task apps:jupyter:dev

--- a/docs/python/python.md
+++ b/docs/python/python.md
@@ -14,6 +14,13 @@ To support the integration into ClassMosaic, we need to implement its `iframe-rp
 To ensure no messages are missed, we load custom JavaScript code (`iframe-message-buffering.js`) before the page finishes loading which immediately attaches a listener and starts buffering incoming `iframe-rpc` messages.
 The `notebook-runner` extension then later retrieves the buffered messages and stops the buffering process.
 
+Beyond handling incoming requests, the `notebook-runner` extension also emits
+app-initiated events back to the platform. In particular, when a solving student
+opens a task it sends [`postTaskStarted`](../architecture/iframe-rpc.md#task-start-posttaskstarted)
+(re-emitting it if the task is re-presented in another language); it also uses
+`postTaskSolution` to auto-save the current solution and `postMessage` to surface
+toast notifications. See the [`iframe-rpc` method list](../architecture/iframe-rpc.md#available-methods) for details.
+
 ## Mode detection
 
 Analogous to the Scratch application, the jupyter application supports three modes.

--- a/docs/scratch/scratch.md
+++ b/docs/scratch/scratch.md
@@ -52,6 +52,13 @@ This document is intended for developers working on this project and who may nee
 
 This project modifies Scratch; the scope of the changes and their purpose are described below.
 
+### ClassMosaic embedding (`iframe-rpc`)
+
+To run embedded inside ClassMosaic, the Scratch app implements the [`iframe-rpc` API](../architecture/iframe-rpc.md).
+Incoming messages are buffered early (`apps/scratch/src/utilities/iframe-message-buffer.ts`) so none are missed before the app is ready, and the integration itself lives in `apps/scratch/src/hooks/useEmbeddedScratch.ts`.
+
+Besides responding to platform requests (e.g. `loadTask`, `getSubmission`), the app emits app-initiated events back to the platform. In particular, when a solving student opens a task it sends [`postTaskStarted`](../architecture/iframe-rpc.md#task-start-posttaskstarted) — re-emitting it if the task is re-presented in another language — which marks the replay starting point and makes the student visible in the progress view before their first submission. It also reports runs and student interactions via `postSolutionRun` and `postStudentAppActivity`. See the [`iframe-rpc` method list](../architecture/iframe-rpc.md#available-methods) for the full set of events.
+
 ### Edit and solve mode
 
 This project extends the Scratch GUI component to additionally accept a `canEditTask` property which, if disabled, deactivates the following built-in Scratch features:


### PR DESCRIPTION
## Summary

Updates the `iframe-rpc` documentation to match the latest task-start changes, then extends into a full documentation review that corrects several stale facts verified against the codebase.

### Task-start / iframe-rpc

- **docs/architecture/iframe-rpc.md** — document the new `postTaskStarted` method (emitted by an app when a solving student opens a task; recorded as a `TASK_STARTED` student activity that marks the replay start and makes the student visible in the progress view before their first submission; re-emitted on language change). Also document the `postMessage` toast-notification method.
- **docs/guides/add-new-app.md** — note that a new app must emit `postTaskStarted`, with a pointer to the method list.
- **docs/python/python.md** — document the events the Jupyter `notebook-runner` extension emits (`postTaskStarted`, `postTaskSolution`, `postMessage`).
- **docs/scratch/scratch.md** — add a "ClassMosaic embedding (`iframe-rpc`)" section (previously absent), covering message buffering and the emitted `postTaskStarted` / `postSolutionRun` / `postStudentAppActivity` events.

### Stale facts fixed during the full review

- **docs/overview/developer-setup-guide.md** — `backend/.env` → `backend/.env.local` (what `task setup:dev` creates); `frontend/.env` → `frontend/.env.development` (the committed dev file); removed a broken empty list item in the Jupyter step.
- **docs/architecture/api.md** — corrected the generated-client path to `frontend/src/api/collimator/generated`; fixed the stale "backend must be running" claim (orval reads the committed `backend/docs/api.json`).
- **docs/infrastructure/deployment.md** — corrected workflow names (`deploy_collimator.yml`, `tests.yml`) and rewrote the secrets table (`DEV_`/`PROD_` prefixes, `SENTRY_DSN`, single shared `SENTRY_AUTH_TOKEN`, `BACKEND_ECR_REGISTRY_URI`, added `APP_JUPYTER_SENTRY_DSN`).
- **docs/guides/add-new-analysis.md** — corrected the `MetaCriterionType` path.
- **docs/data-analyzer/ast-conversion.md** — sequence diagram now shows `convertSolutionToAst` returning `SolutionConversionResult`.

### Checked, no change needed

docs/identity-management/student.md, docs/data-analyzer/data-analysis.md, docs/infrastructure/database.md, docs/quality-assurance/e2e.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `iframe-rpc` docs to add `postTaskStarted` and `postMessage`, and aligns app docs for task-start and toast notifications. Also updates dev/setup and deploy docs to use current Taskfile commands, paths, and secrets.

- **New Features**
  - Documented `postTaskStarted` and `postMessage` in `iframe-rpc`.
  - Updated add-new-app guide to require emitting `postTaskStarted`.
  - Expanded Jupyter and Scratch docs with emitted events and buffering details.

- **Bug Fixes**
  - Dev setup: use `backend/.env.local` and `frontend/.env.development`; recommend `task db:run`; fixed Postgres appendix to `.env.local`; removed a stray empty list item.
  - API client: path is `frontend/src/api/collimator/generated`; regenerate with `task frontend:api:generate` (builds backend, refreshes committed `backend/docs/api.json`, runs Orval).
  - Commands: prefer `task` over yarn/prisma (`task libs:iframe-rpc:setup`, `task libs:iframe-rpc-react:setup`, `task db:migrate:dev`).
  - Deployment: clarified workflows (`development.yml`, `production.yml` → `deploy_collimator.yml`, tests via `tests.yml`); completed DEV_/PROD_-prefixed inputs table with backend image/cluster/service, bucket IDs, and CloudFront ID; single shared `SENTRY_AUTH_TOKEN`; `SONAR_TOKEN` also in Dependabot.
  - Analysis docs: fixed `MetaCriterionType` path and AST conversion return type to `SolutionConversionResult`.

<sup>Written for commit bc6dafa2040855cd2bf3c7cffbf828a72f5e2ff7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

