### PR TITLE
Add impressum to unauthenticated routes whitelist

### DIFF
--- a/frontend/src/components/authentication/AuthenticationBarrier.tsx
+++ b/frontend/src/components/authentication/AuthenticationBarrier.tsx
@@ -13,6 +13,7 @@ const allowedRoutesForUnauthenticatedUsers = new Set<string>([
   "/login/admin",
   "/login/teacher",
   "/login/student",
+  "/impressum",
   // this page has a special role in the process of student authentication
   // in particular, an ephemeral key pair is generated for the session
   // and the student's authentication is completed by communicating with the teacher


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allows unauthenticated access to /impressum by whitelisting it in the AuthenticationBarrier. Previously the page required login; now it is publicly accessible, while all other auth-gated routes and login flows remain unchanged.

<sup>Written for commit 146eb8b37ded8b80d01b99890ed014b089cfdecb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/crt25/collimator/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

