### PR TITLE
Verify message source in pre-boot iframe buffer

### DIFF
--- a/apps/jupyter/iframe-message-buffering.js
+++ b/apps/jupyter/iframe-message-buffering.js
@@ -4,6 +4,10 @@
 const logModule = "[Iframe Message Buffer]";
 
 const bufferIncomingMessages = (e) => {
+  if (window.parent === window || e.source !== window.parent) {
+    return;
+  }
+
   // Only buffer RPC messages (JSON-RPC objects). Non-object payloads are foreign
   // traffic on the shared message channel - most notably the setImmediate
   // polyfill's "setImmediate$<rand>$<handle>" strings, which fire in huge volume

--- a/apps/scratch/src/pages/_app.tsx
+++ b/apps/scratch/src/pages/_app.tsx
@@ -48,6 +48,10 @@ const App = ({ Component, pageProps }: AppProps) => {
         // so that we can buffer any incoming iframe messages until the main app is ready to handle them.
 
         const bufferIncomingMessages = (e) => {
+          if (window.parent === window || e.source !== window.parent) {
+            return;
+          }
+
           // Only buffer RPC messages (JSON-RPC objects). Non-object payloads are
           // foreign traffic on the shared message channel - most notably the
           // setImmediate polyfill's "setImmediate$<rand>$<handle>" strings, which


### PR DESCRIPTION
## Problem

`bufferIncomingMessages` in the embedded apps' pre-boot message buffer accepted **any** `postMessage` payload and pushed it into `window.bufferedMessages`. Those buffered events are later replayed into the RPC layer (`stopBufferingIframeMessages()` → `handleWindowMessage`), so the buffer had no origin/source verification at all — the flaw called out for `apps/jupyter/iframe-message-buffering.js`.

### Impact
- **Forged RPC injection**: a sibling frame, popup, or `window.opener` holding a reference to the embedded app's window could post messages that get buffered and later replayed as if they came from the trusted platform, driving RPC handlers (e.g. `loadTask`/`loadSubmission`, which write files into the JupyterLite VM).
- **Unbounded buffer growth**: before the app is ready, untrusted senders could grow the replay buffer without limit.

## Fix

Buffer a message only when its **source window is the embedding parent** (`window.parent`), rejecting anything else — and skip buffering entirely when not embedded (`window.parent === window`). This is the *same source-identity guard the RPC layer already enforces* in [`iframe-rpc-api.ts` `handleWindowMessage`](https://github.com/crt25/collimator/blob/main/libraries/iframe-rpc/src/apis/iframe-rpc-api.ts#L245), so the pre-boot buffer and the live handler now agree.

### Why source identity, not a static origin string
The apps are embedded **cross-origin by design** (dev serves them on separate ports; the app only learns the parent origin *dynamically* from received RPC messages — see `useIframeParent`). There is no trusted origin string available this early in boot, and a literal `e.origin === window.origin` "same-origin" check would reject the legitimate parent. Verifying the source **window reference** is unforgeable and deployment-agnostic.

## Scope — audit of other `window.addEventListener("message", …)` sites

| Location | Verdict |
|---|---|
| `apps/jupyter/iframe-message-buffering.js` | **Fixed** — added source guard |
| `apps/scratch/src/pages/_app.tsx` (inline pre-boot buffer) | **Fixed** — identical flaw, same guard |
| `libraries/iframe-rpc-react` `useIframeChild.ts` / `useIframeParent.ts` | Already safe — delegate to `handleWindowMessage`, which checks `event.source !== requestTarget` |
| `libraries/iframe-rpc/src/apis/iframe-rpc-api.ts` | Already safe — source-identity check present |
| `e2e/**`, `libraries/iframe-rpc/demo/index.html` | Test/demo fixtures, not shipped |

## Residual risk (out of scope)
Source-identity verification stops non-parent windows, but does not by itself stop a **malicious top-level page from embedding the app** (it then legitimately *is* `window.parent`). That threat is the job of the `frame-ancestors` CSP / `X-Frame-Options` response headers on the app hosts, and of the RPC layer's per-request origin handling — unchanged here.

## Testing
The buffer scripts are injected verbatim (Jupyter: appended into `lab/index.html` at build; Scratch: `dangerouslySetInnerHTML`), so there is no compile step. `prettier` and `eslint` pass on the changed files. Behavior is unchanged for the legitimate parent → app path exercised by the existing e2e suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers pre-boot iframe messages only when they come from the embedding parent. Previously the buffer accepted any postMessage and replayed it into the RPC layer; now it buffers only when the source is window.parent and skips buffering when not embedded, preventing forged RPC injection and unbounded buffer growth.

- Applies to the Jupyter pre-boot buffer and the Scratch inline pre-boot buffer.
- Mirrors the source-identity guard in `libraries/iframe-rpc` handleWindowMessage; no static origin pin because embeds are cross-origin and the parent origin is unknown at boot.
- No change to legitimate parent-to-app flows; no migration required.

<sup>Written for commit 1cd2c6a7462970a1adc92964dd1185aedc5f787d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

